### PR TITLE
Replace "virtual" with "override" where a given function is overridden

### DIFF
--- a/libmediation/containers/safequeue.h
+++ b/libmediation/containers/safequeue.h
@@ -117,7 +117,7 @@ public:
 	{
 	}
 
-	virtual ~WaitableSafeQueue() {}
+	~WaitableSafeQueue() override {}
 
 	T pop()
 	{

--- a/libmediation/fs/file.h
+++ b/libmediation/fs/file.h
@@ -61,7 +61,7 @@ public:
 		const char* fName, 
 		unsigned int oflag,
 		unsigned int systemDependentFlags = 0 ) /* throw ( std::runtime_error ) */;
-	virtual ~File();
+	~File() override;
 
 	//! Open the file
 	/*!
@@ -72,7 +72,7 @@ public:
 			In the unix implementation, this is the second parameter to the open function.
 		\return true if the file was opened successfully, false otherwise
 	*/
-	virtual bool open( 
+	bool open( 
 		const char* fName, 
 		unsigned int oflag,
 		unsigned int systemDependentFlags = 0 ) override;
@@ -80,7 +80,7 @@ public:
 	/*!
 		\return true, if the file was closed, false in case of an error
 	*/
-	virtual bool close() override;
+	bool close() override;
 
 	//! Read the file
 	/*!
@@ -92,12 +92,12 @@ public:
 	/*!
 		\return The number of bytes written into the file. -1 in case of an error (for example, if the disk is full).
 	*/
-	virtual int write( const void* buffer, uint32_t count ) override;
+	int write( const void* buffer, uint32_t count ) override;
 	//! Write changes into the disk.
 	/*!
 		Write changes into the disk
 	*/
-	virtual void sync() override;
+	void sync() override;
 
 	//! Check if the file is open.
 	/*!
@@ -111,7 +111,7 @@ public:
 	*/
 	bool size( uint64_t* const fileSize ) const;
 
-    virtual int64_t size() const override {
+    int64_t size() const override {
         uint64_t result;
         if (size(&result))
             return (int64_t) result;

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -5,10 +5,6 @@
 #include <vector>
 #include <cstdint>
 
-//class Serializator;
-
-#define override
-
 #ifdef WIN32
 #define strcasecmp stricmp
 #endif

--- a/tsMuxer/BufferedReader.h
+++ b/tsMuxer/BufferedReader.h
@@ -77,21 +77,21 @@ class BufferedReader: public AbstractReader, TerminatableThread
 public:
 	const static int UNKNOWN_READERID = 3;
 	BufferedReader ( uint32_t blockSize, uint32_t allocSize = 0, uint32_t prereadThreshold = 0);
-	virtual ~BufferedReader();
-	uint32_t createReader(int readBuffOffset = 0);
-	virtual void deleteReader(uint32_t readerID); // unregister readed
-	virtual uint8_t* readBlock(uint32_t readerID, uint32_t& readCnt, int& rez, bool* firstBlockVar = 0);
-	virtual void notify(uint32_t readerID, uint32_t dataReaded); // reader must call notificate when part of data handled
+	~BufferedReader() override;
+	uint32_t createReader(int readBuffOffset = 0) override;
+	void deleteReader(uint32_t readerID) override; // unregister readed
+	uint8_t* readBlock(uint32_t readerID, uint32_t& readCnt, int& rez, bool* firstBlockVar = 0) override;
+	void notify(uint32_t readerID, uint32_t dataReaded) override; // reader must call notificate when part of data handled
 	uint32_t getReaderCount();
 	void terminate();
 	void setFileIterator(FileNameIterator* itr, int readerID);
 	bool incSeek(uint32_t readerID, int64_t offset);
-    virtual bool gotoByte(uint32_t readerID, uint64_t seekDist)  { return false; }
+    bool gotoByte(uint32_t readerID, uint64_t seekDist) override  { return false; }
 
 	void setId(int value) { m_id = value; }
 protected:
     virtual ReaderData* intCreateReader() = 0;
-    void thread_main();
+    void thread_main() override;
 
 protected:
 	bool m_started;

--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -9,18 +9,18 @@ class AACStreamReader: public SimplePacketizerReader, public AACCodec {
 public:
 public:
 	AACStreamReader(): SimplePacketizerReader() {};
-	virtual int getTSDescriptor(uint8_t* dstBuff) {return 0;}
-	virtual int getFreq() {return m_sample_rate;}
-	virtual int getChannels() {return m_channels;}
+	int getTSDescriptor(uint8_t* dstBuff) override {return 0;}
+	int getFreq() override {return m_sample_rate;}
+	int getChannels() override {return m_channels;}
 protected:
-	virtual unsigned getHeaderLen();
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes);
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) {
+	unsigned getHeaderLen() override;
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
+	uint8_t* findFrame(uint8_t* buff, uint8_t* end) override {
 		return findAacFrame(buff,end);
 	}
-	virtual double getFrameDurationNano() {return (INTERNAL_PTS_FREQ * m_samples) / (double) m_sample_rate;}
-	virtual const CodecInfo& getCodecInfo() {return aacCodecInfo;}
-	virtual const std::string getStreamInfo(); 
+	double getFrameDurationNano() override {return (INTERNAL_PTS_FREQ * m_samples) / (double) m_sample_rate;}
+	const CodecInfo& getCodecInfo() override {return aacCodecInfo;}
+	const std::string getStreamInfo() override; 
 };
 
 #endif

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -21,45 +21,45 @@ public:
         m_nextAc3Time = 0;
         m_thdFrameOffset = 0;
 	};
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	void setNewStyleAudioPES(bool value) {m_useNewStyleAudioPES = value;}
-	virtual void setTestMode(bool value) {AC3Codec::setTestMode(value);}
-	virtual int getFreq() {return AC3Codec::m_sample_rate;}
-	virtual int getAltFreq() {
+	void setTestMode(bool value) override {AC3Codec::setTestMode(value);}
+	int getFreq() override {return AC3Codec::m_sample_rate;}
+	int getAltFreq() override {
 		if (m_downconvertToAC3)
 			return AC3Codec::m_sample_rate;
 		else
 			return mh.subType == MLPHeaderInfo::stUnknown ? AC3Codec::m_sample_rate : mh.group1_samplerate;
 	}
-	virtual int getChannels() {return AC3Codec::m_channels;}
-    virtual bool isPriorityData(AVPacket* packet) override;
-    virtual bool isIFrame(AVPacket* packet) override { return isPriorityData(packet); }
+	int getChannels() override {return AC3Codec::m_channels;}
+    bool isPriorityData(AVPacket* packet) override;
+    bool isIFrame(AVPacket* packet) override { return isPriorityData(packet); }
 protected:
-	virtual unsigned getHeaderLen() {return AC3Codec::getHeaderLen();}
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) {
+	unsigned getHeaderLen() override {return AC3Codec::getHeaderLen();}
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override {
 		skipBeforeBytes = 0;
 		return AC3Codec::decodeFrame(buff, end, skipBytes);
 	}
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) {
+	uint8_t* findFrame(uint8_t* buff, uint8_t* end) override {
 		return AC3Codec::findFrame(buff, end);
 	}
-	virtual double getFrameDurationNano(){
+	double getFrameDurationNano() override{
 		return AC3Codec::getFrameDurationNano();
 	}
-	virtual const CodecInfo& getCodecInfo(){
+	const CodecInfo& getCodecInfo() override{
 		return AC3Codec::getCodecInfo();
 	}
-	virtual const std::string getStreamInfo() {
+	const std::string getStreamInfo() override {
 		return AC3Codec::getStreamInfo();
 	}
-	virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket);
+	void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) override;
 
 
-    virtual int readPacket(AVPacket& avPacket) override;
-    virtual int flushPacket(AVPacket& avPacket) override;
+    int readPacket(AVPacket& avPacket) override;
+    int flushPacket(AVPacket& avPacket) override;
     int readPacketTHD(AVPacket& avPacket);
 
-    virtual bool needMPLSCorrection() const override;
+    bool needMPLSCorrection() const override;
 
 private:
 	bool m_useNewStyleAudioPES;

--- a/tsMuxer/blurayHelper.h
+++ b/tsMuxer/blurayHelper.h
@@ -15,7 +15,7 @@ class BlurayHelper: public FileFactory
 {
 public:
     BlurayHelper();
-    ~BlurayHelper();
+    ~BlurayHelper() override;
 
     bool open(const std::string& dst, DiskType dt, int64_t diskSize = 0, int extraISOBlocks = 0);
     bool createBluRayDirs();
@@ -33,8 +33,8 @@ public:
     void close();
     // file factory interface
 
-    virtual AbstractOutputStream* createFile() override;
-    virtual bool isVirtualFS() const override;
+    AbstractOutputStream* createFile() override;
+    bool isVirtualFS() const override;
     void setVolumeLabel(const std::string& label);
 private:
     std::string m_dstPath;

--- a/tsMuxer/bufferedFileReader.h
+++ b/tsMuxer/bufferedFileReader.h
@@ -15,9 +15,9 @@ class FileListIterator: public FileNameIterator
 public:
     FileListIterator(): m_index(0)
     {}
-	virtual ~FileListIterator() {}
+	~FileListIterator() override {}
 
-	virtual std::string getNextName() override
+	std::string getNextName() override
     {
         if (++m_index < m_files.size())
             return m_files[m_index];
@@ -53,10 +53,10 @@ public:
         m_fileHeaderSize(0)
     {}
 
-    virtual ~FileReaderData() 
+    ~FileReaderData() override 
     {}
 
-    virtual uint32_t readBlock(uint8_t* buffer, int max_size) 
+    uint32_t readBlock(uint8_t* buffer, int max_size) override 
     {
         int rez = 0;
         rez = m_file.read(buffer, max_size);
@@ -65,9 +65,9 @@ public:
     }
 	
 
-    virtual bool openStream();
-	virtual bool closeStream() { return m_file.close(); }
-	virtual bool incSeek ( int64_t offset ) { return m_file.seek(offset, File::smCurrent) != uint64_t(-1); }
+    bool openStream() override;
+	bool closeStream() override { return m_file.close(); }
+	bool incSeek ( int64_t offset ) override { return m_file.seek(offset, File::smCurrent) != uint64_t(-1); }
 
 public:
 	File     m_file;
@@ -79,10 +79,10 @@ class BufferedFileReader: public BufferedReader
 public:
 	BufferedFileReader (uint32_t blockSize, uint32_t allocSize = 0, uint32_t prereadThreshold = 0);
 
-    virtual bool openStream(uint32_t readerID, const char* streamName, int pid = 0, const CodecInfo* codecInfo = 0);
-	virtual bool gotoByte(uint32_t readerID, uint64_t seekDist);
+    bool openStream(uint32_t readerID, const char* streamName, int pid = 0, const CodecInfo* codecInfo = 0) override;
+	bool gotoByte(uint32_t readerID, uint64_t seekDist) override;
 protected:
-	ReaderData* intCreateReader() { return new FileReaderData(m_blockSize, m_allocSize); }
+	ReaderData* intCreateReader() override { return new FileReaderData(m_blockSize, m_allocSize); }
 };
 
 #endif

--- a/tsMuxer/bufferedFileWriter.h
+++ b/tsMuxer/bufferedFileWriter.h
@@ -26,7 +26,7 @@ class BufferedFileWriter: public TerminatableThread
 {
 public:
 	BufferedFileWriter ();
-	~BufferedFileWriter();
+	~BufferedFileWriter() override;
 	void terminate();
 	inline int getQueueSize() {return (int) m_writeQueue.size();}
 	inline bool addWriterData(const WriterData& data)
@@ -42,7 +42,7 @@ public:
 	}
 	bool isQueueEmpty() { return m_nothingToExecute;}
 protected:
-	void thread_main();
+	void thread_main() override;
 private:
 	bool m_nothingToExecute;
 	int m_lastErrorCode;

--- a/tsMuxer/combinedH264Demuxer.h
+++ b/tsMuxer/combinedH264Demuxer.h
@@ -38,16 +38,16 @@ class CombinedH264Demuxer: public AbstractDemuxer, public CombinedH264Reader
 {
 public:
     CombinedH264Demuxer(const BufferedReaderManager& readManager, const char* streamName);
-    virtual ~CombinedH264Demuxer();
-    void openFile(const std::string& streamName);
-    virtual void readClose();
-    virtual uint64_t getDemuxedSize();
-    virtual int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize);
-    virtual void getTrackList(std::map<uint32_t, TrackInfo>& trackList);
-    virtual int getLastReadRez() {return m_lastReadRez; };
-    virtual void setFileIterator(FileNameIterator* itr) override;
+    ~CombinedH264Demuxer() override;
+    void openFile(const std::string& streamName) override;
+    void readClose() override;
+    uint64_t getDemuxedSize() override;
+    int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize) override;
+    void getTrackList(std::map<uint32_t, TrackInfo>& trackList) override;
+    int getLastReadRez() override {return m_lastReadRez; };
+    void setFileIterator(FileNameIterator* itr) override;
 
-    virtual bool isPidFilterSupported() const { return true; }
+    bool isPidFilterSupported() const override { return true; }
 private:
     const BufferedReaderManager& m_readManager;
     AbstractReader* m_bufferedReader;
@@ -60,8 +60,8 @@ class CombinedH264Filter: public SubTrackFilter, public CombinedH264Reader
 {
 public:
     CombinedH264Filter(int demuxedPID);
-    virtual ~CombinedH264Filter() {}
-    virtual int demuxPacket(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, AVPacket& avPacket) override;
+    ~CombinedH264Filter() override {}
+    int demuxPacket(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, AVPacket& avPacket) override;
 };
 
 

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -33,23 +33,23 @@ public:
         m_dtsEsChannels = 0;
         m_testMode = false;
 	};
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	void setDownconvertToDTS(bool value) {m_downconvertToDTS = value;}
 	bool getDownconvertToDTS() {return m_downconvertToDTS;}
 	DTSHD_SUBTYPE getDTSHDMode() {return m_hdType;}
 	void setNewStyleAudioPES(bool value) {m_useNewStyleAudioPES = value;}
-	virtual int getFreq() {return hd_pi_sample_rate ? hd_pi_sample_rate : pi_sample_rate;}
-	virtual int getChannels() {return hd_pi_channels ? hd_pi_channels : pi_channels;}
-    virtual bool isPriorityData(AVPacket* packet) override;
-    virtual bool isIFrame(AVPacket* packet) override { return isPriorityData(packet); }
-    virtual void setTestMode(bool value) override {m_testMode = value;}
+	int getFreq() override {return hd_pi_sample_rate ? hd_pi_sample_rate : pi_sample_rate;}
+	int getChannels() override {return hd_pi_channels ? hd_pi_channels : pi_channels;}
+    bool isPriorityData(AVPacket* packet) override;
+    bool isIFrame(AVPacket* packet) override { return isPriorityData(packet); }
+    void setTestMode(bool value) override {m_testMode = value;}
 protected:
-	virtual unsigned getHeaderLen() {return DTS_HEADER_SIZE;}; 
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes); 
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end); 
-	virtual double getFrameDurationNano(); 
+	unsigned getHeaderLen() override {return DTS_HEADER_SIZE;}; 
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override; 
+	uint8_t* findFrame(uint8_t* buff, uint8_t* end) override; 
+	double getFrameDurationNano() override; 
 	//virtual bool isSubFrame() {return m_state == stDecodeHD2;} 
