### PR TITLE
Fix reading MP4 (bug from #205)

### DIFF
--- a/tsMuxer/movDemuxer.h
+++ b/tsMuxer/movDemuxer.h
@@ -61,6 +61,7 @@ class MovDemuxer : public IOContextDemuxer
     bool found_moof;
     int64_t m_mdat_pos;
     int64_t m_mdat_size;
+    uint64_t m_fileSize;
     std::vector<std::pair<int64_t, uint64_t>> m_mdat_data;
     int itunes_metadata;  ///< metadata are itunes style
     int64_t moof_offset;


### PR DESCRIPTION
With patch #205, tsMuxer is reading over the end of the mp4 file, which results in erratic behavior -Visual Studio build works correctly, but cmake build does not.

This fix allows to stop the reading of the mp4 file at the last atom, before end of file.