### PR TITLE
Enable translation in GUI

### DIFF
--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(Qt5 COMPONENTS Widgets Multimedia LinguistTools REQUIRED)
 set(lang_qrc "translations.qrc")
 configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
 qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
-qt5_add_resources(QM_COMPILED_FILES ${CMAKE_CURRENT_BINARY_DIR}/${lang_qrc})
 
 set(tsmuxer_gui_sources
   main.cpp
@@ -25,7 +24,7 @@ set(tsmuxer_gui_sources
   checkboxedheaderview.cpp
   images.qrc
   ${QM_FILES}
-  ${QM_COMPILED_FILES}
+  ${CMAKE_CURRENT_BINARY_DIR}/${lang_qrc}
 )
 
 add_executable(tsMuxerGUI ${tsmuxer_gui_sources})

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -21,7 +21,7 @@ set(tsmuxer_gui_sources
   images.qrc
 )
 
-qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts)
+qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
 
 add_executable(tsMuxerGUI ${tsmuxer_gui_sources} ${QM_FILES})
 target_link_libraries(tsMuxerGUI Qt5::Widgets Qt5::Multimedia)

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Qt5 COMPONENTS Widgets Multimedia LinguistTools REQUIRED)
 
 set(lang_qrc "translations.qrc")
 configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
-qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
+qt5_add_translation(QM_FILES translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
 
 set(tsmuxer_gui_sources
   main.cpp

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Qt5 COMPONENTS Widgets Multimedia LinguistTools REQUIRED)
 
 set(lang_qrc "translations.qrc")
 configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
+# create_translation is not used due to QTBUG-41736
 qt5_add_translation(QM_FILES translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
 
 set(tsmuxer_gui_sources

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -11,6 +11,11 @@ endif()
 
 find_package(Qt5 COMPONENTS Widgets Multimedia LinguistTools REQUIRED)
 
+set(lang_qrc "translations.qrc")
+configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
+qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
+qt5_add_resources(QM_COMPILED_FILES ${CMAKE_CURRENT_BINARY_DIR}/${lang_qrc})
+
 set(tsmuxer_gui_sources
   main.cpp
   tsmuxerwindow.cpp
@@ -19,11 +24,11 @@ set(tsmuxer_gui_sources
   muxForm.ui
   checkboxedheaderview.cpp
   images.qrc
+  ${QM_FILES}
+  ${QM_COMPILED_FILES}
 )
 
-qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts)
-
-add_executable(tsMuxerGUI ${tsmuxer_gui_sources} ${QM_FILES})
+add_executable(tsMuxerGUI ${tsmuxer_gui_sources})
 target_link_libraries(tsMuxerGUI Qt5::Widgets Qt5::Multimedia)
 
 if (WIN32)

--- a/tsMuxerGUI/main.cpp
+++ b/tsMuxerGUI/main.cpp
@@ -8,13 +8,6 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
-    QTranslator tsMuxerTranslator;
-    tsMuxerTranslator.load(QLocale::system(), "tsmuxergui_", "", ":/i18n");
-    app.installTranslator(&tsMuxerTranslator);
-    QTranslator qtCoreTranslator;
-    qtCoreTranslator.load(QLocale::system(), "qtbase_", "", QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-    app.installTranslator(&qtCoreTranslator);
-
     TsMuxerWindow win;
     win.show();
     QList<QUrl> files;

--- a/tsMuxerGUI/main.cpp
+++ b/tsMuxerGUI/main.cpp
@@ -1,12 +1,20 @@
 #include <QApplication>
+#include <QLibraryInfo>
+#include <QTranslator>
 #include <QUrl>
 
 #include "tsmuxerwindow.h"
 
 int main(int argc, char *argv[])
 {
-    Q_INIT_RESOURCE(images);
     QApplication app(argc, argv);
+    QTranslator tsMuxerTranslator;
+    tsMuxerTranslator.load(QLocale::system(), "tsmuxergui_", "", ":/i18n");
+    app.installTranslator(&tsMuxerTranslator);
+    QTranslator qtCoreTranslator;
+    qtCoreTranslator.load(QLocale::system(), "qtbase_", "", QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    app.installTranslator(&qtCoreTranslator);
+
     TsMuxerWindow win;
     win.show();
     QList<QUrl> files;

--- a/tsMuxerGUI/main.cpp
+++ b/tsMuxerGUI/main.cpp
@@ -1,6 +1,4 @@
 #include <QApplication>
-#include <QLibraryInfo>
-#include <QTranslator>
 #include <QUrl>
 
 #include "tsmuxerwindow.h"

--- a/tsMuxerGUI/muxForm.cpp
+++ b/tsMuxerGUI/muxForm.cpp
@@ -21,6 +21,15 @@ void MuxForm::closeEvent(QCloseEvent *event)
     event->accept();
 }
 
+void MuxForm::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange)
+    {
+        ui->retranslateUi(this);
+    }
+    QDialog::changeEvent(event);
+}
+
 void MuxForm::prepare(const QString &label)
 {
     muxProcess = 0;

--- a/tsMuxerGUI/muxForm.h
+++ b/tsMuxerGUI/muxForm.h
@@ -19,6 +19,7 @@ class MuxForm : public QDialog  // QWidget
 
    protected:
     void closeEvent(QCloseEvent* event) override;
+    void changeEvent(QEvent* event) override;
    private slots:
     void onProgressChanged();
     void onAbort();

--- a/tsMuxerGUI/muxForm.ui
+++ b/tsMuxerGUI/muxForm.ui
@@ -136,7 +136,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="layoutWidget" >
+        <widget class="QWidget" name="layoutWidget1" >
          <layout class="QVBoxLayout" name="verticalLayout_4" >
           <item>
            <widget class="QLabel" name="label_4" >

--- a/tsMuxerGUI/translations.qrc
+++ b/tsMuxerGUI/translations.qrc
@@ -1,0 +1,6 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="i18n">
+<file alias="tsmuxergui_en.qm">tsmuxergui_en.qm</file>
+<file alias="tsmuxergui_ru.qm">tsmuxergui_ru.qm</file>
+</qresource>
+</RCC>

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -4,32 +4,32 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../muxForm.cpp" line="39"/>
+        <location filename="../muxForm.cpp" line="48"/>
         <source>Progress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="62"/>
+        <location filename="../muxForm.cpp" line="71"/>
         <source>Too many errors! tsMuxeR is terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="75"/>
+        <location filename="../muxForm.cpp" line="84"/>
         <source>tsMuxeR successfully finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="77"/>
+        <location filename="../muxForm.cpp" line="86"/>
         <source>tsMuxeR finished with error code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="90"/>
+        <location filename="../muxForm.cpp" line="99"/>
         <source>terminating tsMuxeR...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="93"/>
+        <location filename="../muxForm.cpp" line="102"/>
         <source>tsMuxeR is terminated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -758,7 +758,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2763"/>
-        <location filename="../tsmuxerwindow.cpp" line="1400"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Demux</source>
         <translation type="unfinished"></translation>
     </message>
@@ -769,7 +769,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2797"/>
-        <location filename="../tsmuxerwindow.cpp" line="2346"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -784,167 +784,167 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2909"/>
-        <location filename="../tsmuxerwindow.cpp" line="2332"/>
+        <location filename="../tsmuxerwindow.ui" line="2929"/>
+        <location filename="../tsmuxerwindow.cpp" line="2350"/>
         <source>Sta&amp;rt muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2928"/>
+        <location filename="../tsmuxerwindow.ui" line="2948"/>
         <source>Save meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="531"/>
+        <location filename="../tsmuxerwindow.cpp" line="534"/>
         <source>Not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="597"/>
-        <location filename="../tsmuxerwindow.cpp" line="1114"/>
+        <location filename="../tsmuxerwindow.cpp" line="600"/>
+        <location filename="../tsmuxerwindow.cpp" line="1117"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="598"/>
+        <location filename="../tsmuxerwindow.cpp" line="601"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="868"/>
+        <location filename="../tsmuxerwindow.cpp" line="871"/>
         <source>Add media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="908"/>
         <source>File already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="906"/>
+        <location filename="../tsmuxerwindow.cpp" line="909"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1119"/>
+        <location filename="../tsmuxerwindow.cpp" line="1122"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1130"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1400"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Mux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.cpp" line="1422"/>
         <source>tsMuxeR error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1423"/>
+        <location filename="../tsmuxerwindow.cpp" line="1426"/>
         <source>tsMuxeR not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1441"/>
+        <location filename="../tsmuxerwindow.cpp" line="1444"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2186"/>
-        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2204"/>
+        <location filename="../tsmuxerwindow.cpp" line="2205"/>
         <source>No track selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
+        <location filename="../tsmuxerwindow.cpp" line="2212"/>
         <source>Append media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2231"/>
+        <location filename="../tsmuxerwindow.cpp" line="2249"/>
         <source>Invalid file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2232"/>
+        <location filename="../tsmuxerwindow.cpp" line="2250"/>
         <source>Appended file must have same file extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2348"/>
         <source>Sta&amp;rt demuxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2342"/>
+        <location filename="../tsmuxerwindow.cpp" line="2360"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2432"/>
+        <location filename="../tsmuxerwindow.cpp" line="2450"/>
         <source>Select file for muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2454"/>
-        <location filename="../tsmuxerwindow.cpp" line="2470"/>
+        <location filename="../tsmuxerwindow.cpp" line="2472"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>Invalid file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2455"/>
+        <location filename="../tsmuxerwindow.cpp" line="2473"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2471"/>
+        <location filename="../tsmuxerwindow.cpp" line="2489"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2485"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2485"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2487"/>
+        <location filename="../tsmuxerwindow.cpp" line="2505"/>
         <source>Overwrite existing %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2506"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Muxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Demuxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2534"/>
+        <location filename="../tsmuxerwindow.cpp" line="2552"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2535"/>
+        <location filename="../tsmuxerwindow.cpp" line="2553"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -787,7 +787,7 @@
         <location filename="../tsmuxerwindow.ui" line="2909"/>
         <location filename="../tsmuxerwindow.cpp" line="2332"/>
         <source>Sta&amp;rt muxing</source>
-        <translation>Ста&amp;rт муксинга</translation>
+        <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2928"/>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
@@ -168,7 +167,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="660"/>
         <source>Delay (in ms):</source>
-        <translation>Задержка (в мс)</translation>
+        <translation>Задержка (в мс):</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
@@ -188,7 +187,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="714"/>
         <source>3d offset:</source>
-        <translation>3d глубина</translation>
+        <translation>3d глубина:</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="751"/>
@@ -224,7 +223,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="827"/>
         <source>Bitrate</source>
-        <translation>Битрейт/translation>
+        <translation>Битрейт</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="840"/>
@@ -559,7 +558,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="1952"/>
         <source> Default text based subtitles font: </source>
-        <translation>Шрифт текстовых субтитров по умолчанию</translation>
+        <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="1976"/>
@@ -629,7 +628,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="2103"/>
         <source>Additional border, pixels:</source>
-        <translation>Дополнительная рамка, пикселей</translation>
+        <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2129"/>
@@ -639,7 +638,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="2155"/>
         <source>Fade in/out animation:</source>
-        <translation>Постепенное появление/исчезание</translation>
+        <translation>Постепенное появление/исчезание:</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2166"/>
@@ -669,7 +668,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="2222"/>
         <source> Vertical position: </source>
-        <translation>Вертикальная позиция:</translation>
+        <translation> Вертикальная позиция: </translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2233"/>
@@ -700,7 +699,7 @@
     <message>
         <location filename="../tsmuxerwindow.ui" line="2394"/>
         <source> Horizontal position: </source>
-        <translation>Позиция по горизонтали</translation>
+        <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2405"/>
@@ -809,7 +808,7 @@
     <message>
         <location filename="../tsmuxerwindow.cpp" line="598"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
-        <translation>Не определён тип потока</translation>
+        <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="868"/>
@@ -875,7 +874,7 @@
     <message>
         <location filename="../tsmuxerwindow.cpp" line="2232"/>
         <source>Appended file must have same file extension.</source>
-        <translation>Присоединяемый файл должен иметь тоже самое расширение файла</translation>
+        <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="2330"/>
@@ -912,7 +911,8 @@
         <location filename="../tsmuxerwindow.cpp" line="2485"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
-        <translation>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</translation>
+        <translatorcomment>Используется в фразах &quot;%1 уже есть&quot; и &quot;Перезаписать %1?&quot;</translatorcomment>
+        <translation>файл</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="2485"/>
@@ -927,7 +927,7 @@
     <message>
         <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
-        <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
+        <translation>%1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="2505"/>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -342,8 +342,8 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="1329"/>
-        <source>Задать 3 версию формата BD-ROM</source>
-        <translation></translation>
+        <source>Force BD-ROM V3 format</source>
+        <translation>Задать 3 версию формата BD-ROM</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="1341"/>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -4,32 +4,32 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../muxForm.cpp" line="39"/>
+        <location filename="../muxForm.cpp" line="48"/>
         <source>Progress: </source>
         <translation>Выполняется: </translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="62"/>
+        <location filename="../muxForm.cpp" line="71"/>
         <source>Too many errors! tsMuxeR is terminated.</source>
         <translation>Слишком много ошибок. tsMuxeR остановлен.</translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="75"/>
+        <location filename="../muxForm.cpp" line="84"/>
         <source>tsMuxeR successfully finished</source>
         <translation>tsMuxeR успешно завершился</translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="77"/>
+        <location filename="../muxForm.cpp" line="86"/>
         <source>tsMuxeR finished with error code %1</source>
         <translation>tsMuxeR завершился с кодом ошибки %1</translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="90"/>
+        <location filename="../muxForm.cpp" line="99"/>
         <source>terminating tsMuxeR...</source>
         <translation>tsMuxeR завершается...</translation>
     </message>
     <message>
-        <location filename="../muxForm.cpp" line="93"/>
+        <location filename="../muxForm.cpp" line="102"/>
         <source>tsMuxeR is terminated</source>
         <translation>tsMuxeR завершился</translation>
     </message>
@@ -758,7 +758,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2763"/>
-        <location filename="../tsmuxerwindow.cpp" line="1400"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
@@ -769,7 +769,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2797"/>
-        <location filename="../tsmuxerwindow.cpp" line="2346"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
@@ -784,168 +784,168 @@
         <translation>Файл метаданных</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2909"/>
-        <location filename="../tsmuxerwindow.cpp" line="2332"/>
+        <location filename="../tsmuxerwindow.ui" line="2929"/>
+        <location filename="../tsmuxerwindow.cpp" line="2350"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2928"/>
+        <location filename="../tsmuxerwindow.ui" line="2948"/>
         <source>Save meta file</source>
         <translation>Сохранить файл метаданных</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="531"/>
+        <location filename="../tsmuxerwindow.cpp" line="534"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="597"/>
-        <location filename="../tsmuxerwindow.cpp" line="1114"/>
+        <location filename="../tsmuxerwindow.cpp" line="600"/>
+        <location filename="../tsmuxerwindow.cpp" line="1117"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="598"/>
+        <location filename="../tsmuxerwindow.cpp" line="601"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="868"/>
+        <location filename="../tsmuxerwindow.cpp" line="871"/>
         <source>Add media file</source>
         <translation>Добавить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="908"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="906"/>
+        <location filename="../tsmuxerwindow.cpp" line="909"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1119"/>
+        <location filename="../tsmuxerwindow.cpp" line="1122"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1130"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation>Некоторые дорожки не распознаны. Эта дорожка была проигнорирована. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1400"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.cpp" line="1422"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1423"/>
+        <location filename="../tsmuxerwindow.cpp" line="1426"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1441"/>
+        <location filename="../tsmuxerwindow.cpp" line="1444"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2186"/>
-        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2204"/>
+        <location filename="../tsmuxerwindow.cpp" line="2205"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
+        <location filename="../tsmuxerwindow.cpp" line="2212"/>
         <source>Append media file</source>
         <translation>Присоединить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2231"/>
+        <location filename="../tsmuxerwindow.cpp" line="2249"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2232"/>
+        <location filename="../tsmuxerwindow.cpp" line="2250"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2348"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2342"/>
+        <location filename="../tsmuxerwindow.cpp" line="2360"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2432"/>
+        <location filename="../tsmuxerwindow.cpp" line="2450"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2454"/>
-        <location filename="../tsmuxerwindow.cpp" line="2470"/>
+        <location filename="../tsmuxerwindow.cpp" line="2472"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2455"/>
+        <location filename="../tsmuxerwindow.cpp" line="2473"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2471"/>
+        <location filename="../tsmuxerwindow.cpp" line="2489"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2485"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;%1 уже есть&quot; и &quot;Перезаписать %1?&quot;</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2485"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2487"/>
+        <location filename="../tsmuxerwindow.cpp" line="2505"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2506"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>%1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2534"/>
+        <location filename="../tsmuxerwindow.cpp" line="2552"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл метаданных</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2535"/>
+        <location filename="../tsmuxerwindow.cpp" line="2553"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл метаданных &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/tsMuxerGUI.pro
+++ b/tsMuxerGUI/tsMuxerGUI.pro
@@ -15,7 +15,7 @@ SOURCES += main.cpp tsmuxerwindow.cpp muxForm.cpp checkboxedheaderview.cpp
 FORMS += tsmuxerwindow.ui muxForm.ui
 
 RESOURCES += images.qrc
-TRANSLATIONS = translations/tsmuxergui_en.ts
+TRANSLATIONS = translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts
 win32 {
   RC_FILE += icon.rc
 }

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -267,6 +267,8 @@ TsMuxerWindow::TsMuxerWindow()
       sound(0)
 {
     ui->setupUi(this);
+    qApp->installTranslator(&qtCoreTranslator);
+    qApp->installTranslator(&tsMuxerTranslator);
     setWindowTitle("tsMuxeR GUI " TSMUXER_VERSION);
     lastInputDir = QDir::homePath();
     lastOutputDir = QDir::homePath();
@@ -1872,14 +1874,10 @@ void TsMuxerWindow::updateMuxTime2()
 
 void TsMuxerWindow::onLanguageComboBoxIndexChanged(int x)
 {
-    qApp->removeTranslator(&qtCoreTranslator);
-    qApp->removeTranslator(&tsMuxerTranslator);
     static const QString languages[] = {"en", "ru"};
     auto lang = languages[x];
     qtCoreTranslator.load(QString("qtbase_%1").arg(lang), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     tsMuxerTranslator.load(QString("tsmuxergui_%1").arg(lang), ":/i18n");
-    qApp->installTranslator(&qtCoreTranslator);
-    qApp->installTranslator(&tsMuxerTranslator);
 }
 
 void TsMuxerWindow::updateMetaLines()

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1874,15 +1874,12 @@ void TsMuxerWindow::onLanguageComboBoxIndexChanged(int x)
 {
     qApp->removeTranslator(&qtCoreTranslator);
     qApp->removeTranslator(&tsMuxerTranslator);
-    if (x != 0)
-    {
-        static const QString languages[] = {"ru"};
-        auto lang = languages[x - 1];
-        qtCoreTranslator.load(QString("qtbase_%1").arg(lang), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-        tsMuxerTranslator.load(QString("tsmuxergui_%1").arg(lang), ":/i18n");
-        qApp->installTranslator(&qtCoreTranslator);
-        qApp->installTranslator(&tsMuxerTranslator);
-    }
+    static const QString languages[] = {"en", "ru"};
+    auto lang = languages[x];
+    qtCoreTranslator.load(QString("qtbase_%1").arg(lang), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    tsMuxerTranslator.load(QString("tsmuxergui_%1").arg(lang), ":/i18n");
+    qApp->installTranslator(&qtCoreTranslator);
+    qApp->installTranslator(&tsMuxerTranslator);
 }
 
 void TsMuxerWindow::updateMetaLines()

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -4,6 +4,7 @@
 #include <QHeaderView>
 #include <QProcess>
 #include <QTimer>
+#include <QTranslator>
 #include <QWidget>
 
 #include "codecinfo.h"
@@ -45,7 +46,8 @@ class TsMuxerWindow : public QWidget
     void codecListReady();
     void fileAdded();
     void fileAppended();
-   private slots:
+
+   private:
     void onAddBtnClick();
     void readFromStdout();
     void readFromStderr();
@@ -87,9 +89,11 @@ class TsMuxerWindow : public QWidget
     void at_sectionCheckstateChanged(Qt::CheckState state);
     void updateMuxTime1();
     void updateMuxTime2();
+    void onLanguageComboBoxIndexChanged(int);
 
    protected:
     void closeEvent(QCloseEvent* event) override;
+    void changeEvent(QEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
     void updateMaxOffsets();
     void updateCustomChapters();
@@ -177,6 +181,9 @@ class TsMuxerWindow : public QWidget
     bool m_3dMode;
     QnCheckBoxedHeaderView* m_header;
     QString lastSourceDir;
+
+    QTranslator qtCoreTranslator;
+    QTranslator tsMuxerTranslator;
 
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2997,9 +2997,6 @@ p, li { white-space: pre-wrap; }
        <property name="textInteractionFlags">
         <set>Qt::NoTextInteraction</set>
        </property>
-       <property name="buddy">
-        <cstring></cstring>
-       </property>
       </widget>
      </item>
     </layout>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2873,11 +2873,31 @@ p, li { white-space: pre-wrap; }
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="leftMargin">
-      <number>80</number>
+      <number>0</number>
      </property>
      <property name="rightMargin">
       <number>0</number>
      </property>
+     <item>
+      <widget class="QComboBox" name="languageSelectComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string notr="true">English</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">Русский</string>
+        </property>
+       </item>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">


### PR DESCRIPTION
This change brings translation support to the tsMuxeR GUI. We have a Russian translation available so far, thanks to @abakum. The last selected translation is saved in the settings file and restored at the application's next startup. The currently used language is selectable by a combo box in the lower left corner of the window.
Unfortunately, the translation support for Qt applications in CMake is far from perfect, since it requires a separate resource file to be created and updating translation files from within the build is currently broken due to [QTBUG-41736](https://bugreports.qt.io/browse/QTBUG-41736). QMake supports this much better, since the translation files only need to be added to the `TRANSLATION` variable and are automatically updated and embedded into the application binary thanks to the `embed_translations` token in `CONFIG`. This means that GUI builds made via CMake might occasionally display some strings as untranslated, depending on whether the `.ts` files are up-to-date in that particular build or not.