### PR TITLE
WIN32_LEAN_AND_MEAN for Windows built

### DIFF
--- a/tsMuxer/textSubtitles.h
+++ b/tsMuxer/textSubtitles.h
@@ -2,6 +2,7 @@
 #define __TEXT_SUBTITLES_H
 
 #ifdef WIN32
+#define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #include "windows.h"
 #endif
 


### PR DESCRIPTION
On MSVC 16.3.10, textSubtitles.cpp won't compile without this line (which was originally in the removed file stdafx.h). See attached Error log without this line.
[Error Log.txt](https://github.com/justdan96/tsMuxer/files/3907831/Error.Log.txt)
