### PR TITLE
Parse channel number from 'esds' atom

### DIFF
--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -183,6 +183,7 @@ public:
 			if (frameSize == 0) 
 				frameSize = m_sc->m_index[m_sc->m_indexCur++];
 			if (isAAC) {
+				m_aacRaw.m_channels = m_sc->channels;
 				m_aacRaw.buildADTSHeader(dst, frameSize + AAC_HEADER_LEN);
 				memcpy(dst + AAC_HEADER_LEN, buff, frameSize);
 				dst += frameSize + AAC_HEADER_LEN;
@@ -1451,6 +1452,7 @@ int MovDemuxer::mov_read_esds(MOVAtom atom)
 			if (st->parsed_priv_data) {
 				((MovParsedAudioTrackData*)st->parsed_priv_data)->isAAC = true;
 				st->parsed_priv_data->setPrivData(st->codec_priv, st->codec_priv_size);
+				st->channels = (st->codec_priv[1] >> 3) & 0x0f; 
 			}
         }
     }


### PR DESCRIPTION
tsMuxeR cannot demux correctly mp4 aac 5.1 : the problem seems to be linked to a bug from ffmpeg. tsMuxeR takes the channel count from 'mp4a' atom (cf. movDemuxer.cpp line 1252), but as noted [here](http://ffmpeg.org/pipermail/ffmpeg-user/2019-February/043300.html) ffmpeg sets the channel count to 2 in 'mp4a' atom even for aac 5.1, and the correct channel count has to be taken from 'esds' atom.

This patch allows tsMuxeR to read the channel number from the 'esds' atom rather than from the 'mp4a' atom.