### PR TITLE
Ts descriptors

### DIFF
--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -10,7 +10,7 @@ class AACStreamReader : public SimplePacketizerReader, public AACCodec
    public:
    public:
     AACStreamReader() : SimplePacketizerReader(){};
-    int getTSDescriptor(uint8_t* dstBuff) override { return 0; }
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override { return 0; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return m_channels; }
 

--- a/tsMuxer/abstractStreamReader.h
+++ b/tsMuxer/abstractStreamReader.h
@@ -55,7 +55,7 @@ class AbstractStreamReader : public BaseAbstractStreamReader
     virtual int getTmpBufferSize() { return MAX_AV_PACKET_SIZE; }
     virtual int readPacket(AVPacket& avPacket) = 0;
     virtual int flushPacket(AVPacket& avPacket) = 0;
-    virtual int getTSDescriptor(uint8_t* dstBuff) { return 0; }
+    virtual int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
     virtual int getStreamHDR() const { return 0; }
     virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) {}
     virtual void setStreamIndex(int index) { m_streamIndex = index; }

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -54,7 +54,7 @@ void AC3StreamReader::writePESExtension(PESPacket* pesPacket, const AVPacket& av
     }
 }
 
-int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff)
+int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     {
         AC3Codec::setTestMode(true);

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -24,7 +24,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
         m_nextAc3Time = 0;
         m_thdFrameOffset = 0;
     };
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
     void setTestMode(bool value) override { AC3Codec::setTestMode(value); }
     int getFreq() override { return AC3Codec::m_sample_rate; }

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -66,7 +66,7 @@ const static int AOUT_CHAN_REVERSESTEREO = 0x40000;
 
 using namespace std;
 
-int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff)
+int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -45,7 +45,7 @@ class DTSStreamReader : public SimplePacketizerReader
         m_dtsEsChannels = 0;
         m_testMode = false;
     };
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     void setDownconvertToDTS(bool value) { m_downconvertToDTS = value; }
     bool getDownconvertToDTS() { return m_downconvertToDTS; }
     DTSHD_SUBTYPE getDTSHDMode() { return m_hdType; }

--- a/tsMuxer/dvbSubStreamReader.cpp
+++ b/tsMuxer/dvbSubStreamReader.cpp
@@ -5,7 +5,7 @@
 const static uint64_t TS_FREQ_TO_INT_FREQ_COEFF = INTERNAL_PTS_FREQ / PCR_FREQUENCY;
 static const int BAD_FRAME = -1;
 
-int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff) { return 0; }
+int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
 
 uint8_t* DVBSubStreamReader::findFrame(uint8_t* buff, uint8_t* end)
 {

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -9,7 +9,7 @@ class DVBSubStreamReader : public SimplePacketizerReader
 {
    public:
     DVBSubStreamReader() : SimplePacketizerReader(), m_big_offsets(0), m_frameDuration(0), m_firstFrame(true) {}
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
 
    protected:
     unsigned getHeaderLen() override { return 10; }

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -454,8 +454,8 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
         dstBuff += 5;
 
         int video_format, frame_rate_index, aspect_ratio_index;
-        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-            &video_format, &frame_rate_index, &aspect_ratio_index);
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(),
+                                           getStreamAR(), &video_format, &frame_rate_index, &aspect_ratio_index);
 
         *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
         *dstBuff++ = (video_format << 4) + frame_rate_index;
@@ -465,7 +465,7 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
     }
     else
         for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
-            nal = NALUnit::findNextNAL(nal, m_bufEnd))
+             nal = NALUnit::findNextNAL(nal, m_bufEnd))
         {
             uint8_t nalType = *nal & 0x1f;
             if (nalType == nuSPS || nalType == nuSubSPS)

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -437,7 +437,7 @@ int H264StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVP
     return curPos - dstBuffer;
 }
 
-int H264StreamReader::getTSDescriptor(uint8_t* dstBuff)
+int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     SliceUnit slice;
     if (m_firstDecodeNal)
@@ -445,22 +445,42 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff)
         additionalStreamCheck(m_buffer, m_bufEnd);
         m_firstDecodeNal = false;
     }