-	virtual const CodecInfo& getCodecInfo() 
+	const CodecInfo& getCodecInfo() override 
 	{
         if (m_dts_hd_mode) {
             if (m_hdType == DTS_SUBTYPE_EXPRESS)
@@ -60,9 +60,9 @@ protected:
 		else
 			return dtsCodecInfo;
 	}
-	virtual const std::string getStreamInfo(); 
-    virtual bool needSkipFrame(const AVPacket& packet) override;
-	virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket);
+	const std::string getStreamInfo() override;
+    bool needSkipFrame(const AVPacket& packet) override;
+	void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) override;
 private:
 	enum DTSHD_SUBTYPE m_hdType;
 	enum DTSDecodeState {stDecodeDTS, stDecodeHD, stDecodeHD2};

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -9,17 +9,17 @@ class DVBSubStreamReader: public SimplePacketizerReader{
 public:
 	DVBSubStreamReader(): SimplePacketizerReader(),m_big_offsets(0),m_frameDuration(0),m_firstFrame(true) {
 	}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 protected:
-	virtual unsigned getHeaderLen() override {return 10;}
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
-	virtual double getFrameDurationNano() override; 
-	virtual const CodecInfo& getCodecInfo() {return dvbSubCodecInfo;}
-	virtual const std::string getStreamInfo() override;
+	unsigned getHeaderLen() override {return 10;}
+	uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
+	double getFrameDurationNano() override; 
+	const CodecInfo& getCodecInfo() override {return dvbSubCodecInfo;}
+	const std::string getStreamInfo() override;
 	void setStreamType(int streamType) {}
-	virtual int getChannels() override {return 6;} // fake. need refactor this class
-	virtual int getFreq() override {return 48000;} // fake. need refactor this class
+	int getChannels() override {return 6;} // fake. need refactor this class
+	int getFreq() override {return 48000;} // fake. need refactor this class
 private:
 	bool m_firstFrame;
 	int m_big_offsets;

--- a/tsMuxer/h264StreamReader.h
+++ b/tsMuxer/h264StreamReader.h
@@ -19,9 +19,9 @@ public:
     };
 
 	H264StreamReader();
