### PR TITLE
Correct Arrival Time Stamps

### DIFF
--- a/tsMuxer/blurayHelper.cpp
+++ b/tsMuxer/blurayHelper.cpp
@@ -178,7 +178,8 @@ bool BlurayHelper::writeBluRayFiles(bool usedBlackPL, int mplsNum, int blankNum,
         emptyCommand = bdIndexData + 0x78;
         memcpy(emptyCommand, "\x00\x00\x00\x20\x00\x00\x00\x18\x00\x00\x00\x01"
                              "\x00\x03\x00\x01\x00\x00\x00\x18\x00\x00\x00\x0C"
-                             "\x00\x00\x00\x08\x51\x00\x00\x00\x00\x00\x00\x00", 36); // HDR data extension
+                             "\x00\x00\x00\x08\x21\x00\x00\x00\x00\x00\x00\x00", 36); // HDR data extension
+        if (*HDR10_metadata & 0x20) bdIndexData[0x94] = 0x51; // 4K flag => 66/100 GB Disk, 109 MB/s Recording_Rate
         bdIndexData[0x96] = (uint8_t)HDR10_metadata[0]; // HDR flags
 
     }
@@ -268,7 +269,6 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
     vector<int64_t> packetCount = muxer->getMuxedPacketCnt();
     vector<int64_t> firstPts = muxer->getFirstPts();
     vector<int64_t> lastPts = muxer->getLastPts();
-    vector<double> maxRates = muxer->getMaxRate();
 
     for (unsigned i = 0; i < muxer->splitFileCnt(); i++)
     {
@@ -282,10 +282,9 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
             clpiParser.TS_recording_rate = MAX_SUBMUXER_RATE / 8;
         else
             clpiParser.TS_recording_rate = MAX_MAIN_MUXER_RATE / 8;
-        // max rate is 109 mbps for UHD BD 66/100 GB Default TR
-        if (m_dt == UHD_BLURAY)
+        // max rate is 109 mbps for 4K
+        if (*HDR10_metadata & 0x20)
             clpiParser.TS_recording_rate = (clpiParser.TS_recording_rate * 109) / 48;
-        //clpiParser.TS_recording_rate = 188.0 / (maxRates[i] / 27000000.0);
         clpiParser.number_of_source_packets = packetCount[i];
         clpiParser.presentation_start_time = firstPts[i] / 2;
         clpiParser.presentation_end_time = lastPts[i] / 2;

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -51,7 +51,6 @@ public:
     bool isInterleaveMode() const;
     std::vector<int32_t> getInterleaveInfo(int idx) const;
     bool isSubStream() const { return m_subMode; }
-    std::vector<double> getMaxRate() const { return m_maxRates; }
 
     void setPtsOffset(int64_t value);
 protected:
@@ -188,7 +187,7 @@ private:
     bool m_masterMode;
     bool m_subMode;
     PriorityDataInfo m_priorityData;
-    std::vector<double> m_maxRates;
+    int m_minPcrInc;
     int64_t m_timeOffset;
     int64_t m_lastSITPCR;
     bool m_canSwithBlock;

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -832,7 +832,7 @@ void CLPIParser::composeCPI(BitStreamWriter& writer, bool isCPIExt) {
 	writer.putBits(32,0); // skip lengthField
 
     if (isDependStream && !isCPIExt || !isDependStream && isCPIExt)
-        return; // CPI_SS for MVC depend stream only and vice versa: standart CPI for standart video stream
+        return; // CPI_SS for MVC depend stream only and vice versa: standard CPI for standard video stream
 
 	int beforeCount = writer.getBitsCount() / 8;
 	//if (length != 0) 
@@ -2606,8 +2606,10 @@ void M2TSStreamInfo::blurayStreamParams(double fps, bool interlaced, int width, 
         *video_format = interlaced ? 1 : 3;
     else if (isPal)
         *video_format = interlaced ? 2 : 7;
-	else if (width >= 2600)
+	else if (width >= 2600) {
 		*video_format = 8;
+		*HDR10_metadata |= 0x20; // 4K flag
+	}
     else if (width >= 1300)
         *video_format = interlaced ? 4 : 6; // as 1920x1080
     else


### PR DESCRIPTION
The BD Player cannot read faster than the TS_Recording_Rate.
The TS_Recording_Rate is hereby fixed to be 6 MB/s for 2K (25/50 GB disk), and 13.625 MB/s for 4K (66/100 GB Disk).

Therefore the difference of ATS between two consecutive M2TS packets cannot be less than 846 PCR units for 2K, and 373 PCR units for 4K.
Those two values have been checked to be the standard for ATS difference between two video packets in several commercial HD and UHD Blu-rays.

This patch fixes BD-ROM Part3 Verifier Error M2TS0077 :

    ----------------------------------------------
    Error ID      : M2TS0077
    Target File   : 00000.m2ts <Dolby Digital audio PID=0x1100>
    Target Field  : <Source de-packetizer>.TS_recoding_rate
    Section No    : 6.2.2.1
    Error Message : TS_recoding_rate value is less than 188[byte] / (min(arrival_time_stamp[i] - arrival_time_stamp[i+1]) 
                / 27[MHz]). 
                
                TS_recoding_rate = 13625000.
                arrival_time_stamp[83073] = 177219240.
                arrival_time_stamp[83074] = 48874258294762232.
    Explanation   : The TS_recording_rate shall satisfy the following inequality. The TS_recording_rate 
                is expressed in units of bytes/second.
    - - - - - - - - - - - - - - - - - - - - - - - 