### PR TITLE
Correct AAC frame size parsing

### DIFF
--- a/tsMuxer/aac.cpp
+++ b/tsMuxer/aac.cpp
@@ -48,7 +48,7 @@ uint8_t* AACCodec::findAacFrame(uint8_t* buffer, uint8_t* end)
 
 int AACCodec::getFrameSize(uint8_t* buffer)
 {
-	return buffer[4]*8 + (buffer[5] >> 5);
+	return ((buffer[3] & 0x03) << 11) + (buffer[4] << 3) + (buffer[5] >> 5);
 }
 
 bool AACCodec::decodeFrame(uint8_t* buffer, uint8_t* end)


### PR DESCRIPTION
This patch solves issue 26.

tsMuxeR incorrectly parses the AAC frame length : as per ISO/IEC 13818-7, frame_length is 13-bit, however tsMuxer reads 11 bits only. Therefore all frames above 2048 bytes are reported as bad frames and discarded.