-    virtual ~H264StreamReader();
+    ~H264StreamReader() override;
 	void setForceLevel(uint8_t value) {m_forcedLevel = value;}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 	void setH264SPSCont(bool val) {m_h264SPSCont = val;}
 	
@@ -35,28 +35,28 @@ public:
 
     // used for correction offset metadata
     virtual void setStartPTS(int64_t pts) {m_startPts = pts; }
-    virtual bool needSPSForSplit() const override { return true; }
+    bool needSPSForSplit() const override { return true; }
 protected:
-	virtual void onSplitEvent() { m_firstFileFrame = true; }
-	virtual const CodecInfo& getCodecInfo();
-	virtual int intDecodeNAL(uint8_t* buff);
-	virtual void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen);
-	virtual double getStreamFPS(void* curNalUnit) {
+	void onSplitEvent() override { m_firstFileFrame = true; }
+	const CodecInfo& getCodecInfo() override;
+	int intDecodeNAL(uint8_t* buff) override;
+	void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
+	double getStreamFPS(void* curNalUnit) override {
 		SPSUnit* sps = (SPSUnit*) curNalUnit;
 		return sps->getFPS();
 	};
 
-	virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData);
-	virtual int getFrameDepth() { return m_frameDepth; }
-	virtual int getStreamWidth() const;
-	virtual int getStreamHeight() const;
-	virtual bool getInterlaced();
-	virtual bool isIFrame() { return m_lastIFrame; }
+	int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override;
+	int getFrameDepth() override { return m_frameDepth; }
+	int getStreamWidth() const override;
+	int getStreamHeight() const override;
+	bool getInterlaced() override;
+	bool isIFrame() override { return m_lastIFrame; }
     //virtual bool isIFrame() { return m_lastSliceIDR; }
 
-    virtual bool isPriorityData(AVPacket* packet) override;
-    virtual void onShiftBuffer(int offset) override;
-    virtual bool skipNal(uint8_t* nal) override;
+    bool isPriorityData(AVPacket* packet) override;
+    void onShiftBuffer(int offset) override;
+    bool skipNal(uint8_t* nal) override;
 private:
     bool replaceToOwnSPS() const;
     int deserializeSliceHeader(SliceUnit& slice, uint8_t* buff, uint8_t* sliceEnd);

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -82,7 +82,7 @@ protected:
 struct HevcVpsUnit: public HevcUnitWithProfile
 {
     HevcVpsUnit();
-    virtual int deserialize() override;
+    int deserialize() override;
     double getFPS() const;
     void setFPS(double value);
     std::string getDescription() const;
@@ -113,7 +113,7 @@ struct ShortTermRPS
 struct HevcSpsUnit: public HevcUnitWithProfile
 {
     HevcSpsUnit();
-    virtual int deserialize() override;
+    int deserialize() override;
 
     std::string getDescription() const;
 public:
@@ -160,7 +160,7 @@ private:
 struct HevcPpsUnit: public HevcUnit
 {
     HevcPpsUnit();
-    int deserialize();
+    int deserialize() override;
 public:
     int pps_id;
     int sps_id;

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -10,24 +10,24 @@ class HEVCStreamReader: public MPEGStreamReader
 {
 public:
     HEVCStreamReader();
-    virtual ~HEVCStreamReader();
-    virtual int getTSDescriptor(uint8_t* dstBuff);
+    ~HEVCStreamReader() override;
+    int getTSDescriptor(uint8_t* dstBuff) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
-    virtual bool needSPSForSplit() const override { return false; }
+    bool needSPSForSplit() const override { return false; }
 protected:
-    virtual const CodecInfo& getCodecInfo() override {return hevcCodecInfo;};
+    const CodecInfo& getCodecInfo() override {return hevcCodecInfo;};
     virtual int intDecodeNAL(uint8_t* buff) override;
 
-    virtual double getStreamFPS(void * curNalUnit) override;
-    virtual int getStreamWidth() const  override;
-    virtual int getStreamHeight() const  override;
-    virtual bool getInterlaced()  override {return false;}
-    virtual bool isIFrame() {return m_lastIFrame;}
+    double getStreamFPS(void * curNalUnit) override;
+    int getStreamWidth() const  override;
+    int getStreamHeight() const  override;
+    bool getInterlaced()  override {return false;}
+    bool isIFrame() override {return m_lastIFrame;}
 
-    virtual void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
-    virtual int getFrameDepth() override { return m_frameDepth; }
+    void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
+    int getFrameDepth() override { return m_frameDepth; }
     virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override;
-    virtual void onSplitEvent() { m_firstFileFrame = true; }
+    void onSplitEvent() override { m_firstFileFrame = true; }
 private:
     bool isSlice(int nalType) const;
     void incTimings();

--- a/tsMuxer/ioContextDemuxer.h
+++ b/tsMuxer/ioContextDemuxer.h
@@ -79,10 +79,10 @@ class IOContextDemuxer: public AbstractDemuxer
 {
 public:
 	IOContextDemuxer(const BufferedReaderManager& readManager);
-    virtual ~IOContextDemuxer();
-	virtual void setFileIterator(FileNameIterator* itr) override;
-	virtual uint64_t getDemuxedSize();
-	virtual int getLastReadRez() {return m_lastReadRez;};
+    ~IOContextDemuxer() override;
+	void setFileIterator(FileNameIterator* itr) override;
+	uint64_t getDemuxedSize() override;
+	int getLastReadRez() override {return m_lastReadRez;};
 	int64_t getProcessedBytes() { return m_processedBytes; }
 protected:
 	const static int MAX_STREAMS = 64;

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -259,11 +259,11 @@ class ISOFile: public AbstractOutputStream
 {
 public:
     ISOFile(IsoWriter* owner): AbstractOutputStream(), m_owner(owner), m_entry(0) {}
-    virtual ~ISOFile() { close(); }
+    ~ISOFile() override { close(); }
 
-    virtual int write(const void* data, uint32_t len) override;
-    virtual bool open(const char* name, unsigned int oflag, unsigned int systemDependentFlags = 0 ) override;
-    virtual void sync() override;
+    int write(const void* data, uint32_t len) override;
+    bool open(const char* name, unsigned int oflag, unsigned int systemDependentFlags = 0 ) override;
+    void sync() override;
     virtual bool close() override;
     virtual int64_t size() const override;
     void setSubMode(bool value);

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -25,27 +25,27 @@ public:
         m_lastChannelRemapPos = 0;
 	}
 	void setNewStyleAudioPES(bool value) {m_useNewStyleAudioPES = value;}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
-	virtual int getFreq() {return m_freq;}
-	virtual int getChannels() {return m_channels;}
+	int getTSDescriptor(uint8_t* dstBuff) override;
+	int getFreq() override {return m_freq;}
+	int getChannels() override {return m_channels;}
 	//void setDemuxMode(bool value) {m_demuxMode = value;}
 	void setFirstFrame(bool value) {m_firstFrame = value;}
-	virtual bool beforeFileCloseEvent(File& file);
+	bool beforeFileCloseEvent(File& file) override;
     void setHeadersType(LPCMHeaderType value);
 protected:
-	virtual unsigned getHeaderLen() {return 4;}
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes,int& skipBeforeBytes);
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end);
-	virtual double getFrameDurationNano();
-    virtual const CodecInfo& getCodecInfo();
-	virtual const std::string getStreamInfo();
-	void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket);
-	virtual void setTestMode(bool value) {m_testMode = value;}
-	virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData);
-	virtual int readPacket(AVPacket& avPacket);
-	virtual int flushPacket(AVPacket& avPacket);
-	virtual void onSplitEvent() {m_firstFrame = true;}
-    virtual void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false);
+	unsigned getHeaderLen() override {return 4;}
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes,int& skipBeforeBytes) override;
+	uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
+	double getFrameDurationNano() override;
+    const CodecInfo& getCodecInfo() override;
+	const std::string getStreamInfo() override;
+	void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) override;
+	void setTestMode(bool value) override {m_testMode = value;}
+	int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override;
+	int readPacket(AVPacket& avPacket) override;
+	int flushPacket(AVPacket& avPacket) override;
+	void onSplitEvent() override {m_firstFrame = true;}
+    void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false) override;
 private:
 	LPCMHeaderType m_headerType;
 	bool m_useNewStyleAudioPES;

