### PR TITLE
Remove 3d-plane info for 2D BD-ROM

### DIFF
--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -162,7 +162,7 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
 
             LTRACE(LT_INFO, 2, "Stream ID:   " << streams[i].codecInfo.programName);
             std::string descr = streams[i].streamDescr;
-            if (streams[i].codecInfo.codecID == CODEC_S_PGS && mplsParser)
+            if (streams[i].codecInfo.codecID == CODEC_S_PGS && mplsParser && mplsParser->isDependStreamExist)
             {
                 // PG stream
                 MPLSStreamInfo streamInfo = mplsParser->getStreamByPID(streams[i].trackID);


### PR DESCRIPTION
Fix  bug provoked by #159: 3d-plane information should show only for 3D BD-ROMs