### PR TITLE
Fix wav64

### DIFF
--- a/tsMuxer/wave.cpp
+++ b/tsMuxer/wave.cpp
@@ -49,8 +49,8 @@ void buildWaveHeader(MemoryBlock& waveBuffer, int samplerate, int channels, bool
     waveFormatPCMEx->nChannels = channels;
     waveFormatPCMEx->nSamplesPerSec = samplerate;
     waveFormatPCMEx->nAvgBytesPerSec = channels * samplerate * ((bitdepth+4)>>3);
+    waveFormatPCMEx->nBlockAlign = channels * waveFormatPCMEx->wBitsPerSample / 8;
     waveFormatPCMEx->wBitsPerSample = bitdepth==20 ? 24 : bitdepth;
-    waveFormatPCMEx->nBlockAlign = channels * waveFormatPCMEx->wBitsPerSample/8; 
     waveFormatPCMEx->cbSize = 22; // After this to GUID 
     waveFormatPCMEx->Samples.wValidBitsPerSample = bitdepth;
     waveFormatPCMEx->dwChannelMask = getWaveChannelMask(channels, lfeExist); // Specify PCM


### PR DESCRIPTION
For w64, data length includes data metadata (16 bytes) and size (8 bytes)
So 24 bytes have to be substracted from the length read in the stream.

Reordering of waveFormatPCMEx is just to be in the same order as the defined struct.

For lpcm, tsMuxer considers frames of 5 ms and rounds up the last block for frame alignment.
So it is normal for the demux to be slightly larger thant the original wav stream.

Note than 5ms framelength (200 frames / second) is very short. In the future I might push a change to 10ms as an enhancement to reduce the number of frames and corresponding PES/adaptation packets. For instance all Criterion BD LPCM are 10ms frames.

Edit : fixes #136