### PR TITLE
Fix MSYS2 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,20 +251,11 @@ echo 'QMAKE_LIBS_VULKAN       =' >> $MINGW_PREFIX/qt5-static/share/qt5/mkspecs/c
 With that fixed, browse to the location of the tsMuxer repo and then run the following commands:
 
 ```
-# compile tsmuxer
 mkdir build
 cd build
 cmake ../ -G Ninja
-
-# generate the tsMuxerGUI makefile
-export PATH=$PATH:$MINGW_PREFIX/qt5-static/bin
-cd ..
-cd tsMuxerGUI
-qmake
-
-# compile tsMuxerGUI to ../bin
-make release
-cp bin/tsMuxerGUI.exe ../bin/
+cmake . --build
+cp tsMuxer/tsmuxer.exe tsMuxerGUI/tsMuxeR.exe
 ```
 
 This will create statically compiled versions of tsMuxer and tsMuxerGUI - so no external DLL files are required.

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -1,5 +1,6 @@
 #include "types.h"
 
+#include <cstring>
 #include <sstream>
 #include <iomanip>
 #include <memory.h>

--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -78,20 +78,18 @@ function(pkg_check_modules_with_static prefix req_or_opt package)
 endfunction()
 
 find_package (Threads REQUIRED)
+find_package (PkgConfig)
 
-if (WIN32)
-  target_sources(tsmuxer PRIVATE osdep/textSubtitlesRenderWin32.cpp)
-else()
-  find_package (PkgConfig REQUIRED)
-  pkg_check_modules_with_static (FREETYPE2 REQUIRED freetype2)
+if (PkgConfig_FOUND)
   pkg_check_modules_with_static (ZLIB REQUIRED zlib)
-  target_sources(tsmuxer PRIVATE osdep/textSubtitlesRenderFT.cpp)
+  if (NOT WIN32)
+    pkg_check_modules_with_static (FREETYPE2 REQUIRED freetype2)
+  endif()
 endif()
 
 target_include_directories(tsmuxer PRIVATE
   "${PROJECT_SOURCE_DIR}/../libmediation"
   ${ZLIB_INCLUDE_DIRS}
-  ${FREETYPE2_INCLUDE_DIRS}
 )
 target_link_libraries(tsmuxer
   mediation
@@ -100,9 +98,12 @@ target_link_libraries(tsmuxer
 )
 
 if (WIN32)
-  target_link_libraries (tsmuxer gdiplus)
-else ()
-  target_link_libraries (tsmuxer ${FREETYPE2_LIBRARIES})
+  target_sources(tsmuxer PRIVATE osdep/textSubtitlesRenderWin32.cpp)
+  target_link_libraries(tsmuxer gdiplus)
+else()
+  target_sources(tsmuxer PRIVATE osdep/textSubtitlesRenderFT.cpp)
+  target_link_libraries(tsmuxer ${FREETYPE2_LIBRARIES})
+  target_include_directories(tsmuxer PRIVATE ${FREETYPE2_INCLUDE_DIRS})
 endif()
 
 install (TARGETS tsmuxer DESTINATION bin)


### PR DESCRIPTION
The MSYS2 build failed due to using stuff from `string.h`, but the header not being included. This commit fixes this.