### PR TITLE
Detect audio delay in MKV

### DIFF
--- a/tsMuxer/matroskaDemuxer.cpp
+++ b/tsMuxer/matroskaDemuxer.cpp
@@ -221,6 +221,7 @@ MatroskaDemuxer::MatroskaDemuxer(const BufferedReaderManager &readManager) : IOC
     num_streams = 0;
     segment_start = 0;
     time_scale = 0;
+    m_firstTimecode.clear();
     index_parsed = false;
     metadata_parsed = false;
     writing_app = 0;
@@ -665,7 +666,11 @@ int MatroskaDemuxer::matroska_parse_block(uint8_t *data, int size, int64_t pos, 
         uint64_t timecode = AV_NOPTS_VALUE;
 
         if (cluster_time != (uint64_t)-1 && (block_time >= 0 || cluster_time >= -block_time))
+        {
             timecode = cluster_time + block_time;
+            if (m_firstTimecode.find(tracks[track]->num) == m_firstTimecode.end())
+                m_firstTimecode[tracks[track]->num] = timecode;
+        }
 
         for (n = 0; n < laces; n++)
         {
@@ -1080,6 +1085,7 @@ void MatroskaDemuxer::openFile(const std::string &streamName)
 
     segment_start = 0;
     time_scale = 0;
+    m_firstTimecode.clear();
     index_parsed = false;
     metadata_parsed = false;
 

--- a/tsMuxer/matroskaDemuxer.h
+++ b/tsMuxer/matroskaDemuxer.h
@@ -18,6 +18,10 @@ class MatroskaDemuxer : public IOContextDemuxer
     std::vector<AVChapter> getChapters() override;
 
     bool isPidFilterSupported() const override { return true; }
+    int64_t getTrackDelay(uint32_t pid) override
+    {
+        return (m_firstTimecode.find(pid) != m_firstTimecode.end()) ? m_firstTimecode[pid] : 0 ;
+    }
 
     int64_t getFileDurationNano() const override { return fileDuration; }
 
@@ -55,6 +59,7 @@ class MatroskaDemuxer : public IOContextDemuxer
     char *writing_app;
     char *muxing_app;
     int time_scale;
+    std::map<int, int64_t> m_firstTimecode;
     bool index_parsed;
     bool metadata_parsed;
     int num_streams;

--- a/tsMuxer/matroskaDemuxer.h
+++ b/tsMuxer/matroskaDemuxer.h
@@ -20,7 +20,7 @@ class MatroskaDemuxer : public IOContextDemuxer
     bool isPidFilterSupported() const override { return true; }
     int64_t getTrackDelay(uint32_t pid) override
     {
-        return (m_firstTimecode.find(pid) != m_firstTimecode.end()) ? m_firstTimecode[pid] : 0 ;
+        return (m_firstTimecode.find(pid) != m_firstTimecode.end()) ? m_firstTimecode[pid] : 0;
     }
 
     int64_t getFileDurationNano() const override { return fileDuration; }


### PR DESCRIPTION
tsMuxer currently has the ability to detect audio delay from TS/M2TS/MPG/VOB/EVO sources, but not from MKV sources.

This patch adds ability to detect audio delay from MKV sources.