### PR TITLE
Use standard-width types in convertUTF.h

### DIFF
--- a/tsMuxer/convertUTF.h
+++ b/tsMuxer/convertUTF.h
@@ -87,10 +87,12 @@
     bit mask & shift operations.
 ------------------------------------------------------------------------ */
 
-typedef unsigned long	UTF32;	/* at least 32 bits */
-typedef unsigned short	UTF16;	/* at least 16 bits */
-typedef unsigned char	UTF8;	/* typically 8 bits */
-typedef unsigned char	Boolean; /* 0 or 1 */
+#include <cstdint>
+
+typedef std::uint32_t UTF32;	/* at least 32 bits */
+typedef std::uint16_t UTF16;	/* at least 16 bits */
+typedef std::uint8_t UTF8;	/* typically 8 bits */
+typedef bool	Boolean; /* 0 or 1 */
 
 /* Some fundamental constants */
 #define UNI_REPLACEMENT_CHAR (UTF32)0x0000FFFD


### PR DESCRIPTION
convertUTF.h typedefed the UTF32 type as unsigned long, which is really 64-bit
wide on LP64 platforms. Since there is a number of casts, mostly around
utf8Converter.cpp, which indirectly assume that UTF32 is 32 bits and no more, this caused
some of the pointers to point outside of their respective arrays due to pointer
arithmetic adding an offset of 8 instead of 4.

This naturally never occured on Windows, because it uses 32 bits for longs, and
the problematic code was never actually really hit because sizeof(wchar_t) on
Windows is 2, which means that the code which needed to cast to UTF32 was never
executed.

Fixes #69.