### PR TITLE
Parse hdr10 metadata

### DIFF
--- a/tsMuxer/aac.cpp
+++ b/tsMuxer/aac.cpp
@@ -1,7 +1,7 @@
 #include "aac.h"
 #include "bitStream.h"
 #include "vod_common.h"
-
+//for new branch
 
 
 

--- a/tsMuxer/aac.cpp
+++ b/tsMuxer/aac.cpp
@@ -1,7 +1,6 @@
 #include "aac.h"
 #include "bitStream.h"
 #include "vod_common.h"
-//for new branch
 
 
 

--- a/tsMuxer/aac.cpp
+++ b/tsMuxer/aac.cpp
@@ -4,6 +4,7 @@
 
 
 
+
 // convert AAC prifle to mpeg 4 object type.
 
 /*

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -833,15 +833,15 @@ int HevcSeiUnit::deserialize() {
 				nbyte = m_reader.getBits(8);
 				payloadSize += nbyte;
 			}
-			if (payloadType == 137) {
+			if (payloadType == 137) { // mastering_display_colour_volume
 				primariesGreen = m_reader.getBits(32);
 				primariesBlue = m_reader.getBits(32);
 				primariesRed = m_reader.getBits(32);
 				white_point = m_reader.getBits(32);
 				mastering_luminance = (m_reader.getBits(32)/10000) << 8 + m_reader.getBits(32);
 			}
-			else if (payloadType == 144)
-				maxCLL = m_reader.getBits(32);
+			else if (payloadType == 144) // content_light_level_info
+				maxCLL = m_reader.getBits(32); // maxCLL, maxFALL
 			else for (int i = 0; i < payloadSize; i++)
 				m_reader.skipBits(8);
 		} while (m_reader.showBits(8) != 0x80);

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -169,6 +169,18 @@ public:
     int num_extra_slice_header_bits;
 };
 
+struct HevcSeiUnit: public HevcUnit // HDR Metadata
+{
+	HevcSeiUnit();
+	int deserialize();
+	int primariesGreen;
+	int primariesBlue;
+	int primariesRed;
+	int white_point;
+	int mastering_luminance;
+	int maxCLL;
+};
+
 struct HevcSliceHeader: public HevcUnit
 {
     HevcSliceHeader();

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -12,6 +12,7 @@ HEVCStreamReader::HEVCStreamReader():
     m_vps(0),
     m_sps(0),
     m_pps(0),
+    m_sei(0), // HDR Metadata
     m_firstFrame(true),
     m_frameNum(0),
     m_fullPicOrder(0),

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -41,6 +41,7 @@ private:
     HevcVpsUnit* m_vps;
     HevcSpsUnit* m_sps;
     HevcPpsUnit* m_pps;
+    HevcSeiUnit* m_sei; // HDR Metadata
     bool m_firstFrame;
     
     int m_frameNum;


### PR DESCRIPTION
Parse HDR10 metadata from HEVC stream, by detecting and parsing SEI NAL units with Payload 137 and 144.
This data will be used to inject in mpls/clpi/bdmv files (future patches)