### PR TITLE
[bug]Incorrect subtitle space in Windows

### DIFF
--- a/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
@@ -146,7 +146,7 @@ void TextSubtitlesRenderWin32::getTextSize(const std::wstring& text, SIZE* mSize
     RectF rect;
     Pen pen(Color(0x30, 0, 0, 0), m_font.m_borderWidth * 2);
     pen.SetLineJoin(LineJoinRound);
-    path.GetBounds(&rect, 0, 0);
+    path.GetBounds(&rect, 0, &pen);
     mSize->cx = rect.Width;
     mSize->cy = lineSpacingPixel;
 #endif


### PR DESCRIPTION
The font space between regular and italics is incorrect, simply because the pen object was not passed to the GDI+ 'GetBound' class !

The bug was reported e.g. [here](https://forum.doom9.org/showthread.php?p=1752780#post1752780) and [here](https://forum.doom9.org/showthread.php?p=1898949#post1898949).


