### PR TITLE
Actions will now fail if a executable isn't produced

### DIFF
--- a/rebuild_linux_docker.sh
+++ b/rebuild_linux_docker.sh
@@ -6,3 +6,4 @@ make
 cp tsMuxer/tsmuxer ../bin/tsMuxeR
 cd ..
 rm -rf build
+ls ../bin/tsMuxeR

--- a/rebuild_mxe_docker.sh
+++ b/rebuild_mxe_docker.sh
@@ -9,3 +9,4 @@ make
 cp tsMuxer/tsmuxer.exe ../bin/tsMuxeR.exe
 cd ..
 rm -rf build
+ls ../bin/tsMuxeR.exe

--- a/rebuild_osxcross_docker.sh
+++ b/rebuild_osxcross_docker.sh
@@ -10,3 +10,4 @@ make
 cp tsMuxer/tsmuxer ../bin/tsMuxeR
 cd ..
 rm -rf build
+ls ../bin/tsMuxeR


### PR DESCRIPTION
There was a string of recent builds in GitHub that failed - but were all reported as working. This should resolve that issue.