### PR TITLE
Dolby Vision Integration

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -834,17 +834,17 @@ int HevcSeiUnit::deserialize()
 				payloadSize += nbyte;
 			}
 			if (payloadType == 137 && !isHDR10) { // mastering_display_colour_volume
-                HDR10_metadata[1] = m_reader.getBits(32); // display_primaries Green
-                HDR10_metadata[2] = m_reader.getBits(32); // display_primaries Red
-                HDR10_metadata[3] = m_reader.getBits(32); // display_primaries Blue
-                HDR10_metadata[4] = m_reader.getBits(32); // White Point
-                HDR10_metadata[5] = ((m_reader.getBits(32) / 10000) << 16) + m_reader.getBits(32); // max & min display_mastering_luminance
+                HDR10_metadata[0] = m_reader.getBits(32); // display_primaries Green
+                HDR10_metadata[1] = m_reader.getBits(32); // display_primaries Red
+                HDR10_metadata[2] = m_reader.getBits(32); // display_primaries Blue
+                HDR10_metadata[3] = m_reader.getBits(32); // White Point
+                HDR10_metadata[4] = ((m_reader.getBits(32) / 10000) << 16) + m_reader.getBits(32); // max & min display_mastering_luminance
 			}
             else if (payloadType == 144 && !isHDR10) { // content_light_level_info
                 isHDR10 = true;
-                *HDR10_metadata |= 2; // HDR10 flag
+                V3_flags |= 2; // HDR10 flag
                  int maxCLL = m_reader.getBits(32); // maxCLL, maxFALL
-                 if (maxCLL != 0) HDR10_metadata[6] = maxCLL;
+                 if (maxCLL != 0) HDR10_metadata[5] = maxCLL;
             }
 			else if (payloadType == 4 && !isHDR10plus) { // HDR10Plus Metadata
                 m_reader.skipBits(8); // country_code
@@ -856,7 +856,7 @@ int HevcSeiUnit::deserialize()
                 if (application_identifier == 4 && application_version == 1 && num_windows == 1)
                 {
                     isHDR10plus = true;
-                    *HDR10_metadata |= 16; // HDR10plus flag
+                    V3_flags |= 0x10; // HDR10plus flag
                 }
 				payloadSize -= 8;
 				for (int i = 0; i < payloadSize; i++)

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -3,7 +3,8 @@
 
 #include "nalUnits.h"
 
-extern int HDR10_metadata[7];
+extern int HDR10_metadata[6];
+extern int V3_flags;
 
 enum HevcSliceTypes
 {

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -8,7 +8,8 @@
 using namespace std;
 
 static const int MAX_SLICE_HEADER = 64;
-int HDR10_metadata[7] = { 1,0,0,0,0,0,0 };
+int V3_flags = 0; // flags : isV3, reserved, 4K, HDR10+, SL-HDR2, DV, HDR10, SDR
+int HDR10_metadata[6] = { 0,0,0,0,0,0 };
 
 HEVCStreamReader::HEVCStreamReader(): 
     MPEGStreamReader(),
@@ -92,7 +93,7 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
                     m_sei = new HevcSeiUnit();
                 if (nal[1] == 1 && !m_sei->isDV) {
                     m_sei->isDV = true;
-                    *HDR10_metadata |= 4; // Dolby Vision flag
+                    V3_flags |= 4; // Dolby Vision flag
                 }
                 break;
             }
@@ -262,7 +263,7 @@ int HEVCStreamReader::intDecodeNAL(uint8_t* buff)
         {
             if (curPos[2] & 0x80) // slice.first_slice
             {
-                if (sliceFound ) { // first slice of next frame
+                if (sliceFound ) { // first slice of next frame: case where there is no non-VCL NAL between the two frames
                     m_lastDecodedPos = prevPos; // next frame started
                     incTimings();
                     return 0;

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -92,8 +92,9 @@ DiskType checkBluRayMux(const char* metaFileName, int& autoChapterLen, vector<do
 			}
 
 			if (str.find("--blu-ray-v3") != string::npos)
-				result =  UHD_BLURAY;
-			else if (str.find("--blu-ray") != string::npos)
+				V3_flags |= 0x80; // flag "V3"
+
+			if (str.find("--blu-ray") != string::npos)
 				result =  DT_BLURAY;
 			else if (str.find("--avchd") != string::npos)
 				result =  DT_AVCHD;
@@ -667,9 +668,9 @@ int main(int argc, char** argv)
 			MuxerManager muxerManager(readManager, tsMuxerFactory);
             muxerManager.setAllowStereoMux(fileExt2 == "SSIF" || dt != DT_NONE);
 			muxerManager.openMetaFile(argv[1]);
-			if (dt == DT_BLURAY && muxerManager.getHevcFound()) {
+			if (!V3_flags && dt == DT_BLURAY && muxerManager.getHevcFound()) {
 				LTRACE(LT_WARN, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
-				dt = UHD_BLURAY;
+				V3_flags |= 0x80; // flag "V3"
 			}
 			string dstFile = unquoteStr(argv[2]);
 

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -182,7 +182,7 @@ void TSMuxer::intAddStream(const std::string& streamName,
 	int tsStreamIndex = streamIndex + 16;
 	bool isSecondary = codecReader->isSecondary();
 	// 4K flag => change min PCR between two TS packets for TS_Recording_Rate of 13.6 MB/s
-	if (*HDR10_metadata & 0x20) m_minPcrInc = 373;
+	if (V3_flags & 0x20) m_minPcrInc = 373;
 
 	if (codecName[0] == 'V') 
     {
@@ -652,6 +652,7 @@ void TSMuxer::writePATPMT(int64_t pcr, bool force)
         }
 	}
 }
+
 bool TSMuxer::isSplitPoint(const AVPacket& avPacket)
 {
     if (avPacket.stream_index != m_mainStreamIndex || !(avPacket.flags & AVPacket::IS_IFRAME))

--- a/tsMuxer/vod_common.h
+++ b/tsMuxer/vod_common.h
@@ -94,7 +94,7 @@ struct AVRational{
 
 typedef std::vector<std::pair<int, int> > PriorityDataInfo; // mark some data as priority data
 
-enum DiskType {DT_NONE, DT_BLURAY, UHD_BLURAY, DT_AVCHD};
+enum DiskType {DT_NONE, DT_BLURAY, DT_AVCHD};
 
 uint16_t AV_RB16(const uint8_t* buffer);
 uint32_t AV_RB24(const uint8_t* buffer);


### PR DESCRIPTION
- Separate the V3 flags (for index.bdmv) from the HDR metadata (for .mpls)
- With V3_flags the UHD_BLURAY DiskType is not needed anymore
- Add subpath stream_id=10 for Dolby Vision
- When 4K is detected, change BD Type from 25/50 GB to 66/100 GB,
   and TS-Recording_Rate from 48 mbps to 109 mbps

This DV patch has been successfully tested by some Doom9 members from my fork.
Cf. https://forum.doom9.org/showthread.php?p=1894442#post1894442 and following posts.