### PR TITLE
WIP: Allow users to specify explicit PIDs via the meta file

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -57,7 +57,7 @@ bool isValidCustomPID(int pid) {
     case NULL_PID:
         return false;
     default:
-        return pid < NULL_PID;
+        return pid > 0 && pid < NULL_PID;
     }
 }
 }

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -99,6 +99,10 @@ private:
     void flushTSBuffer();
     void finishFileBlock(uint64_t newPts, uint64_t newPCR, bool doChangeFile, bool recursive = true);
     void gotoNextFile(uint64_t newPts);
+    int getStreamPID(const std::string& codecName, int streamIndex,
+                     const std::map<std::string, std::string>& params,
+                     bool isSecondary) const;
+    int* getStreamCounter(const std::string& codecName, bool isSecondary);
 private:
     //bool m_iFrameFound;
 	//File* m_muxFile;


### PR DESCRIPTION
According to [this post](https://forum.doom9.org/showthread.php?p=1892798#post1892798) on Doom9, it would be nice if TSMuxer allowed specifying PIDs of the streams that are going to end up in the TS explicitly.

This adds a `pid` parameter to the stream descriptions in the meta file, which allows the users to specify the PID that they want the given stream to have in the TS, as long as it doesn't collide with any predefined ones.

@jcdr428 is working on the real reason why this is needed (Dolby Vision streams need a specific PID), but this doesn't collide with their work - and I hope that the little refactoring I've done turns out to be helpful while developing.