--- a/tsMuxer/matroskaDemuxer.h
+++ b/tsMuxer/matroskaDemuxer.h
@@ -9,17 +9,17 @@ class MatroskaDemuxer: public IOContextDemuxer
 {
 public:
 	MatroskaDemuxer(const BufferedReaderManager& readManager);
-	virtual ~MatroskaDemuxer() {readClose();}
-	void openFile(const std::string& streamName);
+	~MatroskaDemuxer() override {readClose();}
+	void openFile(const std::string& streamName) override;
 	virtual int readPacket(AVPacket& avPacket); // not implemented
-	virtual void readClose();
-	virtual int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize);
-	virtual void getTrackList(std::map<uint32_t,TrackInfo>& trackList);
-	virtual std::vector<AVChapter> getChapters();
+	void readClose() override;
+	int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize) override;
+	void getTrackList(std::map<uint32_t,TrackInfo>& trackList) override;
+	std::vector<AVChapter> getChapters() override;
 
-    virtual bool isPidFilterSupported() const { return true; }
+    bool isPidFilterSupported() const override { return true; }
 
-    virtual int64_t getFileDurationNano() const override { return fileDuration; }
+    int64_t getFileDurationNano() const override { return fileDuration; }
 private:
 	typedef Track MatroskaTrack;
 	typedef IOContextTrackType MatroskaTrackType;

