### PR TITLE
Disable replacing spaces with underscores in the temporary meta file …

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -2383,7 +2383,6 @@ void TsMuxerWindow::startMuxing() {
   QFileInfo fi(ui.outFileName->text());
   metaName = QDir::toNativeSeparators(QDir::tempPath()) + QDir::separator() +
              "tsMuxeR_" + fi.completeBaseName() + ".meta";
-  metaName = metaName.replace(' ', '_');
   if (!saveMetaFile(metaName)) {
     metaName.clear();
     return;


### PR DESCRIPTION
…path

Unfortunately, we don't have enough history to be able to tell for sure, but it
seems like this was introduced somewhere between 2.6.12 and 2.6.13. The only
reason for this replacement that I can see is trying to prevent the shell from
treating the space-separated parts of the file paths as separate tokens.
Unfortunately, the string returned by QDir::tempPath() can legitimately contain
spaces, as there is nothing preventing the user from having a "fancy" temporary
directory path.

The real reason behind this line remains unknown. tsMuxer GUI currently doesn't
use shell for spawning processes, and arguments to the binary are properly
passed as a QStringList instead of one long string with command and arguments,
where the described issue could actually occur.

Fixes #93.