### PR TITLE
macOS: fix build

### DIFF
--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -4,8 +4,8 @@
 #include "mpegVideo.h"
 
 #include <fs/systemlog.h>
-#include <memory.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cmath>
 
 #ifndef _APPLE
 #include <cmath>
@@ -279,7 +279,7 @@ void MPEGSequenceHeader::setFrameRate(uint8_t* buff, double fps)
 {
     // return; // todo delete this!!!
     for (int i = 1; i < sizeof(frame_rates) / sizeof(double); i++)
-        if (abs(frame_rates[i] - fps) < FRAME_RATE_EPS)
+        if (std::abs(frame_rates[i] - fps) < FRAME_RATE_EPS)
         {
             frame_rate_index = i;
             buff[3] = (buff[3] & 0xf0) + i;

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -6,6 +6,7 @@
 #include <fs/systemlog.h>
 #include <memory.h>
 #include <stdlib.h>
+#include <cmath>
 
 #include "vodCoreException.h"
 #include "vod_common.h"

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -6,6 +6,7 @@
 #include <fs/systemlog.h>
 #include <memory.h>
 #include <stdlib.h>
+
 #include <cmath>
 
 #include "vodCoreException.h"

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -4,12 +4,9 @@
 #include "mpegVideo.h"
 
 #include <fs/systemlog.h>
-#include <cstring>
-#include <cmath>
 
-#ifndef _APPLE
 #include <cmath>
-#endif
+#include <cstring>
 
 #include "vodCoreException.h"
 #include "vod_common.h"

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -7,7 +7,9 @@
 #include <memory.h>
 #include <stdlib.h>
 
+#ifndef _APPLE
 #include <cmath>
+#endif
 
 #include "vodCoreException.h"
 #include "vod_common.h"


### PR DESCRIPTION
Fix build error:
`mpegVideo.cpp:278:13: error: call to 'abs' is ambiguous
        if (abs(frame_rates[i] - fps) < FRAME_RATE_EPS)`