### PR TITLE
Bug: correct EAC3+AC3 core bitrate

### DIFF
--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -151,7 +151,7 @@ int AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
         int lfeonExt = gbc.getBit();
         if (m_lfeon == 0)
             m_lfeon = lfeonExt;
-        if (m_channels == 0) // no AC3 core
+        if (m_channels == 0)  // no AC3 core
             m_channels = ff_ac3_channels[acmodExt] + lfeonExt;
         m_samples = eac3_blocks[numblkscod] * 256;
         m_bit_rateExt = m_frame_size * (m_sample_rate)*8 / (m_samples);

--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -147,17 +147,17 @@ int AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
             numblkscod = gbc.getBits(2);
             m_sample_rate = ff_ac3_freqs[m_fscod];
         }
-        m_bsmod = 0;
-        m_acmod = gbc.getBits(3);
-        m_lfeon = gbc.getBit();
-        m_channels = ff_ac3_channels[m_acmod] + m_lfeon;
+        int acmodExt = gbc.getBits(3);
+        int lfeonExt = gbc.getBit();
+        if (m_lfeon == 0)
+            m_lfeon = lfeonExt;
+        if (m_channels == 0) // no AC3 core
+            m_channels = ff_ac3_channels[acmodExt] + lfeonExt;
         m_samples = eac3_blocks[numblkscod] * 256;
         m_bit_rateExt = m_frame_size * (m_sample_rate)*8 / (m_samples);
-        m_bit_rate = 0;
 
         gbc.skipBits(5);  // skip bsid, already got it
-        m_bsidBase = m_bsid;
-        for (int i = 0; i < (m_acmod ? 1 : 2); i++)
+        for (int i = 0; i < (acmodExt ? 1 : 2); i++)
         {
             gbc.skipBits(5);  // skip dialog normalization
             if (gbc.getBit())

--- a/tsMuxer/ac3Codec.h
+++ b/tsMuxer/ac3Codec.h
@@ -59,6 +59,9 @@ class AC3Codec
         setTestMode(false);
         m_frameDuration = false;
         m_bit_rateExt = 0;
+        m_bit_rate = 0;
+        m_channels = 0;
+        m_lfeon = 0;
         m_extChannelsExists = false;
         m_bsid = m_bsidBase = 0;
         m_dsurmod = 0;


### PR DESCRIPTION
Bitrate and channel number are shown incorrectly with EAC3 + AC3 core.
This patch corrects the above.

Bug reported here https://forum.doom9.org/showthread.php?p=1898309#post1898309