### PR TITLE
Bug: Shorten filename when adding more than two files

### DIFF
--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -121,7 +121,7 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
 
     vector<string> fileList = extractFileList(streamName);
     string fileName;
-    if (fileList.size() < 2)
+    if (fileList.size() < 3)
         for (int i = 0; i < (int)fileList.size(); i++)
         {
             if (i > 0)

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -129,7 +129,7 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
             fileName += extractFileName(fileList[i]);
         }
     else
-        fileName = extractFileName(fileList[0]) + "+...+" + extractFileName(fileList[fileList.size() - 1]);
+        fileName = extractFileName(fileList[0]) + "+___+" + extractFileName(fileList[fileList.size() - 1]);
 
     map<string, string>::const_iterator itr = params.find("track");
     if (itr != params.end())

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -130,7 +130,7 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
         }
     else
         fileName = extractFileName(fileList[0]) + "+...+" + extractFileName(fileList[fileList.size() - 1]);
-    
+
     map<string, string>::const_iterator itr = params.find("track");
     if (itr != params.end())
     {

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -121,12 +121,16 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
 
     vector<string> fileList = extractFileList(streamName);
     string fileName;
-    for (int i = 0; i < (int)fileList.size(); i++)
-    {
-        if (i > 0)
-            fileName += '+';
-        fileName += extractFileName(fileList[i]);
-    }
+    if (fileList.size() < 2)
+        for (int i = 0; i < (int)fileList.size(); i++)
+        {
+            if (i > 0)
+                fileName += '+';
+            fileName += extractFileName(fileList[i]);
+        }
+    else
+        fileName = extractFileName(fileList[0]) + "+...+" + extractFileName(fileList[fileList.size() - 1]);
+    
     map<string, string>::const_iterator itr = params.find("track");
     if (itr != params.end())
     {

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -149,6 +149,8 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
     }
     StreamInfo* streamInfo = new StreamInfo((unsigned)DEFAULT_FILE_BLOCK_SIZE);
     streamInfo->m_fileName = fileName + fileExt;
+    if (streamInfo->m_fileName.size() > 254)
+        LTRACE(LT_ERROR, 2, "Error: File name too long.");
     streamInfo->m_codecReader = codecReader;
     m_streamInfo[streamIndex] = streamInfo;
 }


### PR DESCRIPTION
See eg https://forum.doom9.org/showthread.php?p=1897783#post1897783

tsMuxer currently adds the filenames one after the other to create the new file name.
This creates a "Can't create output file" error on Windows when new file name is more than 255 bytes.

This patch simply names the created files "first file+...+lastfile.ext" when more than two files are concatenated.