--- a/tsMuxer/matroskaParser.h
+++ b/tsMuxer/matroskaParser.h
@@ -212,8 +212,8 @@ struct CodecTags{
 class ParsedH264TrackData: public ParsedTrackPrivData {
 public:
 	ParsedH264TrackData(uint8_t* buff, int size);
-	virtual ~ParsedH264TrackData() {}
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
+	~ParsedH264TrackData() override {}
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
 protected:
 	int m_nalSize;
 	bool m_firstExtract;
@@ -228,16 +228,16 @@ protected:
 class ParsedH265TrackData: public ParsedH264TrackData {
 public:
     ParsedH265TrackData(uint8_t* buff, int size);
-    virtual ~ParsedH265TrackData() {}
+    ~ParsedH265TrackData() override {}
 
-    virtual bool spsppsExists(uint8_t* buff, int size) override;
+    bool spsppsExists(uint8_t* buff, int size) override;
 };
 
 class ParsedAC3TrackData: public ParsedTrackPrivData {
 public:
 	ParsedAC3TrackData(uint8_t* buff, int size);
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
-	virtual ~ParsedAC3TrackData() {}
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
+	~ParsedAC3TrackData() override {}
 private:
 	bool m_firstPacket;
 	bool m_shortHeaderMode;
@@ -246,8 +246,8 @@ private:
 class ParsedAACTrackData: public ParsedTrackPrivData {
 public:
 	ParsedAACTrackData(uint8_t* buff, int size);
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
-	virtual ~ParsedAACTrackData() {}
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
+	~ParsedAACTrackData() override {}
 private:
 	AACCodec m_aacRaw;
 };
@@ -255,8 +255,8 @@ private:
 class ParsedLPCMTrackData: public ParsedTrackPrivData {
 public:
     ParsedLPCMTrackData(MatroskaTrack* track);
-    virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
-    virtual ~ParsedLPCMTrackData() {}
+    void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
+    ~ParsedLPCMTrackData() override {}
 private:
     bool m_convertBytes;
     int m_bitdepth;
@@ -267,8 +267,8 @@ private:
 class ParsedSRTTrackData: public ParsedTrackPrivData {
 public:
 	ParsedSRTTrackData(uint8_t* buff, int size);
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
-	virtual ~ParsedSRTTrackData() {}
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
+	~ParsedSRTTrackData() override {}
 private:
 	int m_packetCnt;
 };
@@ -276,8 +276,8 @@ private:
 class ParsedVC1TrackData: public ParsedTrackPrivData {
 public:
 	ParsedVC1TrackData(uint8_t* buff, int size);
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
-	virtual ~ParsedVC1TrackData() {}
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
+	~ParsedVC1TrackData() override {}
 private:
 	std::vector<uint8_t> m_seqHeader;
 	bool m_firstPacket;
@@ -286,8 +286,8 @@ private:
 class ParsedPGTrackData: public ParsedTrackPrivData {
 public:
     ParsedPGTrackData() {}
-    virtual ~ParsedPGTrackData() {}
-    virtual void extractData(AVPacket* pkt, uint8_t* buff, int size);
+    ~ParsedPGTrackData() override {}
+    void extractData(AVPacket* pkt, uint8_t* buff, int size) override;
 private:
 };
 

--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -117,18 +117,18 @@ public:
 		m_discardedSize = 0;
 		m_terminated = false;
 	}
-	virtual uint8_t* readBlock(uint32_t readerID, uint32_t& readCnt, int& rez, bool* firstBlockVar = 0);
-	virtual void notify(uint32_t readerID, uint32_t dataReaded) {return;}
-	virtual uint32_t createReader(int readBuffOffset = 0);
-	virtual void deleteReader(uint32_t readerID);
-	virtual bool openStream(uint32_t readerID, const char* streamName, int pid = 0, const CodecInfo* codecInfo = 0);
+	uint8_t* readBlock(uint32_t readerID, uint32_t& readCnt, int& rez, bool* firstBlockVar = 0) override;
+	void notify(uint32_t readerID, uint32_t dataReaded) override {return;}
+	uint32_t createReader(int readBuffOffset = 0) override;
+	void deleteReader(uint32_t readerID) override;
+	bool openStream(uint32_t readerID, const char* streamName, int pid = 0, const CodecInfo* codecInfo = 0) override;
 	void setFileIterator(const char* streamName, FileNameIterator* itr);
 	void resetDelayedMark();
 	int64_t getDiscardedSize() {
 		return m_discardedSize;
 	};
 
-    virtual bool gotoByte(uint32_t readerID, uint64_t seekDist)  { return false; }
+    bool gotoByte(uint32_t readerID, uint64_t seekDist) override  { return false; }
 	void terminate();
 	void openAllStream();
 	std::map<std::string, DemuxerData> m_demuxers;
@@ -158,18 +158,18 @@ class METADemuxer: public AbstractDemuxer
 public:
 	//METADemuxer(const BufferedReaderManager& readManager, const char* streamName);
 	METADemuxer(const BufferedReaderManager& readManager);
-	virtual ~METADemuxer();
+	~METADemuxer() override;
 	//virtual void initStream();
 	virtual int readPacket(AVPacket& avPacket);
-	virtual void readClose();
-	virtual uint64_t getDemuxedSize();
+	void readClose() override;
+	uint64_t getDemuxedSize() override;
 	int addStream(const std::string codec, const std::string& codecStreamName, 
 			       const std::map<std::string,std::string>& addParams);
-	virtual void openFile(const std::string& streamName);
+	void openFile(const std::string& streamName) override;
 	const std::vector<StreamInfo>& getStreamInfo() {return m_codecInfo;}
 	static DetectStreamRez DetectStreamReader(BufferedReaderManager& readManager, const std::string& fileName, bool calcDuration);
 	std::vector<StreamInfo>& getCodecInfo() { return m_codecInfo; }
-	virtual int getLastReadRez() {return m_lastReadRez;}
+	int getLastReadRez() override {return m_lastReadRez;}
     int64_t totalSize() const { return m_totalSize; }
     std::string mplsTrackToFullName(const std::string& mplsFileName, std::string& mplsNum);
     std::string mplsTrackToSSIFName(const std::string& mplsFileName, std::string& mplsNum);

--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -162,7 +162,7 @@ public:
 	{
 		isAAC = false;
 	}
-	virtual void setPrivData(uint8_t* buff, int size) {
+	void setPrivData(uint8_t* buff, int size) override {
 		m_buff = buff;
 		m_size = size;	
 		m_aacRaw.m_channels = m_sc->channels;
@@ -174,7 +174,7 @@ public:
 		m_aacRaw.m_layer = 0;
 		m_aacRaw.m_rdb = 0;
 	}
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size)
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override
 	{
 		uint8_t* dst = pkt->data;
 		uint8_t* srcEnd = buff + size;
@@ -195,7 +195,7 @@ public:
 			buff += frameSize;
 		}
 	}
-	virtual int newBufferSize(uint8_t* buff, int size) 
+	int newBufferSize(uint8_t* buff, int size) override 
 	{
 		int frameCnt = 0;
 		int left = size;
@@ -231,7 +231,7 @@ public:
     {
 
     }
-	virtual void setPrivData(uint8_t* buff, int size) {
+	void setPrivData(uint8_t* buff, int size) override {
 		spsPpsList.clear();
 		if (size < 6)
 			THROW(ERR_MOV_PARSE, "Invalid H.264/AVC extra data format");
@@ -284,7 +284,7 @@ public:
 			THROW(ERR_MOV_PARSE, "MP4/MOV error: Unsupported H.264/AVC frame length field value " << nal_length_size);
 	}
 
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size)
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override
 	{
 		uint8_t* dst = pkt->data;
 		if (!spsPpsList.empty()) {
@@ -314,7 +314,7 @@ public:
 		}
 	}
 
-	virtual int newBufferSize(uint8_t* buff, int size) 
+	int newBufferSize(uint8_t* buff, int size) override 
 	{
 		uint8_t* end = buff + size;
 		int nalCnt = 0;
@@ -350,7 +350,7 @@ public:
     {
     }
 
-    virtual void setPrivData(uint8_t* buff, int size) 
+    void setPrivData(uint8_t* buff, int size) override 
     {
         spsPpsList = hevc_extract_priv_data(buff, size, &nal_length_size);
     }
@@ -377,13 +377,13 @@ public:
 		return m_sc->stts_data[sttsPos].duration;
 	}
 
-	virtual void setPrivData(uint8_t* buff, int size) {
+	void setPrivData(uint8_t* buff, int size) override {
 		m_buff = buff;
 		m_size = size;
 		sttsCnt = 0;
 		sttsPos = -1;
 	}
-	virtual void extractData(AVPacket* pkt, uint8_t* buff, int size)
+	void extractData(AVPacket* pkt, uint8_t* buff, int size) override
 	{
 		uint8_t* end = buff + size;
 		std::string prefix;
@@ -411,7 +411,7 @@ public:
 		m_timeOffset = endTime;
 	}
 
-	virtual int newBufferSize(uint8_t* buff, int size) 
+	int newBufferSize(uint8_t* buff, int size) override 
 	{
 		if (size <= 2)
 			return 0;

--- a/tsMuxer/movDemuxer.h
+++ b/tsMuxer/movDemuxer.h
@@ -14,16 +14,16 @@ class MovDemuxer: public IOContextDemuxer
 {
 public:
 	MovDemuxer(const BufferedReaderManager& readManager);
-	virtual ~MovDemuxer() {readClose();}
-	void openFile(const std::string& streamName);
-	virtual void readClose();
-	virtual int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize);
-	virtual void getTrackList(std::map<uint32_t,TrackInfo>& trackList);
-	virtual double getTrackFps(uint32_t trackId);
+	~MovDemuxer() override {readClose();}
+	void openFile(const std::string& streamName) override;
+	void readClose() override;
+	int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize) override;
+	void getTrackList(std::map<uint32_t,TrackInfo>& trackList) override;
+	double getTrackFps(uint32_t trackId) override;
     virtual int readPacket(AVPacket &) {return 0;}
-    virtual void setFileIterator(FileNameIterator* itr) override;
-    virtual bool isPidFilterSupported() const { return true; }
-    virtual int64_t getFileDurationNano() const override;
+    void setFileIterator(FileNameIterator* itr) override;
+    bool isPidFilterSupported() const override { return true; }
+    int64_t getFileDurationNano() const override;
 private:
 	struct MOVParseTableEntry;
 	struct MOVAtom

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -19,20 +19,20 @@ public:
 		m_longCodesAllowed = false;
 		m_prevFrameDelay = 0;
 	}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 
-	virtual int getStreamWidth() const {return m_sequence.width;}
-	virtual int getStreamHeight()const {return m_sequence.height;}
-	virtual bool getInterlaced() {return !m_sequence.progressive_sequence;}
+	int getStreamWidth() const override {return m_sequence.width;}
+	int getStreamHeight()const override {return m_sequence.height;}
+	bool getInterlaced() override {return !m_sequence.progressive_sequence;}
 
 protected:
-	virtual const CodecInfo& getCodecInfo() {return mpeg2CodecInfo;};
-	virtual int intDecodeNAL(uint8_t* buff);
-	virtual void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen);
-	virtual void updateStreamAR(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen);
-	virtual double getStreamFPS(void * curNalUnit) { return m_sequence.getFrameRate();};
-	virtual bool isIFrame() {return m_lastIFrame;}
+	const CodecInfo& getCodecInfo() override {return mpeg2CodecInfo;};
+	int intDecodeNAL(uint8_t* buff) override;
+	void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
+	void updateStreamAR(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
+	double getStreamFPS(void * curNalUnit) override { return m_sequence.getFrameRate();};
+	bool isIFrame() override {return m_lastIFrame;}
 private:
 	bool m_streamMsgPrinted;
 	int m_lastRef;

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -9,20 +9,20 @@ public:
 	const static uint32_t DTS_HD_PREFIX = 0x64582025;
 	MpegAudioStreamReader(): SimplePacketizerReader() {
 	}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	int getLayer() {return m_layer;}
-	virtual int getFreq() {return m_sample_rate;}
-	virtual int getChannels() {return 2;}
+	int getFreq() override {return m_sample_rate;}
+	int getChannels() override {return 2;}
 protected:
-	virtual unsigned getHeaderLen() {return MPEG_AUDIO_HEADER_SIZE;}; 
-	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end); 
-	virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes); 
-	virtual double getFrameDurationNano(); 
-	virtual const CodecInfo& getCodecInfo() 
+	unsigned getHeaderLen() override {return MPEG_AUDIO_HEADER_SIZE;};
+	virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
+	int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override; 
+	double getFrameDurationNano() override; 
+	const CodecInfo& getCodecInfo() override 
 	{
 		return mpegAudioCodecInfo;
 	}
-	virtual const std::string getStreamInfo(); 
+	const std::string getStreamInfo() override;
 private:
 	static const int MPEG_AUDIO_HEADER_SIZE = 4;
 };

--- a/tsMuxer/mpegStreamReader.h
+++ b/tsMuxer/mpegStreamReader.h
@@ -32,7 +32,7 @@ public:
 		m_streamAR = m_ar = AR_KEEP_DEFAULT; 
         m_spsPpsFound = false;
 	}
-	virtual ~MPEGStreamReader() {delete [] m_tmpBuffer;}
+	~MPEGStreamReader() override {delete [] m_tmpBuffer;}
 	void setFPS(double fps) {
 		m_fps = fps;
 		if (fps > 0)
@@ -48,10 +48,10 @@ public:
 		return m_streamAR;
 	}
 	void setAspectRatio(VideoAspectRatio ar) {m_ar = ar;}
