### PR TITLE
Bug: subtitle PIDs should start at 0x12A0 for HDR Part 2

### DIFF
--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -762,7 +762,8 @@ CheckStreamRez PGSStreamReader::checkStream(uint8_t* buffer, int len, ContainerT
         rez.codecInfo = pgsCodecInfo;
         rez.streamDescr = "Presentation Graphic Stream";
         if (containerStreamIndex >= 0x1200)
-            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 0x1e ? 0x12A0 : 0x1200));
+            rez.streamDescr +=
+                std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 0x1e ? 0x12A0 : 0x1200));
     }
     else if (containerType == ctMKV && containerDataType == STREAM_TYPE_SUB_PGS)
     {

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -762,7 +762,7 @@ CheckStreamRez PGSStreamReader::checkStream(uint8_t* buffer, int len, ContainerT
         rez.codecInfo = pgsCodecInfo;
         rez.streamDescr = "Presentation Graphic Stream";
         if (containerStreamIndex >= 0x1200)
-            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 1 ? 0x1200 : 0x12A0));
+            rez.streamDescr += std::string(" #") + int32ToStr(containerStreamIndex - (V3_flags & 0x1e ? 0x12A0 : 0x1200));
     }
     else if (containerType == ctMKV && containerDataType == STREAM_TYPE_SUB_PGS)
     {

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -215,12 +215,12 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     }
     else if (codecName == "S_HDMV/PGS")
     {
-        tsStreamIndex = (V3_flags & 1 ? 0x1200 : 0x12A0) + m_pgsTrackCnt;
+        tsStreamIndex = (V3_flags & 0x1e ? 0x12A0 : 0x1200) + m_pgsTrackCnt;
         m_pgsTrackCnt++;
     }
     else if (codecName == "S_TEXT/UTF8")
     {
-        tsStreamIndex = (V3_flags & 1 ? 0x1200 : 0x12A0) + m_pgsTrackCnt;
+        tsStreamIndex = (V3_flags & 0x1e ? 0x12A0 : 0x1200) + m_pgsTrackCnt;
         m_pgsTrackCnt++;
     }
     m_extIndexToTSIndex[streamIndex] = tsStreamIndex;


### PR DESCRIPTION
Correction of commit #171 :
With commit 171, tsMuxer sets PID to 0x12A0 when SDR flag = 0. However when not in blu-ray mode, SDR flag is never set and PID is incorrectly set to 0x12A0 with SDR.

The correct approach is to set PID to 0x12A0 when HDR is detected.