+    if (isM2ts)
+    {
+        // put 'HDMV' registration descriptor
+        *dstBuff++ = 0x05;  // registration descriptor tag
+        *dstBuff++ = 8;     // descriptor length
+        memcpy(dstBuff, "HDMV\xff", 5);
+        dstBuff += 5;
 
-    // put 'HDMV' registration descriptor
-    *dstBuff++ = 0x05;  // registration descriptor tag
-    *dstBuff++ = 8;     // descriptor length
-    memcpy(dstBuff, "HDMV\xff", 5);
-    dstBuff += 5;
+        int video_format, frame_rate_index, aspect_ratio_index;
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
+            &video_format, &frame_rate_index, &aspect_ratio_index);
 
-    int video_format, frame_rate_index, aspect_ratio_index;
-    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-                                       &video_format, &frame_rate_index, &aspect_ratio_index);
+        *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
+        *dstBuff++ = (video_format << 4) + frame_rate_index;
+        *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
 
-    *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
-    *dstBuff++ = (video_format << 4) + frame_rate_index;
-    *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
+        return 10;
+    }
+    else
+        for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
+            nal = NALUnit::findNextNAL(nal, m_bufEnd))
+        {
+            uint8_t nalType = *nal & 0x1f;
+            if (nalType == nuSPS || nalType == nuSubSPS)
+            {
+                processSPS(nal);
+                dstBuff[0] = H264_DESCRIPTOR_TAG;
+                dstBuff[1] = 4;
+                dstBuff[2] = nal[1];                                       // profile
+                dstBuff[3] = nal[2];                                       // flags
+                dstBuff[4] = m_forcedLevel == 0 ? nal[3] : m_forcedLevel;  // level
+                dstBuff[5] = 0xbf;  // still present, avc_24_hour flag, Frame_Packing_SEI_not_present_flag
 
-    return 10;
+                return 6;
+            }
+        }
 }
 
 void H264StreamReader::updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen)

--- a/tsMuxer/h264StreamReader.h
+++ b/tsMuxer/h264StreamReader.h
@@ -23,7 +23,7 @@ class H264StreamReader : public MPEGStreamReader
     H264StreamReader();
     ~H264StreamReader() override;
     void setForceLevel(uint8_t value) { m_forcedLevel = value; }
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     void setH264SPSCont(bool val) { m_h264SPSCont = val; }
 

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -10,6 +10,8 @@
 using namespace std;
 
 static const int MAX_SLICE_HEADER = 64;
+static const int HEVC_DESCRIPTOR_TAG = 0x38;
+
 int V3_flags = 0;  // flags : isV3, reserved, 4K, HDR10+, SL-HDR2, DV, HDR10, SDR
 int HDR10_metadata[6] = {0, 0, 0, 0, 0, 0};
 
@@ -123,27 +125,53 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
     return rez;
 }
 
-int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff)
+int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     if (m_firstFrame)
-    {
         checkStream(m_buffer, m_bufEnd - m_buffer);
+
+    if (isM2ts)
+    {
+        // put 'HDMV' registration descriptor
+        *dstBuff++ = 0x05;  // registration descriptor tag
+        *dstBuff++ = 8;     // descriptor length
+        memcpy(dstBuff, "HDMV\xff\x24", 6);
+        dstBuff += 6;
+
+        int video_format, frame_rate_index, aspect_ratio_index;
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
+            &video_format, &frame_rate_index, &aspect_ratio_index);
+
+        *dstBuff++ = (video_format << 4) + frame_rate_index;
+        *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
+
+        return 10;
     }
