### PR TITLE
Get BT.2100/HDR10 info from VUI

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -270,6 +270,9 @@ HevcSpsUnit::HevcSpsUnit()
       vcl_hrd_parameters_present_flag(false),
       sub_pic_hrd_params_present_flag(false),
       num_short_term_ref_pic_sets(0),
+      colour_primaries(0),
+      transfer_characteristics(0),
+      matrix_coeffs(0),
       num_units_in_tick(0),
       time_scale(0),
       PicSizeInCtbsY_bits(0)

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -1,7 +1,8 @@
 #include "hevc.h"
 
-#include <algorithm>
 #include <fs/systemlog.h>
+
+#include <algorithm>
 
 #include "vodCoreException.h"
 #include "vod_common.h"

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -882,9 +882,12 @@ int HevcSeiUnit::deserialize()
             {
                 int maxCLL = m_reader.getBits(16);
                 int maxFALL = m_reader.getBits(16);
-                maxCLL = (std::max)(maxCLL, HDR10_metadata[5] >> 16);
-                maxFALL = (std::max)(maxFALL, HDR10_metadata[5] & 0x0000ffff);
-                HDR10_metadata[5] = (maxCLL << 16) + maxFALL;
+                if (maxCLL > (HDR10_metadata[5] >> 16) || maxFALL > (HDR10_metadata[5] & 0x0000ffff))
+                {
+                    maxCLL = (std::max)(maxCLL, HDR10_metadata[5] >> 16);
+                    maxFALL = (std::max)(maxFALL, HDR10_metadata[5] & 0x0000ffff);
+                    HDR10_metadata[5] = (maxCLL << 16) + maxFALL;
+                }
             }
             else if (payloadType == 4 && !isHDR10plus)
             {                           // HDR10Plus Metadata

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -360,9 +360,9 @@ void HevcSpsUnit::vui_parameters()
         bool colour_description_present_flag = m_reader.getBit();
         if (colour_description_present_flag)
         {
-            m_reader.skipBits(8);  // colour_primaries u(8)
-            m_reader.skipBits(8);  // transfer_characteristics u(8)
-            m_reader.skipBits(8);  // matrix_coeffs u(8)
+            colour_primaries = m_reader.getBits(8);
+            transfer_characteristics = m_reader.getBits(8);
+            matrix_coeffs = m_reader.getBits(8);
         }
     }
 

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -1,5 +1,6 @@
 #include "hevc.h"
 
+#include <algorithm>
 #include <fs/systemlog.h>
 
 #include "vodCoreException.h"
@@ -880,8 +881,9 @@ int HevcSeiUnit::deserialize()
             {
                 int maxCLL = m_reader.getBits(16);
                 int maxFALL = m_reader.getBits(16);
-                if (maxCLL > (HDR10_metadata[5] >> 16) || maxFALL > (HDR10_metadata[5] & 0x00ff))
-                    HDR10_metadata[5] = (maxCLL << 16) + maxFALL;
+                maxCLL = (std::max)(maxCLL, HDR10_metadata[5] >> 16);
+                maxFALL = (std::max)(maxFALL, HDR10_metadata[5] & 0x0000ffff);
+                HDR10_metadata[5] = (maxCLL << 16) + maxFALL;
             }
             else if (payloadType == 4 && !isHDR10plus)
             {                           // HDR10Plus Metadata

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -160,6 +160,10 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     */
     std::vector<ShortTermRPS> st_rps;
 
+    int colour_primaries;
+    int transfer_characteristics;
+    int matrix_coeffs
+
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;
     int time_scale;

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -162,7 +162,7 @@ struct HevcSpsUnit : public HevcUnitWithProfile
 
     int colour_primaries;
     int transfer_characteristics;
-    int matrix_coeffs
+    int matrix_coeffs;
 
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -176,8 +176,8 @@ int HEVCStreamReader::getStreamHeight() const { return m_sps ? m_sps->pic_height
 
 int HEVCStreamReader::getStreamHDR() const
 {
-    if (m_sps->colour_primaries == 9 && m_sps->transfer_characteristics == 16
-        && m_sps->matrix_coeffs == 9)  // BT.2100 colorspace
+    if (m_sps->colour_primaries == 9 && m_sps->transfer_characteristics == 16 &&
+        m_sps->matrix_coeffs == 9)  // BT.2100 colorspace
     {
         m_sei->isHDR10 = true;
         V3_flags |= 2;

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -176,6 +176,12 @@ int HEVCStreamReader::getStreamHeight() const { return m_sps ? m_sps->pic_height
 
 int HEVCStreamReader::getStreamHDR() const
 {
+    if (m_sps->colour_primaries == 9 && m_sps->transfer_characteristics == 16
+        && m_sps->matrix_coeffs == 9)  // BT.2100 colorspace
+    {
+        m_sei->isHDR10 = true;
+        V3_flags |= 2;
+    }
     return m_sei->isDV ? 4 : (m_sei->isHDR10plus ? 16 : (m_sei->isHDR10 ? 2 : 1));
 }
 


### PR DESCRIPTION
Currently tsMuxer gets the HDR10 info from the SEI (payload 137) nal, which is the standard.
There are some rare cases where there is no such SEI in the hevc stream, however the info that the stream has Rec. BT.2100 colorspace is in the SPS VUI. See eg issue #187 for Terminator Blu-ray.

This patch allows detection of HDR10/BT.2100 from VUI.