### PR TITLE
Use "standard" int main in Windows builds

### DIFF
--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1)
 project (tsmuxer LANGUAGES CXX)
 
-add_executable (tsmuxer WIN32
+add_executable (tsmuxer
   aac.cpp
   aacStreamReader.cpp
   AbstractDemuxer.cpp

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -549,9 +549,11 @@ All parameters in this group start with two dashes:\n\
 
 #ifdef _WIN32
 #include <shellapi.h>
-int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+#endif
+
+int main(int argc, char** argv)
 {
-    int argc;
+#ifdef _WIN32
     auto argvWide = CommandLineToArgvW(GetCommandLineW(), &argc);
     std::vector<std::string> argv_utf8;
     argv_utf8.reserve(static_cast<std::size_t>(argc));
@@ -560,15 +562,13 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
         argv_utf8.emplace_back(toUtf8(argvWide[i]));
     }
     LocalFree(argvWide);
-    std::vector<char*> argv;
-    argv.reserve(argv_utf8.size());
+    std::vector<char*> argv_vec;
+    argv_vec.reserve(argv_utf8.size());
     for (auto&& s : argv_utf8)
     {
-        argv.push_back(&s[0]);
+        argv_vec.push_back(&s[0]);
     }
-#else
-int main(int argc, char** argv)
-{
+    argv = &argv_vec[0];
 #endif
     LTRACE(LT_INFO, 2, "tsMuxeR version " TSMUXER_VERSION << ". github.com/justdan96/tsMuxer");
     int firstMplsOffset = 0;


### PR DESCRIPTION
Using WinMain is not necessary in order to get access to the "wide" command
line, and makes the MSVCRT skip all the initialisation steps needed for
"Console API" to work correctly, leading to the program having no output in
Windows console programs that use it - most notably, cmd.exe.