+    else
+        for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
+            nal = NALUnit::findNextNAL(nal, m_bufEnd))
+        {
+            uint8_t nalType = (*nal >> 1) & 0x3f;
+            uint8_t* nextNal = NALUnit::findNALWithStartCode(nal, m_bufEnd, true);
 
-    // put 'HDMV' registration descriptor
-    *dstBuff++ = 0x05;  // registration descriptor tag
-    *dstBuff++ = 8;     // descriptor length
-    memcpy(dstBuff, "HDMV\xff\x24", 6);
-    dstBuff += 6;
+            if (nalType == NAL_SPS)
+            {
+                uint8_t tmpBuffer[512];
+                int toDecode = FFMIN(sizeof(tmpBuffer) - 8, nextNal - nal);
+                int decodedLen = NALUnit::decodeNAL(nal, nal + toDecode, tmpBuffer, sizeof(tmpBuffer));
+                *dstBuff++ = HEVC_DESCRIPTOR_TAG;
+                *dstBuff++ = 13;  // descriptor length
+                memcpy(dstBuff, tmpBuffer + 3, 12);
+                dstBuff += 12;
+                // temporal_layer_subset, HEVC_still_present, HEVC_24hr_picture_present, sub_pic_hrd_params_not_present
+                *dstBuff = 0x1c;
 
-    int video_format, frame_rate_index, aspect_ratio_index;
-    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-                                       &video_format, &frame_rate_index, &aspect_ratio_index);
+                if (V3_flags & 0x1e)
+                    *dstBuff |= 3;  // HDR & WGC (Wide Gamut Color) flags
 
-    *dstBuff++ = (video_format << 4) + frame_rate_index;
-    *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
-
-    return 10;
+                return 15;
+            }
+        }
 }
 
 void HEVCStreamReader::updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int)

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -139,8 +139,8 @@ int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
         dstBuff += 6;
 
         int video_format, frame_rate_index, aspect_ratio_index;
-        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-            &video_format, &frame_rate_index, &aspect_ratio_index);
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(),
+                                           getStreamAR(), &video_format, &frame_rate_index, &aspect_ratio_index);
 
         *dstBuff++ = (video_format << 4) + frame_rate_index;
         *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
@@ -149,7 +149,7 @@ int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
     }
     else
         for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
-            nal = NALUnit::findNextNAL(nal, m_bufEnd))
+             nal = NALUnit::findNextNAL(nal, m_bufEnd))
         {
             uint8_t nalType = (*nal >> 1) & 0x3f;
             uint8_t* nextNal = NALUnit::findNALWithStartCode(nal, m_bufEnd, true);

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -12,7 +12,7 @@ class HEVCStreamReader : public MPEGStreamReader
    public:
     HEVCStreamReader();
     ~HEVCStreamReader() override;
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool needSPSForSplit() const override { return false; }
 

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -19,7 +19,7 @@ static const uint32_t FMT_FOURCC = FOUR_CC('f', 'm', 't', ' ');
 
 using namespace wave_format;
 
-int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff)
+int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     if (m_headerType == htNone)
         if (!detectLPCMType(m_buffer, m_bufEnd - m_buffer))

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -32,7 +32,7 @@ class LPCMStreamReader : public SimplePacketizerReader
         m_lastChannelRemapPos = 0;
     }
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     int getFreq() override { return m_freq; }
     int getChannels() override { return m_channels; }
     // void setDemuxMode(bool value) {m_demuxMode = value;}

--- a/tsMuxer/mpeg2StreamReader.cpp
+++ b/tsMuxer/mpeg2StreamReader.cpp
@@ -8,7 +8,7 @@
 #include "vodCoreException.h"
 #include "vod_common.h"
 
-int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff)
+int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     try
     {

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -21,7 +21,7 @@ class MPEG2StreamReader : public MPEGStreamReader
         m_longCodesAllowed = false;
         m_prevFrameDelay = 0;
     }
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 
     int getStreamWidth() const override { return m_sequence.width; }

