### PR TITLE
Fix bug introduced by commit 45fbb43

### DIFF
--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1675,7 +1675,7 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
     {
         // SubPath(); // not implemented now
         uint32_t lengthSP = reader.getBits(32);
-        for (int i=0; i !=lengthSP; i++) reader.getBits(8);
+        for (int i = 0; i != lengthSP; i++) reader.getBits(8);
     }
 
     int endBits = reader.getBitsLeft();

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1675,8 +1675,7 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
     {
         // SubPath(); // not implemented now
         uint32_t lengthSP = reader.getBits(32);
-        for (int i=0; i !=lengthSP; i++)
-            reader.getBits(8);
+        for (int i=0; i !=lengthSP; i++) reader.getBits(8);
     }
 
     int endBits = reader.getBitsLeft();

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1674,6 +1674,9 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
     for (int SubPath_id = 0; SubPath_id < number_of_SubPaths; SubPath_id++)
     {
         // SubPath(); // not implemented now
+        uint32_t lengthSP = reader.getBits(32);
+        for (int i=0; i !=lengthSP; i++)
+            reader.getBits(8);
     }
 
     int endBits = reader.getBitsLeft();


### PR DESCRIPTION
Commit 45fbb43 has introduced `reader.skipBits(toPassBits);` to read the bits left in mpls. However toPassBits can be >32 bits.

Note: cf. e.g. US Patent N° 10070097 B2, excerpt attached. The commit 45fbb43 is useless as the various parts of the mpls and clpi are always continuous. I will push a patch later to totally remove the fourty five added lines of this commit, as it might provoke other bugs. 

[Pages from US10070097B2-2.pdf](https://github.com/justdan96/tsMuxer/files/4083605/Pages.from.US10070097B2-2.pdf)
 