### PR TITLE
Keep track order on insertion

### DIFF
--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -84,6 +84,8 @@ if (PkgConfig_FOUND)
   if (NOT WIN32)
     pkg_check_modules_with_static (FREETYPE2 REQUIRED freetype2)
   endif()
+else()
+  find_package(ZLIB REQUIRED)
 endif()
 
 target_include_directories(tsmuxer PRIVATE

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -659,13 +659,7 @@ DetectStreamRez METADemuxer::DetectStreamReader(BufferedReaderManager& readManag
                     trackRez.isSecondary = true;
             }
 
-            if (trackRez.codecInfo.programName == "V_MS/VFW/WVC1" || trackRez.codecInfo.programName == "V_MPEG-2" ||
-                trackRez.codecInfo.programName == "V_MPEG4/ISO/AVC" ||
-                trackRez.codecInfo.programName == "V_MPEG4/ISO/MVC" ||
-                trackRez.codecInfo.programName == "V_MPEGH/ISO/HEVC")
-                addTrack(streams, trackRez, true);
-            else
-                addTrack(streams, trackRez, false);
+            addTrack(streams, trackRez);
         }
         chapters = demuxer->getChapters();
         if (calcDuration)
@@ -689,7 +683,7 @@ DetectStreamRez METADemuxer::DetectStreamReader(BufferedReaderManager& readManag
             containerType = AbstractStreamReader::ctSRT;
         CheckStreamRez trackRez = detectTrackReader(tmpBuffer, len, containerType, 0, 0);
 
-        addTrack(streams, trackRez, false);
+        addTrack(streams, trackRez);
 
         delete[] tmpBuffer;
     }
@@ -700,32 +694,23 @@ DetectStreamRez METADemuxer::DetectStreamReader(BufferedReaderManager& readManag
     return rez;
 }
 
-void METADemuxer::addTrack(vector<CheckStreamRez>& rez, CheckStreamRez trackRez, bool insToBegin)
+void METADemuxer::addTrack(vector<CheckStreamRez>& rez, CheckStreamRez trackRez)
 {
     if (trackRez.codecInfo.codecID == h264DepCodecInfo.codecID && trackRez.multiSubStream)
     {
         // split combined MVC/AVC track to substreams
-        if (insToBegin)
-            rez.insert(rez.begin(), trackRez);
-        else
-            rez.push_back(trackRez);
+        rez.push_back(trackRez);
 
         trackRez.codecInfo = h264CodecInfo;
         int postfixPos = trackRez.streamDescr.find("3d-pg");
         if (postfixPos != string::npos)
             trackRez.streamDescr = trackRez.streamDescr.substr(0, postfixPos);
 
-        if (insToBegin)
-            rez.insert(rez.begin() + 1, trackRez);
-        else
-            rez.push_back(trackRez);
+        rez.push_back(trackRez);
     }
     else
     {
-        if (insToBegin)
-            rez.insert(rez.begin(), trackRez);
-        else
-            rez.push_back(trackRez);
+        rez.push_back(trackRez);
     }
 }
 

--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -217,7 +217,7 @@ class METADemuxer : public AbstractDemuxer
 
     int addPGSubStream(const std::string& codec, const std::string& _codecStreamName,
                        const std::map<std::string, std::string>& addParams, MPLSStreamInfo* subStream);
-    static void addTrack(std::vector<CheckStreamRez>& rez, CheckStreamRez trackRez, bool insToBegin);
+    static void addTrack(std::vector<CheckStreamRez>& rez, CheckStreamRez trackRez);
     std::vector<MPLSPlayItem> mergePlayItems(const std::vector<MPLSParser>& mplsInfoList);
 };
 

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -2708,6 +2708,7 @@ void TsMuxerWindow::writeSettings()
     settings->setValue("hdmvPES", ui->checkBoxNewAudioPes->isChecked());
     if (ui->checkBoxCrop->isEnabled())
         settings->setValue("restoreCropEnabled", ui->checkBoxCrop->isChecked());
+    settings->setValue("inputDir", lastInputDir);
     settings->setValue("outputDir", lastOutputDir);
     settings->setValue("useBlankPL", ui->checkBoxBlankPL->isChecked());
     settings->setValue("blankPLNum", ui->BlackplaylistCombo->value());
@@ -2789,15 +2790,14 @@ bool TsMuxerWindow::readSettings()
 bool TsMuxerWindow::readGeneralSettings(const QString &prefix)
 {
     settings->beginGroup(prefix);
-
-    QString outputDir = settings->value("outputDir").toString();
-    if (!outputDir.isEmpty())
-        lastOutputDir = outputDir;
-    else
+    if (!settings->contains("outputDir"))
     {
         settings->endGroup();
         return false;
     }
+
+    lastInputDir = settings->value("inputDir").toString();
+    lastOutputDir = settings->value("outputDir").toString();
 
     // ui->checkBoxuseAsynIO->setChecked(settings->value("asyncIO").toBool());
     ui->checkBoxSound->setChecked(settings->value("soundEnabled").toBool());


### PR DESCRIPTION
When a file with multiple video tracks is added (e.g. with Dolby Vision), tsMuxer swaps the order of the video tracks in the output.
This change, prevents such behavior and maintains the order of the inserted tracks.