--- a/tsMuxer/mpegAudioStreamReader.cpp
+++ b/tsMuxer/mpegAudioStreamReader.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff)
+int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -9,7 +9,7 @@ class MpegAudioStreamReader : public SimplePacketizerReader, MP3Codec
    public:
     const static uint32_t DTS_HD_PREFIX = 0x64582025;
     MpegAudioStreamReader() : SimplePacketizerReader() {}
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     int getLayer() { return m_layer; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return 2; }

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -40,7 +40,7 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
 {
     codecReader->setDemuxMode(true);
     uint8_t descrBuffer[188];
-    int descriptorLen = codecReader->getTSDescriptor(descrBuffer);
+    int descriptorLen = codecReader->getTSDescriptor(descrBuffer, true);
     string fileExt = "track";
     if (codecName == "A_AC3")
         fileExt = ".ac3";

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -160,7 +160,7 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     int descriptorLen = 0;
     uint8_t descrBuffer[1024];
     if (codecReader != 0)
-        descriptorLen = codecReader->getTSDescriptor(descrBuffer);
+        descriptorLen = codecReader->getTSDescriptor(descrBuffer, m_m2tsMode);
 
     if (codecName[0] == 'V')
         m_mainStreamIndex = streamIndex;
@@ -680,16 +680,6 @@ void TSMuxer::writePATPMT(int64_t pcr, bool force)
 {
     if (pcr == -1 || pcr - m_lastPMTPCR >= m_patPmtDelta || force)
     {
-        if (!m_m2tsMode && m_lastPMTPCR == -1)
-        {
-            for (int k = 0; k < 15; k++)
-            {
-                writePAT();
-                writePMT();
-                writeSIT();
-            }
-        }
-
         m_lastPMTPCR = pcr != -1 ? pcr : m_fixed_pcr_offset;
         writePAT();
         writePMT();
@@ -1196,7 +1186,7 @@ void TSMuxer::buildPMT()
     tsPacket->setPID(DEFAULT_PMT_PID);
     tsPacket->dataExists = 1;
     tsPacket->payloadStart = 1;
-    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, !m_bluRayMode);
+    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, !m_bluRayMode, m_m2tsMode);
     uint8_t* pmtEnd = m_pmtBuffer + TSPacket::TS_HEADER_SIZE + size;
     uint8_t* curPos = m_pmtBuffer + TS_FRAME_SIZE;
     for (; curPos < pmtEnd; curPos += TS_FRAME_SIZE)

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -463,13 +463,13 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
         bitWriter.putBits(8, itr->second.m_streamType);
         bitWriter.putBits(3, 7);  // reserved
         bitWriter.putBits(13, itr->second.m_pid);
-        // video stream, non Blu-ray mode and Dolby Vision flag => write DoVi descriptors
         
         uint16_t* esInfoLen = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
         bitWriter.putBits(4, 15);  // reserved
         bitWriter.putBits(12, 0);  // es_info_len
         int beforeCount = bitWriter.getBitsCount() / 8;
-
+        
+        // video stream, non Blu-ray mode and Dolby Vision flag => write DoVi descriptors
         bool insertDoVi = (itr->second.m_pid >> 4 == 0x101) && !isM2ts && (V3_flags & 0x04);
         if (insertDoVi)
         {

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -376,13 +376,10 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
 {
     buffer[0] = 0;
     buffer++;
-    // PutBitContext pBitContext;
-    // init_bitWriter.putBits( buffer, max_buf_size*8);
     BitStreamWriter bitWriter;
     bitWriter.setBuffer(buffer, buffer + max_buf_size);
-
-    // bitWriter.putBits( 8, 0);
     bitWriter.putBits(8, 2);  // table id
+    
     uint16_t* LengthPos1 = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
     bitWriter.putBits(2, 2);   // indicator
     bitWriter.putBits(2, 3);   // reserved
@@ -396,7 +393,6 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
     bitWriter.putBits(16, 0);        // section_number and last_section_number
     bitWriter.putBits(3, 7);         // reserved
     bitWriter.putBits(13, pcr_pid);  // reserved
-    bitWriter.putBits(4, 15);        // reserved
 
     uint16_t* LengthPos2 = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
     bitWriter.putBits(4, 15);  // reserved

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -379,7 +379,7 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
     BitStreamWriter bitWriter;
     bitWriter.setBuffer(buffer, buffer + max_buf_size);
     bitWriter.putBits(8, 2);  // table id
-    
+
     uint16_t* LengthPos1 = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
     bitWriter.putBits(2, 2);   // indicator
     bitWriter.putBits(2, 3);   // reserved
@@ -463,12 +463,12 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
         bitWriter.putBits(8, itr->second.m_streamType);
         bitWriter.putBits(3, 7);  // reserved
         bitWriter.putBits(13, itr->second.m_pid);
-        
+
         uint16_t* esInfoLen = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
         bitWriter.putBits(4, 15);  // reserved
         bitWriter.putBits(12, 0);  // es_info_len
         int beforeCount = bitWriter.getBitsCount() / 8;
-        
+
         // video stream, non Blu-ray mode and Dolby Vision flag => write DoVi descriptors
         bool insertDoVi = (itr->second.m_pid >> 4 == 0x101) && !isM2ts && (V3_flags & 0x04);
         if (insertDoVi)
@@ -513,17 +513,17 @@ void TS_program_map_section::setDoViDescriptor(BitStreamWriter& bitWriter, int P
     bitWriter.putBits(8, 0x56);  // 'V'
     bitWriter.putBits(8, 0x49);  // 'I'
 
-    bitWriter.putBits(8, 0xb0);           // DoVi descriptor tag
+    bitWriter.putBits(8, 0xb0);             // DoVi descriptor tag
     bitWriter.putBits(8, isDV_EL ? 6 : 4);  // Length
-    bitWriter.putBits(8, 1);              // dv version major
-    bitWriter.putBits(8, 0);              // dv version minor
-    bitWriter.putBits(7, (HDR10 ? (PID == 0x1011 ? 7 : (isDV_EL ? 7 : 8)) :
-                                  (PID == 0x1011 ? 4 : (isDV_EL ? 4 : 5))));    // profile
-    bitWriter.putBits(6, 6);                                                    // dv level
-    bitWriter.putBits(1, PID == 0x1011 ? 0 : 1);                                // rpu_present_flag
-    bitWriter.putBits(1, PID == 0x1011 ? 0 : (isDV_EL ? 1 : 0));                // el_present_flag
-    bitWriter.putBits(1, PID == 0x1011 ? 1 : (isDV_EL ? 0 : 1));                // bl_present_flag
-    if (isDV_EL)                                                                // Enhancement Layer
+    bitWriter.putBits(8, 1);                // dv version major
+    bitWriter.putBits(8, 0);                // dv version minor
+    bitWriter.putBits(
+        7, (HDR10 ? (PID == 0x1011 ? 7 : (isDV_EL ? 7 : 8)) : (PID == 0x1011 ? 4 : (isDV_EL ? 4 : 5))));  // profile
+    bitWriter.putBits(6, 6);                                                                              // dv level
+    bitWriter.putBits(1, PID == 0x1011 ? 0 : 1);                  // rpu_present_flag
+    bitWriter.putBits(1, PID == 0x1011 ? 0 : (isDV_EL ? 1 : 0));  // el_present_flag
+    bitWriter.putBits(1, PID == 0x1011 ? 1 : (isDV_EL ? 0 : 1));  // bl_present_flag
+    if (isDV_EL)                                                  // Enhancement Layer
     {
         bitWriter.putBits(13, 0x1011);  // dependency_pid
         bitWriter.putBits(3, 7);        // reserved

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -372,7 +372,7 @@ void TS_program_map_section::extractDescriptors(uint8_t* curPos, int es_info_len
     }
 }
 
-uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bool addLang)
+uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bool addLang, bool isM2ts)
 {
     buffer[0] = 0;
     buffer++;
@@ -383,22 +383,11 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
 
     // bitWriter.putBits( 8, 0);
     bitWriter.putBits(8, 2);  // table id
-    bitWriter.putBits(2, 2);  // indicator
-    bitWriter.putBits(2, 3);  // reserved
-
-    int program_info_len = 12;
-    if (casPID)
-        program_info_len += 6;
-
-    int sectionLen =
-        9 + (video_pid ? 5 : 0) + (audio_pid ? 5 : 0) + (sub_pid ? 5 : 0) + (pidList.size() * 5) + 4 + program_info_len;
-    for (PIDListMap::const_iterator itr = pidList.begin(); itr != pidList.end(); ++itr)
-    {
-        sectionLen += itr->second.m_esInfoLen;
-        if (*itr->second.m_lang && addLang)
-            sectionLen += 6;  // lang descriptor len
-    }
-    bitWriter.putBits(12, sectionLen);  // reserved
+    uint16_t* LengthPos1 = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
+    bitWriter.putBits(2, 2);   // indicator
+    bitWriter.putBits(2, 3);   // reserved
+    bitWriter.putBits(12, 0);  // skip lengthField
+    int beforeCount1 = bitWriter.getBitsCount() / 8;
 
     bitWriter.putBits(16, program_number);
     bitWriter.putBits(2, 3);         // reserved
@@ -409,25 +398,30 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
     bitWriter.putBits(13, pcr_pid);  // reserved
     bitWriter.putBits(4, 15);        // reserved
 
-    bitWriter.putBits(12, program_info_len);  // program info len
-    // 88 04 0f ff 84 fc 05 04 48 44 4d 56
+    uint16_t* LengthPos2 = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
+    bitWriter.putBits(4, 15);  // reserved
+    bitWriter.putBits(12, 0);  // program info len
+    int beforeCount2 = bitWriter.getBitsCount() / 8;
 
-    // put 'HDMV' registration descriptor
-    bitWriter.putBits(8, 0x05);
-    bitWriter.putBits(8, 0x04);
-    bitWriter.putBits(8, 0x48);
-    bitWriter.putBits(8, 0x44);
-    bitWriter.putBits(8, 0x4d);
-    bitWriter.putBits(8, 0x56);
+    if (isM2ts)
+    {
+        // put 'HDMV' registration descriptor
+        bitWriter.putBits(8, 0x05);
+        bitWriter.putBits(8, 0x04);
+        bitWriter.putBits(8, 0x48);
+        bitWriter.putBits(8, 0x44);
+        bitWriter.putBits(8, 0x4d);
+        bitWriter.putBits(8, 0x56);
 
-    // put DTCP descriptor
-    bitWriter.putBits(8, 0x88);
-    bitWriter.putBits(8, 0x04);
-    bitWriter.putBits(8, 0x0f);
-    bitWriter.putBits(8, 0xff);
-    bitWriter.putBits(
-        8, 0xfc);  // scenarist: 0xfc, prev example: 0x84          here               1 0 000 1 00 1 1 111 1 00
-    bitWriter.putBits(8, 0xfc);
+        // put DTCP descriptor
+        bitWriter.putBits(8, 0x88);
+        bitWriter.putBits(8, 0x04);
+        bitWriter.putBits(8, 0x0f);
+        bitWriter.putBits(8, 0xff);
+        bitWriter.putBits(
+            8, 0xfc);  // scenarist: 0xfc, prev example: 0x84          here               1 0 000 1 00 1 1 111 1 00
+        bitWriter.putBits(8, 0xfc);
+    }
 
     if (casPID)
     {
@@ -437,6 +431,7 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
         bitWriter.putBits(16, casID);
         bitWriter.putBits(16, casPID);
     }
+    *LengthPos2 = my_htons(0xf000 + bitWriter.getBitsCount() / 8 - beforeCount2);
 
     if (video_pid)
     {
@@ -466,15 +461,30 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
         bitWriter.putBits(12, 0);  // es_info_len
     }
 
+    int isDV_EL = false;  // DoVi Enhancement Layer
     for (PIDListMap::const_iterator itr = pidList.begin(); itr != pidList.end(); ++itr)
     {
         bitWriter.putBits(8, itr->second.m_streamType);
         bitWriter.putBits(3, 7);  // reserved
         bitWriter.putBits(13, itr->second.m_pid);
-        bitWriter.putBits(4, 15);                                                                   // reserved
-        bitWriter.putBits(12, itr->second.m_esInfoLen + (*itr->second.m_lang && addLang ? 6 : 0));  // es_info_len
+        // video stream, non Blu-ray mode and Dolby Vision flag => write DoVi descriptors
+        
+        uint16_t* esInfoLen = (uint16_t*)(bitWriter.getBuffer() + bitWriter.getBitsCount() / 8);
+        bitWriter.putBits(4, 15);  // reserved
+        bitWriter.putBits(12, 0);  // es_info_len
+        int beforeCount = bitWriter.getBitsCount() / 8;
+
+        bool insertDoVi = (itr->second.m_pid >> 4 == 0x101) && !isM2ts && (V3_flags & 0x04);
+        if (insertDoVi)
+        {
+            setDoViDescriptor(bitWriter, itr->second.m_pid, isDV_EL);
+            if (itr->second.m_pid == 0x1011)
+                isDV_EL = true;
+        }
+
         for (int j = 0; j < itr->second.m_esInfoLen; j++)
             bitWriter.putBits(8, itr->second.m_esInfoData[j]);  // es_info_len
+
         if (*itr->second.m_lang && addLang)
         {
             bitWriter.putBits(8, TS_LANG_DESCRIPTOR_TAG);                             // lang descriptor ID
@@ -482,8 +492,9 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
             for (int k = 0; k < 3; k++) bitWriter.putBits(8, itr->second.m_lang[k]);  // lang code[i]
             bitWriter.putBits(8, 0);
         }
+        *esInfoLen = my_htons(0xf000 + bitWriter.getBitsCount() / 8 - beforeCount);
     }
-
+    *LengthPos1 = my_htons(0xb000 + bitWriter.getBitsCount() / 8 - beforeCount1 + 4);
     bitWriter.flushBits();
 
     // uint32_t crc = av_crc(tmpAvCrc, 0xffffffff, buffer, bitWriter.getBitsCount()/8);
@@ -492,10 +503,35 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
     uint32_t* crcPtr = (uint32_t*)(buffer + bitWriter.getBitsCount() / 8);
     *crcPtr = my_htonl(crc);
 
-    // bitWriter.putBits( 32, my_htonl(crc));
-    // flush_put_bits(&pBitContext);
-    // return put_bits_count(&pBitContext)/8 + 1;
     return bitWriter.getBitsCount() / 8 + 5;
+}
+
+void TS_program_map_section::setDoViDescriptor(BitStreamWriter& bitWriter, int PID, bool isDV_EL)
+{
+    int HDR10 = V3_flags & 0x02;
+
+    bitWriter.putBits(8, 5);     // Registration descriptor tag
+    bitWriter.putBits(8, 4);     // Length
+    bitWriter.putBits(8, 0x44);  // 'D'
+    bitWriter.putBits(8, 0x4f);  // 'O'
+    bitWriter.putBits(8, 0x56);  // 'V'
+    bitWriter.putBits(8, 0x49);  // 'I'
+
+    bitWriter.putBits(8, 0xb0);           // DoVi descriptor tag
+    bitWriter.putBits(8, isDV_EL ? 6 : 4);  // Length
+    bitWriter.putBits(8, 1);              // dv version major
+    bitWriter.putBits(8, 0);              // dv version minor
+    bitWriter.putBits(7, (HDR10 ? (PID == 0x1011 ? 7 : (isDV_EL ? 7 : 8)) :
+                                  (PID == 0x1011 ? 4 : (isDV_EL ? 4 : 5))));    // profile
+    bitWriter.putBits(6, 6);                                                    // dv level
+    bitWriter.putBits(1, PID == 0x1011 ? 0 : 1);                                // rpu_present_flag
+    bitWriter.putBits(1, PID == 0x1011 ? 0 : (isDV_EL ? 1 : 0));                // el_present_flag
+    bitWriter.putBits(1, PID == 0x1011 ? 1 : (isDV_EL ? 0 : 1));                // bl_present_flag
+    if (isDV_EL)                                                                // Enhancement Layer
+    {
+        bitWriter.putBits(13, 0x1011);  // dependency_pid
+        bitWriter.putBits(3, 7);        // reserved
+    }
 }
 
 // --------------------- CLPIParser -----------------------------

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -257,11 +257,12 @@ struct TS_program_map_section
     TS_program_map_section();
     bool deserialize(uint8_t* buffer, int buf_size);
     static bool isFullBuff(uint8_t* buffer, int buf_size);
-    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool addLang = true);
+    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool addLang, bool isM2ts);
 
    private:
     void extractDescriptors(uint8_t* curPos, int es_info_len, PMTStreamInfo& pmtInfo);
     void extractPMTDescriptors(uint8_t* curPos, int es_info_len);
