### PR TITLE
Place the main tsMuxeR binary inside AppDir

### DIFF
--- a/rebuild_linux_with_gui_docker.sh
+++ b/rebuild_linux_with_gui_docker.sh
@@ -15,6 +15,7 @@ mv ./bin/tsMuxeR ./bin/lnx/tsMuxeR
 mkdir -p ./bin/lnx/AppDir/usr/share/applications
 mkdir -p ./bin/lnx/AppDir/usr/share/icons/hicolor/32x32/apps
 mkdir -p ./bin/lnx/AppDir/usr/bin
+cp ./bin/lnx/tsMuxeR ./bin/lnx/AppDir/usr/bin/
 
 mv ./bin/tsMuxerGUI ./bin/lnx/AppDir/usr/bin/tsMuxerGUI
 


### PR DESCRIPTION
Since AppImage essentially creates a separate filesystem that the GUI binary
runs from, it's not possible for it to be aware of the existence of the main
binary that's alongside the actual AppImage file that's supposed to be run by
the end user.
The only solution to this that I can see now is copying the main binary into the
AppDir, which makes the file reside alongside the GUI binary inside the
filesystem that AppImage creates.

Fixes #103.