### PR TITLE
Fix typos and grammar errors in readme and usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,19 @@ Examples:
     tsMuxeR <meta file name> <out file/dir name>
 ```
 
-tsMuxeR can be run in track detection mode or muxing mode. If run tsMuxeR  with only  one argument  then tsMuxeR  display  input track information  required to construct  meta  file.  If run tsMuxeR  with two arguments tsMuxeR start muxing or demuxing process.
+tsMuxeR can be run in track detection mode or muxing mode. If tsMuxeR is run with only one argument, then the program displays track information required to construct a meta file. When running with two arguments, tsMuxeR starts the muxing or demuxing process.
 
 ### Meta file format
-File MUST has extension .meta.  This file  define files you want to  multiplex. First line of meta file contain additional parameters that apply to all tracks. In this case the line should begin with the word MUXOPT.
+File MUST have the .meta extension. This file defines files you want to multiplex. The first line of a meta file contains additional parameters that apply to all tracks. In this case the first line should begin with the word MUXOPT.
 
-Following lines indicate a list of tracks  and their parameters.  The format is as follows:   `<code name>,   <file name>,   <parameters>`   Parameters are comma separated. Each parameter indicates the name and value.
+The following lines form a list of tracks and their parameters.  The format is as follows: `<code name>,   <file name>,   <parameters>`. Parameters are separated with commas, with each parameter consisting of a name and a value, separated with an equals sign.
 Example of META file:
 ```
 MUXOPT --blu-ray
 V_MPEG4/ISO/AVC, D:/media/test/stream.h264, fps=25
 A_AC3, D:/media/test/stream.ac3, timeshift=-10000ms
 ```
-In this example one AC3 audio stream and one H264 video stream are  multiplexed to BD disk.  Input file name can reference to elementary stream or track inside container.
+In this example one AC3 audio stream and one H264 video stream are multiplexed into BD disc. The input file name can reference an elementary stream or a track located inside a container.
 
 Supported input containers:
 * TS/M2TS/MTS
@@ -138,20 +138,20 @@ A_LPCM            | raw pcm data or PCM WAV file
 S_HDMV/PGS        | Presentation graphic stream (BD subtitle format) 
 S_TEXT/UTF8       | SRT subtitle format.  Encoding MUST be  UTF-8/UTF-16/UTF-32 
 
-Each track may has addition parameters.  Track parameters do not  have dash. If parameter value has several words, parameter must be enclosed in quotes.
+Each track may have additional parameters. Track parameters do not have dashes. If a parameter's value consists of several words, it must be enclosed in quotes.
 
 Common additional parameters for any type of track:
 
 Parameter         | Description 
 ---               | --- 
-track             | track number if input file is container. 
-lang              | track language. MUST contains exact 3 letters. 
+track             | track number if input file is a container.
+lang              | track language. MUST contain exactly 3 letters. 
 
 Additional parameters for audio tracks:
 
 Parameter         | Description 
 ---               | --- 
-timeshift         | Shift audio track to future (positive value) or to past. Measured at milliseconds. 
+timeshift         | Shift audio track by the given number of milliseconds. Can be negative. 
 down-to-dts       | Available only for DTS-HD tracks. Filter out HD part. 
 down-to-ac3       | Available only for TRUE-HD tracks. Filter out HD part. 
 secondary         | Mux as secondary audio.  Available for DD+ and DTS-Express. 
@@ -160,41 +160,37 @@ Additional parameters for video tracks:
 
 Parameter         | Description 
 ---               | --- 
-fps               | Video fps. If not defined, default value auto detected from a source stream if present. If not, default value 23.976. 
-delPulldown       | Remove pulldown from the track if exists.  This option lead to fps change from 30 to 24 if pulldown exists. 
+fps               | The number of frames per second. If not defined, the value is auto detected if available in the source stream. If not, it defaults to 23.976. 
+delPulldown       | Remove pulldown from the track, if it exists. If the pulldown is present, the FPS value is changed from 30 to 24. 
 ar                | Override video aspect ratio. 16:9, 4:3 e.t.c. 
 
 Additional parameters for H.264 video tracks:
 
 Parameter         | Description 
 ---               | --- 
-level             | Overwrite  level in the H264 stream.  Note:  option  update headers only. The H264 stream may not meet the requirements of a lower level. 
-insertSEI         | If original   stream  does not contain  SEI picture timing, SEI buffering period or VUI parameters,  then add this data to the stream. This option is recommended for BD muxing. 
-forceSEI          | Add SEI picture timing, buffering period and VUI parameters to the stream. Rebuild data If data already exist. 
-contSPS           | If original video doesn't contain  repetitive SPS/PPS  then SPS/PPS will be added to the stream before  each key frame. This option is recommended for BD muxing. 
-subTrack          | Used  for  combined  AVC/MVC  tracks  only.  TsMuxeR always demultiplex  such  tracks to separate  AVC and MVC streams. This parameter defined reference to AVC part(if value=1) or to MVC part (if value=2). 
+level             | Overwrite the level in the H264 stream. Do note that this option only updates the headers and does not reencode the stream, which may not meet the requirements for a lower  level. 
+insertSEI         | If the original stream does not contain SEI picture timing, SEI buffering period or VUI parameters, add this data to the stream. This option is recommended for BD muxing. 
+forceSEI          | Add SEI picture timing, buffering period and VUI parameters to the stream and rebuild this data if it already exists. 
+contSPS           | If the original video doesn't contain repetitive SPS/PPS, then SPS/PPS will be added to the stream before each key frame. This option is recommended for BD muxing. 
+subTrack          | Used for combined AVC/MVC tracks only. TsMuxeR always demultiplexes such tracks to separate AVC and MVC streams. Setting this to 1 sets the reference to the AVC part, while 2 sets it to the MVC part. 
 secondary         | Mux as secondary video (PIP). 
 pipCorner         | Corner for PIP video. Allowed values: "TopLeft","TopRight", "BottomRight", "BottomLeft". 
 pipHOffset        | PIP window horizontal offset from the corner in pixels. 
 pipVOffset        | PIP window vertical offset from the corner in pixels. 
 pipScale          | PIP window scale factor. Allowed values: "1", "1/2", "1/4", "1.5", "fullScreen". 
-pipLumma          | Allow PIP window to be transparent. Transparent colors  are lumma colors in range `[0..pipLumma]`. 
-
-Additional parameters for PG and SRT tracks:
+pipLumma          | Allow the PIP window to be transparent. Transparent colors are lumma colors in range [0..pipLumma].  Additional parameters for PG and SRT tracks:
 
 Parameter         | Description 
 ---               | --- 
 video-width       | The width of the video in pixels. 
 video-height      | The height of the video in pixels. 
-fps               | Video fps.  Recommended  to  define this parameter for more carefully timing processing. 
-3d-plane          | Parameter  defines  number  of  the '3D offset track' which placed inside MVC track.  Each message has individual 3D offset. This information stored inside 3D offset track. 
-
-Additional parameters for SRT tracks:
+fps               | Video fps. It is recommended to define this parameter in order to enable more careful timing processing. 
+3d-plane          | Defines the number of the '3D offset track' which is placed inside the MVC track. Each message has an individual 3D offset. This information is stored inside 3D offset track. Additional parameters for SRT tracks:
 
 Parameter         | Description 
 ---               | --- 
 font-name         | Font name to render. 
-font-color        | Font color. Color can be defined in hexadecimal or  decimal format. If color 24 bit long  (for instance 0xFF00FF)  it's  define RGB components.  IF color 32 bit long  (for instance 0x80FF00FF) it's define ARGB components. 
+font-color        | Font color, defined as a hexadecimal or decimal number. 24-bit long numbers (for instance 0xFF00FF) define RGB components, while 32-bit long ones (for instance 0x80FF00FF) define ARGB components. 
 font-size         | Font size in pixels. 
 font-italic       | Italic display text. 
 font-bold         | Bold display text. 
@@ -204,45 +200,45 @@ bottom-offset     | Distance from the lower edge while displaying text.
 font-border       | Outline width. 
 fadein-time       | Time in ms for smooth subtitle appearance. 
 fadeout-time      | Time in ms for smooth subtitle disappearance. 
-line-spacing      | Interval between lines. Default value 1.0. 
+line-spacing      | Interval between subtitle lines. Default value is 1.0.
 
-tsMuxeR  supports  addition  tag inside  SRT track.  The syntax  and parameters coincide with HTML: `<b>, <i>, <u>, <strike>, <font>`. Default relative font size (used in these tags) - 3.  For example:
+tsMuxeR supports additional tags inside SRT tracks.  The syntax  and parameters coincide with HTML: `<b>, <i>, <u>, <strike>, <font>`. Default relative font size (used in these tags) is 3.  For example:
 ```
 <b><font size=5 color="deepskyblue" name="Arial"><u>Test</u>
 <font size= 4 color="#806040">colored</font>text</font>
 </b>
 ```
 
-Global additional parameters placed in the first line of the META file (MUXOPT). All parameters in this group start with two dashes:
+Global additional parameters are placed in the first line of the META file, which must begin with the MUXOPT token. All parameters in this group start with two dashes:
 
 Parameter           | Description 
 ---                 | --- 
---pcr-on-video-pid  | Do not allocate separate PID for PCR, use an existing video PID.
---new-audio-pes     | Use bytes 0xfd instead of 0xbd for AC3, True-HD, DTS and DTS-HD. Parameter is auto activated for BD muxing.
+--pcr-on-video-pid  | Do not allocate a separate PID for PCR and use the existing video PID. 
+--new-audio-pes     | Use bytes 0xfd instead of 0xbd for AC3, True-HD, DTS and DTS-HD. Activated automatically for BD muxing. 
 --vbr               | Use variable bitrate.
---minbitrate        | Sets the lower limit of the vbr bitrate.  If the stream has a  smaller bitrate  then NULL  packets will be inserted  to hold the limit.
+--minbitrate        | Sets the lower limit of the VBR bitrate. If the stream has a smaller bitrate, NULL packets will be inserted to compensate. 
 --maxbitrate        | The upper limit of the vbr bitrate.
---cbr               | Muxing mode  with a fixed bitrate.  Options --vbr and --cbr should not be used together.
---vbv-len           | The  length  of the  virtual  buffer  in milliseconds.  The default value  is 500.  Typically, this  option  is used in together with --cbr. The parameter is similar to the value of  vbv-buffer-size  in  the  x264  coder,  but  defined in milliseconds instead of kbit.
---no-asyncio        | Do not  create  a separate thread  for writing.  Also, this option  disable  flag  FILE_FLAG_NO_BUFFERING  for writing. Deprecated option.
---auto-chapters     | Number.  Insert a chapter every <nn> minutes. Used only for BD/AVCHD mode.
---custom-chapters   | A semicolon delimited list of string in format hh:mm:ss.zzz
---demux             | In this mode selected audio  and video tracks are stored as separate files instead of muxing. utput name must be folder name.  All selected  effects  (such as change  of level for h264) are processed. When demux,  certain types  of tracks always get changed on storing into a file: - Subtitles in a Presentation Graphic Stream  are converted into sup format. - PCM audio are saved as WAV files.
---blu-ray           | Mux to BD disks. If output file name is folder,  bluray disk is created as folder on HDD.  For BD3D disks ssif files are not  created at  this  case.  If output file name  has .iso extension, then BD disk is created as image file.
---blu-ray-v3        | As above - except mux to UHD BD disks.
---avchd             | Mux to AVCHD disk.
---cut-start         | Trim the beginning of the file.  Value should be  completed with  "ms"  (the number of milliseconds),  "s" (seconds) or "min" (minutes).
---cut-end           | Trim  the end of the file.  Value should be  completed with "ms" (the number of milliseconds), "s" (seconds) or "min" (minutes).
---split-duration    | Split output to several files.The time specified in seconds
---split-size        | Split  output to several files.  Values  should be  written using one of the following postfix: Kb,kib, mb,mib, gb,gib.
+--cbr               | Muxing mode with a fixed bitrate. --vbr and --cbr must not be used together. 
+--vbv-len           | The  length  of the  virtual  buffer  in milliseconds.  The default value  is 500.  Typically, this  option  is used together with --cbr. The parameter is similar to  the value of  vbv-buffer-size  in  the  x264  codec,  but  defined in milliseconds instead of kbit. 
+--no-asyncio        | Do not  create  a separate thread  for writing. This option also disables the FILE_FLAG_NO_BUFFERING flag on Windows when writing. This option is deprecated. 
+--auto-chapters     | Insert a chapter every <n> minutes. Used only in BD/AVCHD mode. 
+--custom-chapters   | A semicolon delimited list of hh:mm:ss.zzz strings, representing the chapters' start times. 
+--demux             | Run in demux mode : the selected audio and video tracks are stored as separate files. The output name must be a folder name. All selected effects (such as changing the level of a H264 stream) are processed. When demuxing, certain types of tracks are always changed : - Subtitles in a Presentation Graphic Stream are converted into sup format. - PCM audio is saved as WAV files. 
+--blu-ray           | Mux as a BD disc. If the output file name is a folder, a Blu-Ray folder structure is created inside that folder. SSIF files for BD3D discs are not created in this case. If the output name has an .iso extension, then the disc is created directly as an image file. 
+--blu-ray-v3        | As above - except mux to UHD BD discs.
+--avchd             | Mux to AVCHD disc.
+--cut-start         | Trim the beginning of the file. The value should be followed by the time unit : "ms" (milliseconds), "s" (seconds) or "min" (minutes). 
+--cut-end           | Trim the end of the file. Same rules as --cut-start apply. 
+--split-duration    | Split the output into several files, with each of them being <n> seconds long. 
+--split-size        | Split the output into several files, with each of them having a given maximum size. KB, KiB, MB, MiB, GB and GiB are accepted as size units. 
 --right-eye         | Use base video stream for right eye. Used for 3DBD only.
---start-time        | Timestamp of the first video frame. May be defined as 45Khz clock (just a number) or as time in format hh:mm:ss.zzz
---mplsOffset        | The number of the first MPLS file.  Used for  BD disk mode.
---m2tsOffset        | The number of the first M2TS file.  Used for  BD disk mode.
---insertBlankPL     | Add extra  short playlist.  Used for cropped video muxed to BD disk.
+--start-time        | Timestamp of the first video frame. May be defined as 45Khz clock (just a number) or as time in hh:mm:ss.zzz format
+--mplsOffset        | The number of the first MPLS file. Used for BD disc mode.
+--m2tsOffset        | The number of the first M2TS file. Used for BD disc mode.
+--insertBlankPL     | Add an additional short playlist.  Used for cropped video muxed to BD disc.
 --blankOffset       | Blank playlist number.
---label             | Disk label for muxing to ISO file.
---extra-iso-space   | Allocate extra space  in 64K units  for ISO  disk  metadata (file and directory names). Normally, tsMuxeR allocate this space automatically. But if split condition generates a lot of small files, extra ISO space may be required to define.
+--label             | Disk label when muxing to ISO.
+--extra-iso-space   | Allocate extra space in 64K units for ISO metadata (file and directory names). Normally, tsMuxeR allocates this space automatically, but if split condition generates a lot of small files, it may be required to define extra space. 
 
 
 ## Todo

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -339,35 +339,36 @@ void showHelp()
 {
     const char help[] =
         "\n\
-tsMuxeR is  simple  program to  mux video to  TS/M2TS files or create BD disks.\n\
+tsMuxeR is a simple program to mux video to TS/M2TS files or create BD disks.\n\
 tsMuxeR does not use external filters (codecs).\n\
 \n\
 Examples:\n\
     tsMuxeR <media file name>\n\
     tsMuxeR <meta file name> <out file/dir name>\n\
 \n\
-tsMuxeR can be run in track detection mode or muxing mode. If run tsMuxeR  with\n\
-only  one argument  then tsMuxeR  display  input track information  required to\n\
-construct  meta  file.  If run tsMuxeR  with two arguments tsMuxeR start muxing\n\
-or demuxing process.\n\
+tsMuxeR can be run in track detection mode or muxing mode. If tsMuxeR is run with\n\
+only one argument, then the program displays track information required to\n\
+construct a meta file. When running with two arguments, tsMuxeR starts the\n\
+muxing or demuxing process.\n\
 \n\
 Meta file format:\n\
-File MUST has extension .meta.  This file  define files you want to  multiplex.\n\
-First line of meta file contain additional parameters that apply to all tracks.\n\
-In this case the line should begin with the word MUXOPT.\n\
+File MUST have the .meta extension. This file defines files you want to multiplex.\n\
+The first line of a meta file contains additional parameters that apply to all tracks.\n\
+In this case the first line should begin with the word MUXOPT.\n\
 \n\
-Following lines indicate a list of tracks  and their parameters.  The format is\n\
-as follows:   <code name>,   <file name>,   <parameters>   Parameters are comma\n\
-separated. Each parameter indicates the name and value.\n\
+The following lines form a list of tracks and their parameters.  The format is\n\
+as follows:   <code name>,   <file name>,   <parameters>   Parameters are separated\n\
+with commas, with each parameter consisting of a name and a value, separated \n\
+with an equals sign.\n\
 Example of META file:\n\
 \n\
 MUXOPT --blu-ray\n\
 V_MPEG4/ISO/AVC, D:/media/test/stream.h264, fps=25\n\
 A_AC3, D:/media/test/stream.ac3, timeshift=-10000ms\n\
 \n\
-In this example one AC3 audio stream and one H264 video stream are  multiplexed\n\
-to BD disk.  Input file name can reference to elementary stream or track inside\n\
-container.\n\
+In this example one AC3 audio stream and one H264 video stream are multiplexed\n\
+into BD disc. The input file name can reference an elementary stream or a track\n\
+located inside a container.\n\
 \n\
 Supported input containers:\n\
 - TS/M2TS/MTS\n\
@@ -390,43 +391,45 @@ Names of codecs in the meta file:\n\
 - S_HDMV/PGS        Presentation graphic stream (BD subtitle format)\n\
 - S_TEXT/UTF8       SRT subtitle format.  Encoding MUST be  UTF-8/UTF-16/UTF-32\n\
 \n\
-Each track may has addition parameters.  Track parameters do not  have dash. If\n\
-parameter value has several words, parameter must be enclosed in quotes.\n\
+Each track may have additional parameters. Track parameters do not have dashes.\n\
+If a parameter's value consists of several words, it must be enclosed in quotes.\n\
 \n\
 Common additional parameters for any type of track:\n\
-- track             track number if input file is container.\n\
-- lang              track language. MUST contains exact 3 letters.\n\
+- track             track number if input file is a container.\n\
+- lang              track language. MUST contain exactly 3 letters.\n\
 \n\
 Additional parameters for audio tracks:\n\
-- timeshift         Shift audio track to future (positive value) or to past.\n\
-                    Measured at milliseconds.\n\
+- timeshift         Shift audio track by the given number of milliseconds.\n\
+                    Can be negative.\n\
 - down-to-dts       Available only for DTS-HD tracks. Filter out HD part.\n\
 - down-to-ac3       Available only for TRUE-HD tracks. Filter out HD part.\n\
-- secondary         Mux as secondary audio.  Available for DD+ and DTS-Express.\n\
+- secondary         Mux as secondary audio. Available for DD+ and DTS-Express.\n\
 \n\
 Additional parameters for video tracks:\n\
-- fps               Video fps. If not defined, default value auto detected from\n\
-                    a source stream if present. If not, default value 23.976.\n\
-- delPulldown       Remove pulldown from the track if exists.  This option lead\n\
-                    to fps change from 30 to 24 if pulldown exists.\n\
+- fps               The number of frames per second. If not defined, the value\n\
+                    is auto detected if available in the source stream. If not,\n\
+                    it defaults to 23.976.\n\
+- delPulldown       Remove pulldown from the track, if it exists. If the\n\
+                    pulldown is present, the FPS value is changed from 30 to 24.\n\
 - ar                Override video aspect ratio. 16:9, 4:3 e.t.c.\n\
 \n\
 Additional parameters for H.264 video tracks:\n\
-- level             Overwrite  level in the H264 stream.  Note:  option  update\n\
-                    headers only. The H264 stream may not meet the requirements\n\
-                    of a lower level.\n\
-- insertSEI         If original   stream  does not contain  SEI picture timing,\n\
-                    SEI buffering period or VUI parameters,  then add this data\n\
-                    to the stream. This option is recommended for BD muxing.\n\
+- level             Overwrite the level in the H264 stream. Do note that this\n\
+                    option only updates the headers and does not reencode the\n\
+                    stream, which may not meet the requirements for a lower \n\
+                    level.\n\
+- insertSEI         If the original stream does not contain SEI picture timing,\n\
+                    SEI buffering period or VUI parameters, add this data to\n\
+                    the stream. This option is recommended for BD muxing.\n\
 - forceSEI          Add SEI picture timing, buffering period and VUI parameters\n\
-                    to the stream. Rebuild data If data already exist. \n\
-- contSPS           If original video doesn't contain  repetitive SPS/PPS  then\n\
-                    SPS/PPS will be added to the stream before  each key frame.\n\
-                    This option is recommended for BD muxing.\n\
-- subTrack          Used  for  combined  AVC/MVC  tracks  only.  TsMuxeR always\n\
-                    demultiplex  such  tracks to separate  AVC and MVC streams.\n\
-                    This parameter defined reference to AVC part(if value=1) or\n\
-                    or to MVC part (if value=2).\n\
+                    to the stream and rebuild this data if it already exists.\n\
+- contSPS           If the original video doesn't contain repetitive SPS/PPS,\n\
+                    then SPS/PPS will be added to the stream before each key\n\
+                    frame. This option is recommended for BD muxing.\n\
+- subTrack          Used for combined AVC/MVC tracks only. TsMuxeR always\n\
+                    demultiplexes such tracks to separate AVC and MVC streams.\n\
+                    Setting this to 1 sets the reference to the AVC part, while\n\
+                    2 sets it to the MVC part.\n\
 - secondary         Mux as secondary video (PIP).\n\
 - pipCorner         Corner for PIP video. Allowed values: \"TopLeft\",\"TopRight\",\n\
                     \"BottomRight\", \"BottomLeft\". \n\
@@ -434,26 +437,26 @@ Additional parameters for H.264 video tracks:\n\
 - pipVOffset        PIP window vertical offset from the corner in pixels.\n\
 - pipScale          PIP window scale factor. Allowed values: \"1\", \"1/2\", \"1/4\",\n\
                     \"1.5\", \"fullScreen\".\n\
-- pipLumma          Allow PIP window to be transparent. Transparent colors  are\n\
-                    lumma colors in range [0..pipLumma]. \n\
+- pipLumma          Allow the PIP window to be transparent. Transparent colors\n\
+                    are lumma colors in range [0..pipLumma]. \n\
 \n\
 Additional parameters for PG and SRT tracks:\n\
 \n\
 - video-width       The width of the video in pixels.\n\
 - video-height      The height of the video in pixels.\n\
-- fps               Video fps.  Recommended  to  define this parameter for more\n\
-                    carefully timing processing.\n\
-- 3d-plane          Parameter  defines  number  of  the '3D offset track' which\n\
-                    placed  inside  MVC  track.  Each message has individual 3D\n\
-                    offset. This information  stored  inside 3D offset track.\n\
+- fps               Video fps. It is recommended to define this parameter in\n\
+                    order to enable more careful timing processing.\n\
+- 3d-plane          Defines the number of the '3D offset track' which is placed\n\
+                    inside the MVC track. Each message has an individual 3D\n\
+                    offset. This information is stored inside 3D offset track.\n\
 \n\
 Additional parameters for SRT tracks:\n\
 \n\
 - font-name         Font name to render.\n\
-- font-color        Font color. Color can be defined in hexadecimal or  decimal\n\
-                    format. If color 24 bit long  (for instance 0xFF00FF)  it's\n\
-                    define RGB components.  IF color 32 bit long  (for instance\n\
-                    0x80FF00FF) it's define ARGB components.\n\
+- font-color        Font color, defined as a hexadecimal or decimal number.\n\
+                    24-bit long numbers (for instance 0xFF00FF) define RGB\n\
+                    components, while 32-bit long ones (for instance\n\
+                    0x80FF00FF) define ARGB components.\n\
 - font-size         Font size in pixels.\n\
 - font-italic       Italic display text.\n\
 - font-bold         Bold display text.\n\
@@ -463,77 +466,81 @@ Additional parameters for SRT tracks:\n\
 - font-border       Outline width.\n\
 - fadein-time       Time in ms for smooth subtitle appearance.\n\
 - fadeout-time      Time in ms for smooth subtitle disappearance.\n\
-- line-spacing      Interval between lines. Default value 1.0.\n\
+- line-spacing      Interval between subtitle lines. Default value is 1.0.\n\
 \n\
-tsMuxeR  supports  addition  tag inside  SRT track.  The syntax  and parameters\n\
+tsMuxeR supports additional tags inside SRT tracks. The syntax and parameters\n\
 coincide with HTML: <b>, <i>, <u>, <strike>, <font>. Default relative font size\n\
-(used in these tags) - 3.  For example:\n\
+(used in these tags) is 3.  For example:\n\
 \n\
 <b><font size=5 color=\"deepskyblue\" name=\"Arial\"><u>Test</u>\n\
 <font size= 4 color=\"#806040\">colored</font>text</font>\n\
 </b>\n\
 \n\
-Global addition parameters placed in the first line of the META file  (MUXOPT).\n\
-All parameters in this group started with two dashes:\n\
+Global additional parameters are placed in the first line of the META file,\n\
+which must begin with the MUXOPT token.\n\
+All parameters in this group start with two dashes:\n\
 \n\
---pcr-on-video-pid  Do not allocate separate PID for PCR, use an existing video\n\
-                    PID.\n\
+--pcr-on-video-pid  Do not allocate a separate PID for PCR and use the existing\n\
+                    video PID.\n\
 --new-audio-pes     Use bytes 0xfd instead of 0xbd for AC3, True-HD, DTS and\n\
-                    DTS-HD. Parameter is auto activated for BD muxing.\n\
+                    DTS-HD. Activated automatically for BD muxing.\n\
 --vbr               Use variable bitrate.\n\
---minbitrate        Sets the lower limit of the vbr bitrate.  If the stream has\n\
-                    a  smaller bitrate  then NULL  packets will be inserted  to\n\
-                    hold the limit.\n\
+--minbitrate        Sets the lower limit of the VBR bitrate. If the stream has\n\
+                    a smaller bitrate, NULL packets will be inserted to\n\
+                    compensate.\n\
 --maxbitrate        The upper limit of the vbr bitrate.\n\
---cbr               Muxing mode  with a fixed bitrate.  Options --vbr and --cbr\n\
-                    should not be used together.\n\
+--cbr               Muxing mode with a fixed bitrate. --vbr and --cbr must not\n\
+                    be used together.\n\
 --vbv-len           The  length  of the  virtual  buffer  in milliseconds.  The\n\
-                    default value  is 500.  Typically, this  option  is used in\n\
+                    default value  is 500.  Typically, this  option  is used\n\
                     together with --cbr. The parameter is similar to  the value\n\
-                    of  vbv-buffer-size  in  the  x264  coder,  but  defined in\n\
+                    of  vbv-buffer-size  in  the  x264  codec,  but  defined in\n\
                     milliseconds instead of kbit.\n\
---no-asyncio        Do not  create  a separate thread  for writing.  Also, this\n\
-                    option  disable  flag  FILE_FLAG_NO_BUFFERING  for writing.\n\
-                    Deprecated option.\n\
---auto-chapters     Number.  Insert a chapter every <nn> minutes. Used only for\n\
-                    BD/AVCHD mode.\n\
---custom-chapters   A semicolon delimited list of string in format hh:mm:ss.zzz\n\
---demux             In this mode selected audio  and video tracks are stored as\n\
-                    separate files instead of muxing. utput name must be folder\n\
-                    name.  All selected  effects  (such as change  of level for\n\
-                    h264) are processed.  When demux,  certain types  of tracks\n\
-                    always get changed on storing into a file:\n\
-                    - Subtitles in a Presentation Graphic Stream  are converted\n\
+--no-asyncio        Do not  create  a separate thread  for writing. This option\n\
+                    also disables the FILE_FLAG_NO_BUFFERING flag on Windows\n\
+                    when writing.\n\
+                    This option is deprecated.\n\
+--auto-chapters     Insert a chapter every <n> minutes. Used only in BD/AVCHD\n\
+                    mode.\n\
+--custom-chapters   A semicolon delimited list of hh:mm:ss.zzz strings,\n\
+                    representing the chapters' start times.\n\
+--demux             Run in demux mode : the selected audio and video tracks are\n\
+                    stored as separate files. The output name must be a folder\n\
+                    name. All selected effects (such as changing the level of\n\
+                    a H264 stream) are processed. When demuxing, certain types\n\
+                    of tracks are always changed :\n\
+                    - Subtitles in a Presentation Graphic Stream are converted\n\
                       into sup format.\n\
-                    - PCM audio are saved as WAV files.\n\
---blu-ray           Mux to BD diks. If output file name is folder,  bluray disk\n\
-                    is created as folder on HDD.  For BD3D disks ssif files are\n\
-                    not  created at  this  case.  If output file name  has .iso\n\
-                    extension, then BD disk is created as image file.\n\
---blu-ray-v3        As above - except mux to UHD BD disks.\n\
---avchd             Mux to AVCHD disk.\n\
---cut-start         Trim the beginning of the file.  Value should be  completed\n\
-                    with  \"ms\"  (the number of milliseconds),  \"s\" (seconds) or\n\
+                    - PCM audio is saved as WAV files.\n\
+--blu-ray           Mux as a BD disc. If the output file name is a folder, a\n\
+                    Blu-Ray folder structure is created inside that folder.\n\
+                    SSIF files for BD3D discs are not created in this case. If\n\
+                    the output name has an .iso extension, then the disc is\n\
+                    created directly as an image file.\n\
+--blu-ray-v3        As above - except mux to UHD BD discs.\n\
+--avchd             Mux to AVCHD disc.\n\
+--cut-start         Trim the beginning of the file. The value should be followed\n\
+                    by the time unit : \"ms\" (milliseconds), \"s\" (seconds) or\n\
                     \"min\" (minutes).\n\
---cut-end           Trim  the end of the file.  Value should be  completed with\n\
-                    \"ms\" (the number of milliseconds), \"s\" (seconds) or \"min\"\n\
-                    (minutes).\n\
---split-duration    Split output to several files.The time specified in seconds\n\
---split-size        Split  output to several files.  Values  should be  written\n\
-                    using one of the following postfix: Kb,kib, mb,mib, gb,gib.\n\
+--cut-end           Trim the end of the file. Same rules as --cut-start apply.\n\
+--split-duration    Split the output into several files, with each of them being\n\
+                    <n> seconds long.\n\
+--split-size        Split the output into several files, with each of them\n\
+                    having a given maximum size. KB, KiB, MB, MiB, GB and GiB\n\
+                    are accepted as size units.\n\
 --right-eye         Use base video stream for right eye. Used for 3DBD only.\n\
 --start-time        Timestamp of the first video frame. May be defined as 45Khz\n\
-                    clock (just a number) or as time in format hh:mm:ss.zzz\n\
---mplsOffset        The number of the first MPLS file.  Used for  BD disk mode.\n\
---m2tsOffset        The number of the first M2TS file.  Used for  BD disk mode.\n\
---insertBlankPL     Add extra  short playlist.  Used for cropped video muxed to\n\
-                    BD disk.\n\
+                    clock (just a number) or as time in hh:mm:ss.zzz format.\n\
+--mplsOffset        The number of the first MPLS file.  Used for BD disc mode.\n\
+--m2tsOffset        The number of the first M2TS file.  Used for BD disc mode.\n\
+--insertBlankPL     Add an additional short playlist. Used for cropped video\n\
+                    muxed to BD disc.\n\
 --blankOffset       Blank playlist number.\n\
---label             Disk label for muxing to ISO file.\n\
---extra-iso-space   Allocate extra space  in 64K units  for ISO  disk  metadata\n\
-                    (file and directory names). Normally, tsMuxeR allocate this\n\
-                    space automatically. But if split condition generates a lot\n\
-                    of small files, extra ISO space may be required to define.\n\
+--label             Disk label when muxing to ISO.\n\
+--extra-iso-space   Allocate extra space in 64K units for ISO metadata (file\n\
+                    and directory names). Normally, tsMuxeR allocates this space\n\
+                    automatically, but if split condition generates a lot\n\
+                    of small files, it may be required to define extra space.\n\
 ";
     LTRACE(LT_INFO, 2, help);
 }


### PR DESCRIPTION
Fixes #59.

@justdan96 Since you're the only native speaker among us, it would be nice to get some feedback once you have a while to review the changes.