+    void setDoViDescriptor(BitStreamWriter& bitWriter, int PID, bool isDV_EL);
     // uint32_t tmpAvCrc[257];
 };
 

--- a/tsMuxer/vc1StreamReader.cpp
+++ b/tsMuxer/vc1StreamReader.cpp
@@ -50,7 +50,7 @@ int VC1StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
     return (int)(curPtr - dstBuffer);  // afterPesData;
 }
 
-int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff)
+int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
     for (uint8_t* nal = VC1Unit::findNextMarker(m_buffer, m_bufEnd); nal <= m_bufEnd - 32;
          nal = VC1Unit::findNextMarker(nal + 4, m_bufEnd))

--- a/tsMuxer/vc1StreamReader.h
+++ b/tsMuxer/vc1StreamReader.h
@@ -21,7 +21,7 @@ class VC1StreamReader : public MPEGStreamReader
         m_nextFrameAddr = 0;
     }
     ~VC1StreamReader() override {}
-    int getTSDescriptor(uint8_t* dstBuff) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool skipNal(uint8_t* nal) override;
     bool needSPSForSplit() const override { return true; }


### PR DESCRIPTION
Sets specific .ts file descriptors for AVC and HEVC as per T-REC-H-222.0.
Include DOVI descriptor for Dolby Vision as per [Dolby document](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2.pdf).
HDMV descriptors are reserved for .m2ts files.