### PR TITLE
change the bintray uploads to run on a nightly schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly Releases
 
 on:
-  push:
-    branches: [master]
+  schedule:
+    - cron:  '1 1 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
The releases will be uploaded at 01:01am UTC time every day (if there have been any changes to the master branch since the last nightly upload).