### PR TITLE
Fix bug 3d-plane / PID part 2

### DIFF
--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -169,23 +169,23 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
                 int pgTrackNum = streamInfo.streamPID - 0x1200;
                 if (pgTrackNum >= 0 && pgTrackNum < pgStreams3D.size())
                 {
-                    if (pgStreams3D[pgTrackNum].offsetId != 0xff)
+                    if (streamInfo.offsetId != 0xff)
                     {
                         descr += "   3d-plane: ";
-                        descr += int32ToStr(pgStreams3D[pgTrackNum].offsetId);
+                        descr += int32ToStr(streamInfo.offsetId);
                     }
                     else
                     {
-                        descr += "   3d-plane: zero";
+                        descr += "   3d-plane: undefined";
                     }
-                    if (pgStreams3D[pgTrackNum].isSSPG)
+                    if (streamInfo.isSSPG)
                     {
                         descr += "   (stereo, right=";
-                        descr += (pgStreams3D[pgTrackNum].rightEye->type == 2 ? "dep-view " : "");
-                        descr += int32ToStr(pgStreams3D[pgTrackNum].rightEye->streamPID);
+                        descr += (streamInfo.rightEye->type == 2 ? "dep-view " : "");
+                        descr += int32ToStr(streamInfo.rightEye->streamPID);
                         descr += ", left=";
-                        descr += (pgStreams3D[pgTrackNum].leftEye->type == 2 ? "dep-view " : "");
-                        descr += int32ToStr(pgStreams3D[pgTrackNum].leftEye->streamPID);
+                        descr += (streamInfo.leftEye->type == 2 ? "dep-view " : "");
+                        descr += int32ToStr(streamInfo.leftEye->streamPID);
                         descr += ")";
                     }
                 }

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -189,6 +189,7 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
                         descr += ")";
                     }
                 }
+                else descr += "   (PID is not in mpls)";
             }
             LTRACE(LT_INFO, 2, "Stream info: " << descr);
             LTRACE(LT_INFO, 2, "Stream lang: " << streams[i].lang);

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -189,7 +189,8 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
                         descr += ")";
                     }
                 }
-                else descr += "   (PID is not in mpls)";
+                else
+                    descr += "   (PID is not in mpls)";
             }
             LTRACE(LT_INFO, 2, "Stream info: " << descr);
             LTRACE(LT_INFO, 2, "Stream lang: " << streams[i].lang);

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1497,8 +1497,7 @@ QString TsMuxerWindow::getMuxOpts()
     if (ui->splitByDuration->isChecked())
         rez += QString(" --split-duration=") + ui->spinEditSplitDuration->text();
     if (ui->splitBySize->isChecked())
-        rez += QString(" --split-size=") + ui->editSplitSize->text() +
-               ui->comboBoxMeasure->currentText();
+        rez += QString(" --split-size=") + ui->editSplitSize->text() + ui->comboBoxMeasure->currentText();
 
     int startCut = qTimeToMsec(ui->cutStartTimeEdit->time());
     int endCut = qTimeToMsec(ui->cutEndTimeEdit->time());


### PR DESCRIPTION
All `pgStreams3D[pgTrackNum]` (coming from clpi) must be changed to `streamInfo` (coming from mpls). Tested with "The Hobbit : Desolation of Smaug" as per bug reported [here](https://forum.doom9.org/showthread.php?p=1896255#post1896255).

Also when 3d-plane is "FF", this means it is 'undefined' (i.e. 2D), not 'zero'.
Edit: added `(PID is not in mpls)` in decription in case of "phantom stream", i.e. PID present in clpi but not in mpls. 