### PR TITLE
Correct TS Descriptors

### DIFF
--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -72,7 +72,7 @@ int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff)
 		AC3Codec::setTestMode(false);
 	}
 
-	*dstBuff++ = 0x05; // registreation descriptor tag
+	*dstBuff++ = 0x05; // registration descriptor tag
 	*dstBuff++ = 4;
 	memcpy(dstBuff, "AC-3", 4);
 	dstBuff += 4;

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -98,7 +98,7 @@ int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff)
 
 	return 0;
 
-	*dstBuff++ = 0x05; // dts registreation descriptor tag
+	*dstBuff++ = 0x05; // dts registration descriptor tag
 	*dstBuff++ = 4;
 	*dstBuff++ = 'D';
 	*dstBuff++ = 'T';


### PR DESCRIPTION
Correct TS Descriptors to be the same as the descriptors on commercial Blu-ray disks.