### PR TITLE
Don't use POSIX APIs in Windows builds

### DIFF
--- a/libmediation/fs/directory.cpp
+++ b/libmediation/fs/directory.cpp
@@ -1,12 +1,13 @@
 
 #include "directory.h"
-#include "file.h"
 
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <sstream>
+
+#include "file.h"
 
 #ifdef _WIN32
 #include <windows.h>

--- a/libmediation/fs/directory.cpp
+++ b/libmediation/fs/directory.cpp
@@ -1,5 +1,6 @@
 
 #include "directory.h"
+#include "file.h"
 
 #include <errno.h>
 #include <sys/stat.h>
@@ -45,30 +46,33 @@ string extractFileDir(const string& fileName)
 
 bool fileExists(const string& fileName)
 {
-    bool fileExists = false;
 #ifdef _WIN32
-    struct _stat64 buf;
-    fileExists = _stat64(fileName.c_str(), &buf) == 0;
+    File f;
+    return f.open(fileName.c_str(), File::ofRead | File::ofOpenExisting);
 #else
     struct stat64 buf;
-    fileExists = stat64(fileName.c_str(), &buf) == 0;
+    return stat64(fileName.c_str(), &buf) == 0;
 #endif
-
-    return fileExists;
 }
 
 uint64_t getFileSize(const std::string& fileName)
 {
-    bool res = false;
 #ifdef _WIN32
-    struct _stat64 fileStat;
-    res = _stat64(fileName.c_str(), &fileStat) == 0;
+    File f;
+    if (f.open(fileName.c_str(), File::ofRead | File::ofOpenExisting))
+    {
+        uint64_t rv;
+        return f.size(&rv) ? rv : 0;
+    }
+    else
+    {
+        return 0;
+    }
 #else
     struct stat64 fileStat;
-    res = stat64(fileName.c_str(), &fileStat) == 0;
+    auto res = stat64(fileName.c_str(), &fileStat) == 0;
+    return res ? static_cast<uint64_t>(fileStat.st_size) : 0;
 #endif
-
-    return res ? (uint64_t)fileStat.st_size : 0;
 }
 
 bool createDir(const std::string& dirName, bool createParentDirs)

--- a/libmediation/fs/osdep/file_win32.cpp
+++ b/libmediation/fs/osdep/file_win32.cpp
@@ -100,7 +100,10 @@ bool File::open(const char* fName, unsigned int oflag, unsigned int systemDepend
             systemDependentFlags = FILE_FLAG_RANDOM_ACCESS;
     }
 
-    createDir(extractFileDir(fName), true);
+    if ((oflag & File::ofOpenExisting) == 0)
+    {
+        createDir(extractFileDir(fName), true);
+    }
     m_impl = CreateFile(toWide(fName).data(), dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition,
                         systemDependentFlags, NULL);
     if (m_impl == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
The POSIX compatibility layer provided by the Microsoft C Runtime Library
treats its string arguments as if they were passed to the A-family of WinAPI
functions, which means that they undergo conversion to the ACP before being
passed to the actual WinAPI call. Passing UTF-8 encoded strings could have
never really worked.
Fixes #209.