### PR TITLE
Move BD V3 option to Blu-ray tab

### DIFF
--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -669,7 +669,7 @@ int main(int argc, char** argv)
             muxerManager.setAllowStereoMux(fileExt2 == "SSIF" || dt != DT_NONE);
 			muxerManager.openMetaFile(argv[1]);
 			if (!V3_flags && dt == DT_BLURAY && muxerManager.getHevcFound()) {
-				LTRACE(LT_WARN, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
+				LTRACE(LT_INFO, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
 				V3_flags |= 0x80; // flag "V3"
 			}
 			string dstFile = unquoteStr(argv[2]);

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -457,7 +457,7 @@ TsMuxerWindow::TsMuxerWindow()
           &TsMuxerWindow::onGeneralCheckboxClicked);
   connect(ui.checkBoxBlankPL, &QPushButton::clicked, this,
           &TsMuxerWindow::onSavedParamChanged);
-  connect(ui.checkBoxV3, &CheckBox::stateChanged, this,
+  connect(ui.checkBoxV3, &QCheckBox::stateChanged, this,
           &TsMuxerWindow::updateMetaLines);
   connect(ui.BlackplaylistCombo, spinBoxValueChanged, this,
           &TsMuxerWindow::onSavedParamChanged);

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2942,7 +2942,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>radioButtonTS</tabstop>
   <tabstop>radioButtonM2TS</tabstop>
   <tabstop>radioButtonBluRay</tabstop>
-  <tabstop>radioButtonBluRayUHD</tabstop>
   <tabstop>radioButtonDemux</tabstop>
   <tabstop>outFileName</tabstop>
   <tabstop>btnBrowse</tabstop>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1312,6 +1312,16 @@ p, li { white-space: pre-wrap; }
             </layout>
            </item>
            <item>
+             <widget class="QCheckBox" name="checkBoxV3">
+               <property name="text">
+                 <string>BD-ROM V3 format</string>
+               </property>
+               <property name="checked">
+                 <bool>false</bool>
+               </property>
+             </widget>
+           </item>
+           <item>
             <layout class="QGridLayout" name="gridLayout_10">
              <item row="0" column="0">
               <widget class="QLabel" name="label">
@@ -2663,26 +2673,6 @@ p, li { white-space: pre-wrap; }
               </property>
               <property name="text">
                <string>Blu-ray folder</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="radioButtonBluRayISOUHD">
-              <property name="text">
-               <string>UHD Blu-ray ISO</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="radioButtonBluRayUHD">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>UHD Blu-ray folder</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
BD version is automatically switched to V3 when HEVC stream is detected.
In case the user wants to force the V3 format for AVC, he will be able to do it via the V3 option in the Blu-ray tab.