### PR TITLE
Bug: Subtitle PIDs must start at 0x12A0 for HDR

### DIFF
--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -762,7 +762,7 @@ CheckStreamRez PGSStreamReader::checkStream(uint8_t* buffer, int len, ContainerT
         rez.codecInfo = pgsCodecInfo;
         rez.streamDescr = "Presentation Graphic Stream";
         if (containerStreamIndex >= 0x1200)
-            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 1 ? 0x1200 : 0x12A0);
+            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 1 ? 0x1200 : 0x12A0));
     }
     else if (containerType == ctMKV && containerDataType == STREAM_TYPE_SUB_PGS)
     {

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -9,6 +9,7 @@
 #include "avCodecs.h"
 #include "math.h"
 #include "tsPacket.h"
+#include "tsMuxer.h"
 #include "vodCoreException.h"
 #include "vod_common.h"
 
@@ -761,7 +762,7 @@ CheckStreamRez PGSStreamReader::checkStream(uint8_t* buffer, int len, ContainerT
         rez.codecInfo = pgsCodecInfo;
         rez.streamDescr = "Presentation Graphic Stream";
         if (containerStreamIndex >= 0x1200)
-            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - 0x1200);
+            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 1 ? 0x1200 : 0x12A0);
     }
     else if (containerType == ctMKV && containerDataType == STREAM_TYPE_SUB_PGS)
     {

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -8,8 +8,8 @@
 
 #include "avCodecs.h"
 #include "math.h"
-#include "tsPacket.h"
 #include "tsMuxer.h"
+#include "tsPacket.h"
 #include "vodCoreException.h"
 #include "vod_common.h"
 

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -215,12 +215,12 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     }
     else if (codecName == "S_HDMV/PGS")
     {
-        tsStreamIndex = 0x1200 + m_pgsTrackCnt;
+        tsStreamIndex = (V3_flags & 1 ? 0x1200 : 0x12A0) + m_pgsTrackCnt;
         m_pgsTrackCnt++;
     }
     else if (codecName == "S_TEXT/UTF8")
     {
-        tsStreamIndex = 0x1200 + m_pgsTrackCnt;
+        tsStreamIndex = (V3_flags & 1 ? 0x1200 : 0x12A0) + m_pgsTrackCnt;
         m_pgsTrackCnt++;
     }
     m_extIndexToTSIndex[streamIndex] = tsStreamIndex;


### PR DESCRIPTION
tsMuxer currently gives subtitle PIDs the value of 0x1200 and above.

For BD V3 m2ts with HDR, PGS PID must start at 0x12A0 -thanks @tymoxa for raising the issue.