### PR TITLE
[bug]Fix subtitle timestamp

### DIFF
--- a/tsMuxer/tsDemuxer.cpp
+++ b/tsMuxer/tsDemuxer.cpp
@@ -243,6 +243,7 @@ int TSDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& accepted
             m_prevFileLen += (m_lastPTS - m_firstPTS);
         m_firstPTS = -1;
         m_lastPTS = -1;
+        m_firstVideoPTS = -1;
         m_curFileNum++;
     }
 


### PR DESCRIPTION
When joining several m2ts together (either in a mpls or manually), tsMuxer takes into consideration the start-time of the first file only.
This results in an incorrect subtitle start time when the m2ts don't all have the same start-time.

The bug has been reported e.g. [here](https://forum.doom9.org/showthread.php?p=1768965#post1768965) and [here](https://forum.doom9.org/showthread.php?p=1881372#post1881372).

This simple fix solves this bug.

