### PR TITLE
Fix build with Clang

### DIFF
--- a/tsMuxer/src/psgStreamReader.h
+++ b/tsMuxer/src/psgStreamReader.h
@@ -9,8 +9,6 @@
 #include "textSubtitlesRender.h"
 #include "textSubtitles.h"
 
-class text_subtitles::TextToPGSConverter;
-
 class PGSStreamReader: public AbstractStreamReader 
 {
 public:


### PR DESCRIPTION
Forward declarations are not allowed to have nested namespace declarations, as
they have to appear inside a namespace if the thing they're forwarding appears
in a namespace originally.

This is a warning with GCC, but an error with Clang. Removing the declaration
entirely is the way to go, since psgStreamReader.h includes textSubtitles.h
anyway, which contains a full definition of the TextToPGSConverter class.