### PR TITLE
Set TS video stream_id to 0xe0

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -257,7 +257,7 @@ void TSMuxer::intAddStream(const std::string& streamName,
 			m_pesType[tsStreamIndex] = PES_VC1_ID;
 		}
 		else {
-			m_pesType[tsStreamIndex] = PES_VIDEO_ID; //m_videoCnt++;
+			m_pesType[tsStreamIndex] = (m_m2tsMode ? PES_VIDEO_ID : PES_VIDEO_ID - 1); //m_videoCnt++;
 		}
 	}
 	


### PR DESCRIPTION
First video stream_id has been changed to 0xe1 for m2ts, but must stay at 0xe0 for TS streams.