### PR TITLE
Fix bad looking fonts in Linux

### DIFF
--- a/tsMuxer/osdep/textSubtitlesRenderFT.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderFT.cpp
@@ -452,7 +452,7 @@ void RenderGlyph(FT_Library& library, wchar_t ch, FT_Face& face, int size, const
                 for (int w = 0; w < s->width; ++w)
                 {
                     int y = imgHeight - 1 - (s->y - rect.ymin) + top;
-                    int x = s->x - rect.xmin + w + left;
+                    int x = s->x + w;
                     if (y >= 0 && y < height && x >= 0 && x < width)
                     {
                         Pixel32* dst = (Pixel32*)dstData + y * width + x;
@@ -469,7 +469,7 @@ void RenderGlyph(FT_Library& library, wchar_t ch, FT_Face& face, int size, const
                 for (int w = 0; w < s->width; ++w)
                 {
                     int y = imgHeight - 1 - (s->y - rect.ymin) + top;
-                    int x = s->x - rect.xmin + w + left;
+                    int x = s->x + w;
                     if (y >= 0 && y < height && x >= 0 && x < width)
                     {
                         Pixel32* dst = (Pixel32*)dstData + y * width + x;
@@ -484,7 +484,7 @@ void RenderGlyph(FT_Library& library, wchar_t ch, FT_Face& face, int size, const
                 for (int w = 0; w < s->width; ++w)
                 {
                     int y = imgHeight - 1 - (s->y - rect.ymin) + top;
-                    int x = s->x - rect.xmin + w + left;
+                    int x = s->x + w;
 
                     if (y >= 0 && y < height && x >= 0 && x < width)
                     {


### PR DESCRIPTION
This patch fixes the uneven width between chars in the subtitle (part of issue #133). It does not fix absence of shadow or transparency, which still have to be sorted out.