-	virtual uint64_t getProcessedSize();
-	virtual void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false);
-	virtual int readPacket(AVPacket& avPacket);
-	virtual int flushPacket(AVPacket& avPacket);
+	uint64_t getProcessedSize() override;
+	void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false) override;
+	int readPacket(AVPacket& avPacket) override;
+	int flushPacket(AVPacket& avPacket) override;
 	virtual int getStreamWidth() const = 0;
 	virtual int getStreamHeight() const = 0;
 	virtual bool getInterlaced() = 0;

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -537,7 +537,7 @@ uint8_t* MPEGPictureHeader::deserializeDisplayExtension(BitStreamReader& bitRead
 	horizontal_offset = bitReader.getBits(16);
 	vertical_offset = bitReader.getBits(16);
     //MpegEncContext *s= &s1->mpeg_enc_ctx;
-	/*
+
     int i,nofco;
     nofco = 1;
     if(s->progressive_sequence){

--- a/tsMuxer/mpegVideo.h
+++ b/tsMuxer/mpegVideo.h
@@ -75,7 +75,7 @@ public:
 	uint8_t* m_data_buffer;
 	virtual bool addRawData(uint8_t* buffer, int len,  bool headerIncluded, bool isHeader);
 	MPEGRawDataHeader(int maxBufferLen);
-	~MPEGRawDataHeader();
+	~MPEGRawDataHeader() override;
 	virtual uint32_t serialize(uint8_t* buffer);
 	uint32_t getDataBufferLen() {return m_data_buffer_len;}
 	void clearRawBuffer(){
@@ -132,7 +132,7 @@ public:
 	int pan_scan_width;
 	int pan_scan_height;
 	MPEGSequenceHeader(int bufferSize);
-	~MPEGSequenceHeader() {};
+	~MPEGSequenceHeader() override {};
 	uint8_t* deserialize(uint8_t* buf, int buf_size);
 	uint8_t* deserializeExtension(BitStreamReader& bitContext);
 	uint8_t* deserializeMatrixExtension(BitStreamReader& bitContext);
@@ -218,18 +218,18 @@ public:
 
 	// methods
 	MPEGPictureHeader(int bufferSize);
-	~MPEGPictureHeader() {};
+	~MPEGPictureHeader() override {};
 
 	uint8_t* deserialize(uint8_t* buf, int buf_size);
 	uint8_t* deserializeCodingExtension(BitStreamReader& bitContext);
 	uint8_t* deserializeDisplayExtension(BitStreamReader& bitContext);
 
-	uint32_t serialize(uint8_t* buffer);
+	uint32_t serialize(uint8_t* buffer) override;
 	uint32_t getPictureSize();
 	void setTempRef(uint32_t number);
 	void setVbvDelay(uint16_t val);
 
-	bool addRawData(uint8_t* buffer, int len, bool headerIncluded, bool isHeader);
+	bool addRawData(uint8_t* buffer, int len, bool headerIncluded, bool isHeader) override;
 	void buildHeader();
 	void buildCodingExtension();
 	const char* getPictTypeStr() const {

--- a/tsMuxer/nalUnits.h
+++ b/tsMuxer/nalUnits.h
@@ -103,8 +103,8 @@ public:
 	const static int PCT_I_SI_P_SP_B_FRAMES = 7;
 	int primary_pic_type;
 	NALDelimiter(): NALUnit(nuDelimiter) {}
-	int deserialize(uint8_t* buffer, uint8_t* end);
-	int serialize(uint8_t* dstBuffer);
+	int deserialize(uint8_t* buffer, uint8_t* end) override;
+	int serialize(uint8_t* dstBuffer) override;
 };
 
 class PPSUnit: public NALUnit 
@@ -141,7 +141,7 @@ public:
     */
 
 	PPSUnit(): NALUnit(), m_ready(false) {}
-	virtual ~PPSUnit() {}
+	~PPSUnit() override {}
 	bool isReady() {return m_ready;}
 	int deserialize();
 	// duplicate PPS and change ppsID and cabac parameter for new PPS
@@ -257,7 +257,7 @@ public:
 
 
 	SPSUnit();
-	virtual ~SPSUnit() {
+	~SPSUnit() override {
 	}
 	bool isReady() {return m_ready;}
 	int deserialize();
@@ -286,7 +286,7 @@ class SEIUnit: public NALUnit
 {
 public:
 	SEIUnit(): NALUnit(), pic_struct(0), m_cpb_removal_delay_baseaddr(0), m_cpb_removal_delay_bitpos(0), number_of_offset_sequences(-1), metadataPtsOffset(0), m_mvcHeaderLen(0), m_mvcHeaderStart(0) {}
-	virtual ~SEIUnit() {}
+	~SEIUnit() override {}
 	void deserialize(SPSUnit& sps, int orig_hrd_parameters_present_flag);
 
     void serialize_pic_timing_message(const SPSUnit& sps, BitStreamWriter& writer, bool seiHeader);
@@ -369,7 +369,7 @@ public:
     int anchor_pic_flag;
 
 	SliceUnit();
-	virtual ~SliceUnit() {
+	~SliceUnit() override {
 		;
 	}
 	int deserialize(uint8_t* buffer, uint8_t* end, 

--- a/tsMuxer/osdep/textSubtitlesRenderFT.h
+++ b/tsMuxer/osdep/textSubtitlesRenderFT.h
@@ -16,14 +16,14 @@ class TextSubtitlesRenderFT : public TextSubtitlesRender
 {
 public:
 	TextSubtitlesRenderFT();
-	virtual ~TextSubtitlesRenderFT();
-	virtual void setRenderSize(int width, int height);
-	virtual void drawText(const std::wstring& text, RECT* rect);
-	virtual void setFont(const Font& font);
-	virtual void getTextSize(const std::wstring& text, SIZE* mSize);
-	virtual int getLineSpacing() override;
-    virtual int getBaseline() override;
-	virtual void flushRasterBuffer();
+	~TextSubtitlesRenderFT() override;
+	void setRenderSize(int width, int height) override;
+	void drawText(const std::wstring& text, RECT* rect) override;
+	void setFont(const Font& font) override;
+	void getTextSize(const std::wstring& text, SIZE* mSize) override;
+	int getLineSpacing() override;
+    int getBaseline() override;
+	void flushRasterBuffer() override;
 private:
 	static FT_Library library; 
 	static std::map<std::string, std::string> m_fontNameToFile;

--- a/tsMuxer/osdep/textSubtitlesRenderWin32.h
+++ b/tsMuxer/osdep/textSubtitlesRenderWin32.h
@@ -13,14 +13,14 @@ class TextSubtitlesRenderWin32 : public TextSubtitlesRender
 {
 public:
 	TextSubtitlesRenderWin32();
-	virtual ~TextSubtitlesRenderWin32();
-	virtual void setRenderSize(int width, int height);
-	virtual void drawText(const std::wstring& text, RECT* rect);
-	virtual void setFont(const Font& font);
-	virtual void getTextSize(const std::wstring& text, SIZE* mSize);
-	virtual int getLineSpacing() override;
-    virtual int getBaseline() override;
-	virtual void flushRasterBuffer();
+	~TextSubtitlesRenderWin32() override;
+	void setRenderSize(int width, int height) override;
+	void drawText(const std::wstring& text, RECT* rect) override;
+	void setFont(const Font& font) override;
+	void getTextSize(const std::wstring& text, SIZE* mSize) override;
+	int getLineSpacing() override;
+    int getBaseline() override;
+	void flushRasterBuffer() override;
 private:
 	HBITMAP m_hbmp;
 	BITMAPINFO* m_pbmpInfo;

--- a/tsMuxer/programStreamDemuxer.h
+++ b/tsMuxer/programStreamDemuxer.h
@@ -15,23 +15,23 @@ public:
 	const static int MAX_PES_HEADER_SIZE = 1018; // buffer for PES header and program stream map
 
 	ProgramStreamDemuxer(const BufferedReaderManager& readManager);
-	void openFile(const std::string& streamName);
+	void openFile(const std::string& streamName) override;
 	virtual int readPacket(AVPacket& avPacket) {return 0;}
-	virtual ~ProgramStreamDemuxer();
-	virtual int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize);
-	virtual void getTrackList(std::map<uint32_t,TrackInfo>& trackList);
-	virtual void readClose();
-	virtual uint64_t getDemuxedSize();
-	virtual int getLastReadRez() {return m_lastReadRez;};
-	virtual void setFileIterator(FileNameIterator* itr);
-	virtual int64_t getTrackDelay(uint32_t pid ) 
+	~ProgramStreamDemuxer() override;
+	int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize) override;
+	void getTrackList(std::map<uint32_t,TrackInfo>& trackList) override;
+	void readClose() override;
+	uint64_t getDemuxedSize() override;
+	int getLastReadRez() override {return m_lastReadRez;};
+	void setFileIterator(FileNameIterator* itr) override;
+	int64_t getTrackDelay(uint32_t pid ) override 
 	{
 		if (m_firstPtsTime.find(pid) != m_firstPtsTime.end())
 			return (m_firstPtsTime[pid] - (m_firstVideoPTS != -1 ? m_firstVideoPTS : m_firstPTS)) /90.0 + 0.5; // convert to ms
 		else
 			return 0;
 	}
-    virtual int64_t getFileDurationNano() const override;
+    int64_t getFileDurationNano() const override;
 private:
 	uint32_t m_tmpBufferLen;
 	uint8_t m_tmpBuffer[MAX_PES_HEADER_SIZE]; // TS_FRAME_SIZE

--- a/tsMuxer/psgStreamReader.h
+++ b/tsMuxer/psgStreamReader.h
@@ -23,19 +23,19 @@ public:
 	};
 
 	PGSStreamReader();
-	~PGSStreamReader() {
+	~PGSStreamReader() override {
 		delete [] m_imgBuffer;
 		delete [] m_rgbBuffer;
 		delete [] m_scaledRgbBuffer;
 		delete [] m_renderedData;
 		delete m_render;
 	}
-	virtual int readPacket(AVPacket& avPacket);
-	virtual int flushPacket(AVPacket& avPacket);
-	virtual void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false);
-	virtual uint64_t getProcessedSize();
+	int readPacket(AVPacket& avPacket) override;
+	int flushPacket(AVPacket& avPacket) override;
+	void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false) override;
+	uint64_t getProcessedSize() override;
 	CheckStreamRez checkStream(uint8_t* buffer, int len, ContainerType containerType, int containerDataType, int containerStreamIndex); 
-	virtual const CodecInfo& getCodecInfo() {return pgsCodecInfo;}
+	const CodecInfo& getCodecInfo() override {return pgsCodecInfo;}
 	//void setDemuxMode(bool value) {m_demuxMode = value;}
 	static int calcFpsIndex(double fps);
 
@@ -56,7 +56,7 @@ public:
     int ssPGOffset;
 
 protected:
-	virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData);
+	int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override;
 private:
 	struct PGSRenderedBlock
 	{

--- a/tsMuxer/simplePacketizerReader.h
+++ b/tsMuxer/simplePacketizerReader.h
@@ -10,13 +10,13 @@ class SimplePacketizerReader: public AbstractStreamReader {
 public:
 	//static const int NOT_ENOUGHT_BUFFER = -10;
 	SimplePacketizerReader();
-	~SimplePacketizerReader() {
+	~SimplePacketizerReader() override {
 		//delete [] m_tmpBuffer;
 	}
-	virtual int readPacket(AVPacket& avPacket);
-	virtual int flushPacket(AVPacket& avPacket);
-	virtual void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false);
-	virtual uint64_t getProcessedSize();
+	int readPacket(AVPacket& avPacket) override;
+	int flushPacket(AVPacket& avPacket) override;
+	void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false) override;
+	uint64_t getProcessedSize() override;
 	virtual CheckStreamRez checkStream(uint8_t* buffer, int len, 
 		                               ContainerType containerType, 
 									   int containerDataType, 

--- a/tsMuxer/singleFileMuxer.h
+++ b/tsMuxer/singleFileMuxer.h
@@ -9,17 +9,17 @@ class SingleFileMuxer: public AbstractMuxer
 {
 public:
 	SingleFileMuxer(MuxerManager* owner);
-	~SingleFileMuxer();
-	virtual bool muxPacket(AVPacket& avPacket);
-	virtual void intAddStream(const std::string& streamName,
+	~SingleFileMuxer() override;
+	bool muxPacket(AVPacket& avPacket) override;
+	void intAddStream(const std::string& streamName,
 		                      const std::string& codecName, int streamIndex, 
  		                      const std::map<std::string, std::string>& params,
 							  AbstractStreamReader* codecReader) override;
-	virtual bool doFlush() override;
-	virtual bool close();
-	virtual void openDstFile() override;
+	bool doFlush() override;
+	bool close() override;
+	void openDstFile() override;
 protected:
-    virtual void parseMuxOpt(const std::string& opts) override;
+    void parseMuxOpt(const std::string& opts) override;
 private:
 	const static int ADD_DATA_SIZE = 2048;
 	struct StreamInfo {
@@ -54,7 +54,7 @@ private:
 class SingleFileMuxerFactory: public AbstractMuxerFactory
 {
 public:
-    virtual AbstractMuxer* newInstance(MuxerManager* owner) const override { return new SingleFileMuxer(owner); }
+    AbstractMuxer* newInstance(MuxerManager* owner) const override { return new SingleFileMuxer(owner); }
 };
 
 #endif

--- a/tsMuxer/srtStreamReader.h
+++ b/tsMuxer/srtStreamReader.h
@@ -14,18 +14,18 @@ class SRTStreamReader: public AbstractStreamReader
 {
 public:
 	SRTStreamReader();
-	~SRTStreamReader();
-	virtual int readPacket(AVPacket& avPacket);
-	virtual int flushPacket(AVPacket& avPacket) {return m_dstSubCodec->flushPacket(avPacket);}
-	virtual void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false);
-	virtual uint64_t getProcessedSize() {return m_processedSize;}
+	~SRTStreamReader() override;
+	int readPacket(AVPacket& avPacket) override;
+	int flushPacket(AVPacket& avPacket) override {return m_dstSubCodec->flushPacket(avPacket);}
+	void setBuffer(uint8_t* data, int dataLen, bool lastBlock = false) override;
+	uint64_t getProcessedSize() override {return m_processedSize;}
 	CheckStreamRez checkStream(uint8_t* buffer, int len, ContainerType containerType, int containerDataType, int containerStreamIndex); 
-	virtual const CodecInfo& getCodecInfo() {return pgsCodecInfo;}
-	virtual void setStreamIndex(int index) {
+	const CodecInfo& getCodecInfo() override {return pgsCodecInfo;}
+	void setStreamIndex(int index) override {
 		m_streamIndex = index;
 		m_dstSubCodec->setStreamIndex(index);
 	}
-	virtual void setDemuxMode(bool value) 
+	void setDemuxMode(bool value) override 
 	{
 		m_demuxMode = value;
 		PGSStreamReader* pgsReader = dynamic_cast<PGSStreamReader*> (m_dstSubCodec);
@@ -44,7 +44,7 @@ public:
 	void setBottomOffset(int offset) {m_srtRender->setBottomOffset(offset);}
 
 protected:
-	virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) {
+	int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override {
 		return m_dstSubCodec->writeAdditionData(dstBuffer, dstEnd, avPacket, priorityData);
 	}
 private:

--- a/tsMuxer/tsDemuxer.h
+++ b/tsMuxer/tsDemuxer.h
@@ -15,15 +15,15 @@ class TSDemuxer: public AbstractDemuxer
 {
 public:
 	TSDemuxer(const BufferedReaderManager& readManager, const char* streamName);
-	virtual ~TSDemuxer();
-	void openFile(const std::string& streamName);
-	virtual void readClose();
-	virtual uint64_t getDemuxedSize();
-	virtual int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize);
-	virtual void getTrackList(std::map<uint32_t, TrackInfo>& trackList);
-	virtual int getLastReadRez() {return m_lastReadRez;};
-	virtual void setFileIterator(FileNameIterator* itr) override;
-	virtual int64_t getTrackDelay(uint32_t pid ) 
+	~TSDemuxer() override;
+	void openFile(const std::string& streamName) override;
+	void readClose() override;
+	uint64_t getDemuxedSize() override;
+	int simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& acceptedPIDs, int64_t& discardSize) override;
+	void getTrackList(std::map<uint32_t, TrackInfo>& trackList) override;
+	int getLastReadRez() override {return m_lastReadRez;};
+	void setFileIterator(FileNameIterator* itr) override;
+	int64_t getTrackDelay(uint32_t pid ) override 
 	{
 		if (m_firstPtsTime.find(pid) != m_firstPtsTime.end())
 			return (int64_t)((m_firstPtsTime[pid] - (m_firstVideoPTS != -1 ? m_firstVideoPTS : m_firstPTS)) /90.0 + 0.5); // convert to ms
@@ -31,7 +31,7 @@ public:
 			return 0;
 	}
 	void setMPLSInfo(const std::vector<MPLSPlayItem>& mplsInfo) { m_mplsInfo = mplsInfo; }
-    virtual int64_t getFileDurationNano() const;
+    int64_t getFileDurationNano() const override;
 private:
     bool mvcContinueExpected() const;
 private:

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -16,13 +16,13 @@ class TSMuxer: public AbstractMuxer
     typedef AbstractMuxer base_class;
 public:
 	TSMuxer(MuxerManager* owner);
-	~TSMuxer();
-	virtual void intAddStream(const std::string& streamName,
+	~TSMuxer() override;
+	void intAddStream(const std::string& streamName,
 		                      const std::string& codecName, int streamIndex, 
  		                      const std::map<std::string, std::string>& params,
 							  AbstractStreamReader* codecReader) override;
-	virtual bool doFlush() override;
-	virtual bool close();
+	bool doFlush() override;
+	bool close() override;
 	
 	int getVBVLength() { return m_vbvLen / 90; }
 	void setNewStyleAudioPES(bool val) {m_useNewStyleAudioPES = val;}
@@ -32,7 +32,7 @@ public:
 	void setPCROnVideoPID(bool val) {m_pcrOnVideo = val;}
 	void setMaxBitrate(int val) {m_cbrBitrate = val;}
 	void setMinBitrate(int val) {m_minBitrate = val;}
-	virtual void openDstFile() override;
+	void openDstFile() override;
 	void setVBVBufferLen(int value);
 	const PIDListMap& getPidList() const {return m_pmt.pidList;}
 	std::vector<int64_t> getFirstPts();
@@ -42,9 +42,9 @@ public:
     int splitFileCnt() const { return m_fileNames.size(); }
 	void setSplitDuration(uint64_t value) {m_splitDuration = value;}
 	void setSplitSize(uint64_t value) {m_splitSize = value;}
-	virtual void parseMuxOpt(const std::string& opts) override;
+	void parseMuxOpt(const std::string& opts) override;
 
-    virtual void setFileName(const std::string& fileName, FileFactory* fileFactory) override;
+    void setFileName(const std::string& fileName, FileFactory* fileFactory) override;
     std::string getFileNameByIdx(int idx);
     int getFirstFileNum() const;
     bool isInterleaveMode() const;
@@ -54,7 +54,7 @@ public:
 
     void setPtsOffset(int64_t value);
 protected:
-    virtual bool muxPacket(AVPacket& avPacket);
+    bool muxPacket(AVPacket& avPacket) override;
 	virtual void internalReset();
 	void setMuxFormat(const std::string& format);
 	bool isSplitPoint(const AVPacket& avPacket);
@@ -86,14 +86,14 @@ private:
     }
     void writePATPMT(int64_t pcr, bool force = false);
     void writePCR(uint64_t newPCR);
-    virtual std::string getNextName(const std::string curName) override;
+    std::string getNextName(const std::string curName) override;
     void writeEmptyPacketWithPCRTest(int64_t pcrVal);
     bool appendM2TSNullPacketToFile(uint64_t curFileSize, int counter, int* packetsWrited);
     int writeOutFile(uint8_t* buffer, int len);
 
     void joinToMasterFile() override;
-    virtual void setSubMode(AbstractMuxer* mainMuxer, bool flushInterleavedBlock) override;
-    virtual void setMasterMode(AbstractMuxer* subMuxer, bool flushInterleavedBlock) override;
+    void setSubMode(AbstractMuxer* mainMuxer, bool flushInterleavedBlock) override;
+    void setMasterMode(AbstractMuxer* subMuxer, bool flushInterleavedBlock) override;
 
     AbstractOutputStream* getDstFile() { return m_muxFile; }
     void flushTSBuffer();
@@ -201,7 +201,7 @@ private:
 class TSMuxerFactory: public AbstractMuxerFactory
 {
 public:
-    virtual AbstractMuxer* newInstance(MuxerManager* owner) const override { return new TSMuxer(owner); }
+    AbstractMuxer* newInstance(MuxerManager* owner) const override { return new TSMuxer(owner); }
 };
 
 #endif

--- a/tsMuxer/vc1StreamReader.h
+++ b/tsMuxer/vc1StreamReader.h
@@ -18,23 +18,23 @@ public:
 		m_longCodesAllowed = false;
 		m_nextFrameAddr = 0;
 	}
-	virtual ~VC1StreamReader() {}
-	virtual int getTSDescriptor(uint8_t* dstBuff);
+	~VC1StreamReader() override {}
+	int getTSDescriptor(uint8_t* dstBuff) override;
 	virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
-    virtual bool skipNal(uint8_t* nal) override;
-    virtual bool needSPSForSplit() const override { return true; }
+    bool skipNal(uint8_t* nal) override;
+    bool needSPSForSplit() const override { return true; }
 protected:
-	virtual const CodecInfo& getCodecInfo() {return vc1CodecInfo;};
-	virtual int intDecodeNAL(uint8_t* buff);
-	virtual void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen);
-	virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket);
-	virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData);
-	virtual double getStreamFPS(void * curNalUnit) { return m_sequence.getFPS();};
-	virtual int getStreamWidth() const {return m_sequence.coded_width;}
-	virtual int getStreamHeight() const {return m_sequence.coded_height;}
-	virtual bool getInterlaced() {return m_sequence.interlace;}
-	virtual bool isIFrame() {return m_lastIFrame;}
-	virtual void onSplitEvent() {
+	const CodecInfo& getCodecInfo() override {return vc1CodecInfo;};
+	int intDecodeNAL(uint8_t* buff) override;
+	void updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen) override;
+	void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) override;
+	int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket, PriorityDataInfo* priorityData) override;
+	double getStreamFPS(void * curNalUnit) override { return m_sequence.getFPS();};
+	int getStreamWidth() const override {return m_sequence.coded_width;}
+	int getStreamHeight() const override {return m_sequence.coded_height;}
+	bool getInterlaced() override {return m_sequence.interlace;}
+	bool isIFrame() override {return m_lastIFrame;}
+	void onSplitEvent() override {
 		m_firstFileFrame = true;
 	}
 private:

--- a/tsMuxerGUI/muxForm.h
+++ b/tsMuxerGUI/muxForm.h
@@ -16,7 +16,7 @@ public:
   void muxFinished(int exitCode, const QString& prefix);
   void setProcess(QProcess* proc);
 protected:
-  virtual void closeEvent (QCloseEvent * event );
+  void closeEvent (QCloseEvent * event ) override;
 private slots:
   void onProgressChanged();
   void onAbort();

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -1,12 +1,6 @@
 #ifndef TSMUXER_H_
 #define TSMUXER_H_
 
-#if defined(__GNUC__) && ((__GNUC__ < 4) || \
-    (__GNUC__ == 4 && __GNUC_MINOR__ <= 6))
-#define override
-#endif
-
-
 #include <QtGui>
 #include <QFileDialog>
 #include <QProcess>
@@ -35,9 +29,9 @@ public:
 signals:
     void checkStateChanged(Qt::CheckState state);
 protected:
-    virtual void paintEvent(QPaintEvent *e) override;
-    virtual void paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const override;
-    virtual QSize sectionSizeFromContents(int logicalIndex) const override;
+    void paintEvent(QPaintEvent *e) override;
+    void paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const override;
+    QSize sectionSizeFromContents(int logicalIndex) const override;
     private slots:
         void at_sectionClicked(int logicalIndex);
 private:
@@ -166,8 +160,8 @@ private slots:
     void updateMuxTime1();
     void updateMuxTime2();
 protected:
-    virtual void closeEvent(QCloseEvent * event ) override;
-    virtual bool eventFilter(QObject *obj, QEvent* event) override;
+    void closeEvent(QCloseEvent * event ) override;
+    bool eventFilter(QObject *obj, QEvent* event) override;
     void updateMaxOffsets();
     void updateCustomChapters();
 


### PR DESCRIPTION
With C++14 being officially enabled for some time now, all those defines turning
"override" into an empty token looked kind of embarassing. They are now removed
and the "virtual" keyword is replaced with "override" where appropriate.