### PR TITLE
Remove commit 45fbb43

### DIFF
--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -2521,7 +2521,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
 void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
 {
-    int length = reader.getBits(16);  // 16 uimsbf
+    int length = reader.getBits(16);                                  // 16 uimsbf
     reader.skipBits(16);                                              // reserved_for_future_use 16 bslbf
     number_of_primary_video_stream_entries = reader.getBits(8);       // 8 uimsbf
     number_of_primary_audio_stream_entries = reader.getBits(8);       // 8 uimsbf
@@ -2824,7 +2824,7 @@ MPLSStreamInfo::~MPLSStreamInfo()
 void MPLSStreamInfo::parseStreamEntry(BitStreamReader& reader)
 {
     int length = reader.getBits(8);  // 8 uimsbf
-    type = reader.getBits(8);  // 8 bslbf
+    type = reader.getBits(8);        // 8 bslbf
     if (type == 1)
     {
         streamPID = reader.getBits(16);  // 16 uimsbf

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1658,12 +1658,9 @@ void MPLSParser::UO_mask_table(BitStreamReader& reader)
 
 void MPLSParser::parsePlayList(uint8_t* buffer, int len)
 {
-    // NOTE: see https://github.com/lerks/BluRay/wiki/MPLS
     BitStreamReader reader;
     reader.setBuffer(buffer, buffer + len);
     uint32_t length = reader.getBits(32);
-    int startBits = reader.getBitsLeft();
-
     reader.skipBits(16);                           // reserved_for_future_use 16 bslbf
     int number_of_PlayItems = reader.getBits(16);  // 16 uimsbf
     number_of_SubPaths = reader.getBits(16);       // 16 uimsbf
@@ -1674,13 +1671,6 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
     for (int SubPath_id = 0; SubPath_id < number_of_SubPaths; SubPath_id++)
     {
         // SubPath(); // not implemented now
-    }
-
-    int endBits = reader.getBitsLeft();
-    int toPassBits = length * 8 - (startBits - endBits);
-    if (toPassBits > 0)
-    {
-        reader.skipBits(toPassBits);
     }
 }
 
@@ -2173,11 +2163,8 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
 
 void MPLSParser::parsePlayItem(BitStreamReader& reader, int PlayItem_id)
 {
-    // NOTE: see https://github.com/lerks/BluRay/wiki/PlayItem
     MPLSPlayItem newItem;
     int length = reader.getBits(16);
-    int startBits = reader.getBitsLeft();
-
     char clip_Information_file_name[6];
     char clip_codec_identifier[5];
     CLPIStreamInfo::readString(clip_Information_file_name, reader, 5);
@@ -2219,13 +2206,6 @@ void MPLSParser::parsePlayItem(BitStreamReader& reader, int PlayItem_id)
         }
     }
     STN_table(reader, PlayItem_id);
-
-    int endBits = reader.getBitsLeft();
-    int toPassBits = length * 8 - (startBits - endBits);
-    if (toPassBits > 0)
-    {
-        reader.skipBits(toPassBits);
-    }
 }
 
 void MPLSParser::composePlayItem(BitStreamWriter& writer, int playItemNum, std::vector<PMTIndex>& pmtIndexList)
@@ -2541,10 +2521,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
 void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
 {
-    // NOTE: see https://github.com/lerks/BluRay/wiki/STNTable
     int length = reader.getBits(16);  // 16 uimsbf
-    int startBits = reader.getBitsLeft();
-
     reader.skipBits(16);                                              // reserved_for_future_use 16 bslbf
     number_of_primary_video_stream_entries = reader.getBits(8);       // 8 uimsbf
     number_of_primary_audio_stream_entries = reader.getBits(8);       // 8 uimsbf
@@ -2661,13 +2638,6 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         streamInfo.parseStreamAttributes(reader);
         if (PlayItem_id == 0)
             m_streamInfo.push_back(streamInfo);
-    }
-
-    int endBits = reader.getBitsLeft();
-    int toPassBits = length * 8 - (startBits - endBits);
-    if (toPassBits > 0)
-    {
-        reader.skipBits(toPassBits);
     }
 }
 
@@ -2853,10 +2823,7 @@ MPLSStreamInfo::~MPLSStreamInfo()
 
 void MPLSStreamInfo::parseStreamEntry(BitStreamReader& reader)
 {
-    // NOTE: see https://github.com/lerks/BluRay/wiki/StreamEntry
     int length = reader.getBits(8);  // 8 uimsbf
-    int startBits = reader.getBitsLeft();
-
     type = reader.getBits(8);  // 8 bslbf
     if (type == 1)
     {
@@ -2884,12 +2851,6 @@ void MPLSStreamInfo::parseStreamEntry(BitStreamReader& reader)
         streamPID = reader.getBits(16);  // 16 uimsbf
         reader.skipBits(32);             // reserved_for_future_use 40 bslbf
         reader.skipBits(8);
-    }
-    int endBits = reader.getBitsLeft();
-    int toPassBits = length * 8 - (startBits - endBits);
-    if (toPassBits > 0)
-    {
-        reader.skipBits(toPassBits);
     }
 }
 
@@ -2950,10 +2911,7 @@ void MPLSStreamInfo::composeStreamEntry(BitStreamWriter& writer, int entryNum, i
 
 void MPLSStreamInfo::parseStreamAttributes(BitStreamReader& reader)
 {
-    // NOTE: see https://github.com/lerks/BluRay/wiki/StreamAttributes
     int length = reader.getBits(8);  // 8 uimsbf
-    int startBits = reader.getBitsLeft();
-
     stream_coding_type = reader.getBits(8);  // 8 bslbf
     if (isVideoStreamType(stream_coding_type))
     {
@@ -2984,13 +2942,6 @@ void MPLSStreamInfo::parseStreamAttributes(BitStreamReader& reader)
         // Text subtitle stream
         character_code = reader.getBits(8);  // 8 bslbf
         CLPIStreamInfo::readString(language_code, reader, 3);
-    }
-
-    int endBits = reader.getBitsLeft();
-    int toPassBits = length * 8 - (startBits - endBits);
-    if (toPassBits > 0)
-    {
-        reader.skipBits(toPassBits);
     }
 }
 

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -2911,7 +2911,7 @@ void MPLSStreamInfo::composeStreamEntry(BitStreamWriter& writer, int entryNum, i
 
 void MPLSStreamInfo::parseStreamAttributes(BitStreamReader& reader)
 {
-    int length = reader.getBits(8);  // 8 uimsbf
+    int length = reader.getBits(8);          // 8 uimsbf
     stream_coding_type = reader.getBits(8);  // 8 bslbf
     if (isVideoStreamType(stream_coding_type))
     {


### PR DESCRIPTION
Because of the addition of `reader.skipBits(toPassBits);` , tsMuxer crashes when toPassBits is above 32 bits.

The commit 45fbb43 is useless, as the various parts of mpls and clpi are always contiguous. Cf. excerpt of Patent N° US10070097B2-2.

[Pages from US10070097B2-2.pdf](https://github.com/justdan96/tsMuxer/files/4083671/Pages.from.US10070097B2-2.pdf)
