### PR TITLE
fix typo causing nightly builds despite no changes

### DIFF
--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -3,7 +3,7 @@
 # BINTRAY_API_KEY
 BINTRAY_REPO=tsMuxer
 PCK_NAME=tsMuxerGUI-Nightly
-repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/:commit.txt)
+repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/commit.txt)
 local_commit=$(git rev-parse HEAD)
 version_date=$(date +%Y-%m-%d--%H-%M-%S)
 


### PR DESCRIPTION
Just a small fix to the bash script, should fix the issue with nightly builds.