### PR TITLE
Move the contents of the "about" tab to an external file and other GUI improvements

### DIFF
--- a/tsMuxerGUI/images.qrc
+++ b/tsMuxerGUI/images.qrc
@@ -7,5 +7,6 @@
   <file>sounds/fail.wav</file>
   <file>images/icon.png</file>
   <file>images/btn_donate.png</file>
+  <file alias="about_en.html">translations/about_en.html</file>
 </qresource>
 </RCC>

--- a/tsMuxerGUI/translations/about_en.html
+++ b/tsMuxerGUI/translations/about_en.html
@@ -1,94 +1,61 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<html>
-  <head>
-    <meta name="qrichtext" content="1" />
-    <title>tsMuxeR</title>
-    <style type="text/css">
+<html><head><meta name="qrichtext" content="1" /><title>tsMuxeR</title><style type="text/css">
 p, li { white-space: pre-wrap; }
-</style>
-  </head>
-  <body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
-    <p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <a href="https://github.com/justdan96/tsMuxer">
-        <span style=" font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;">tsMuxeR</span>
-      </a>
-      <span style=" font-size:8pt;"> – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). </span>
-    </p>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">tsMuxeR is open source. </span>
-    </p>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Supported incoming formats: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">TS; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SIFF;</li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MOV;</li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4;</li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MKV;</li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Blu-ray; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Demux option. </li>
-    </ul>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Supported videocodecs: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.264/MVC </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.265/HEVC; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Microsoft VC-1; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MPEG-2. </li>
-    </ul>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Supported audiocodecs: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AAC; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AC3 / E-AC3(DD+); </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Dolby True HD (for streams with AC3 core only); </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">DTS/ DTS-HD; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">LPCM. </li>
-    </ul>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Supported subtitle types: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS Presentation graphic stream. </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SRT text subtitles </li>
-    </ul>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Supported containers and formats: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Elementary stream; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Transport stream TS and M2TS; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Program stream EVO/VOB/MPG; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Matroska MKV/MKA. </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4/MOV. </li>
-    </ul>
-    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
-      <span style=" font-size:8pt;">Main features: </span>
-    </p>
-    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">3D Blu-ray support;</li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">UHD, HDR10, HDR10+ and Dolby Vision support; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Automatic or manual fps adjustment while mixing; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Audio tracks and subtitles time shifting; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract DTS core from DTS-HD; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract AC3 core from True-HD; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to join files; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to adjust fps for subtitles; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert LPCM streams into WAVE and vice versa; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Track language information injection into blu-ray structure and TS header; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to cut source files; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to split output file; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to remove pulldown info from stream; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to open Blu-ray playlist (MPLS) files; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert SRT subtitles to PGS; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; </li>
-      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">United cross-platform GUI - Windows, Linux, MacOS. </li>
-    </ul>
-  </body>
-</html>
+</style></head><body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><a href="https://github.com/justdan96/tsMuxer"><span style=" font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;">tsMuxeR</span></a><span style=" font-size:8pt;"> – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). </span></p>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">tsMuxeR is open source. </span></p>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported incoming formats: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SIFF;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MOV;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MKV;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Blu-ray; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Demux option. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported videocodecs: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.264/MVC </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.265/HEVC; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Microsoft VC-1; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MPEG-2. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported audiocodecs: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AAC; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AC3 / E-AC3(DD+); </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Dolby True HD (for streams with AC3 core only); </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">DTS/ DTS-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">LPCM. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported subtitle types: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS Presentation graphic stream. </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SRT text subtitles </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported containers and formats: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Elementary stream; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Transport stream TS and M2TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Program stream EVO/VOB/MPG; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Matroska MKV/MKA. </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4/MOV. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Main features: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">3D Blu-ray support;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">UHD, HDR10, HDR10+ and Dolby Vision support; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Automatic or manual fps adjustment while mixing; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Audio tracks and subtitles time shifting; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract DTS core from DTS-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract AC3 core from True-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to join files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to adjust fps for subtitles; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert LPCM streams into WAVE and vice versa; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Track language information injection into blu-ray structure and TS header; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to cut source files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to split output file; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to remove pulldown info from stream; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to open Blu-ray playlist (MPLS) files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert SRT subtitles to PGS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">United cross-platform GUI - Windows, Linux, MacOS. </li></ul></body></html>

--- a/tsMuxerGUI/translations/about_en.html
+++ b/tsMuxerGUI/translations/about_en.html
@@ -1,3 +1,6 @@
+<!-- translators : please *don't* change the formatting of this file, as Qt is very sensitive about it
+  and the translated file will most definitely be rendered differently if you choose to reindent it.
+  also, remember to save the file as UTF-8. -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 <html><head><meta name="qrichtext" content="1" /><title>tsMuxeR</title><style type="text/css">
 p, li { white-space: pre-wrap; }

--- a/tsMuxerGUI/translations/about_en.html
+++ b/tsMuxerGUI/translations/about_en.html
@@ -1,61 +1,94 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<html><head><meta name="qrichtext" content="1" /><title>tsMuxeR</title><style type="text/css">
+<html>
+  <head>
+    <meta name="qrichtext" content="1" />
+    <title>tsMuxeR</title>
+    <style type="text/css">
 p, li { white-space: pre-wrap; }
-</style></head><body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
-<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><a href="https://github.com/justdan96/tsMuxer"><span style=" font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;">tsMuxeR</span></a><span style=" font-size:8pt;"> – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). </span></p>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">tsMuxeR is open source. </span></p>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported incoming formats: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">TS; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SIFF;</li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MOV;</li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4;</li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MKV;</li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Blu-ray; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Demux option. </li></ul>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported videocodecs: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.264/MVC </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.265/HEVC; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Microsoft VC-1; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MPEG-2. </li></ul>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported audiocodecs: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AAC; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AC3 / E-AC3(DD+); </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Dolby True HD (for streams with AC3 core only); </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">DTS/ DTS-HD; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">LPCM. </li></ul>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported subtitle types: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS Presentation graphic stream. </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SRT text subtitles </li></ul>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported containers and formats: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Elementary stream; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Transport stream TS and M2TS; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Program stream EVO/VOB/MPG; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Matroska MKV/MKA. </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4/MOV. </li></ul>
-<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Main features: </span></p>
-<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">3D Blu-ray support;</li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">UHD, HDR10, HDR10+ and Dolby Vision support; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Automatic or manual fps adjustment while mixing; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Audio tracks and subtitles time shifting; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract DTS core from DTS-HD; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract AC3 core from True-HD; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to join files; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to adjust fps for subtitles; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert LPCM streams into WAVE and vice versa; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Track language information injection into blu-ray structure and TS header; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to cut source files; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to split output file; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to remove pulldown info from stream; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to open Blu-ray playlist (MPLS) files; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert SRT subtitles to PGS; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; </li>
-<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">United cross-platform GUI - Windows, Linux, MacOS. </li></ul></body></html>
+</style>
+  </head>
+  <body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+    <p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <a href="https://github.com/justdan96/tsMuxer">
+        <span style=" font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;">tsMuxeR</span>
+      </a>
+      <span style=" font-size:8pt;"> – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). </span>
+    </p>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">tsMuxeR is open source. </span>
+    </p>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Supported incoming formats: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">TS; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SIFF;</li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MOV;</li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4;</li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MKV;</li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Blu-ray; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Demux option. </li>
+    </ul>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Supported videocodecs: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.264/MVC </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.265/HEVC; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Microsoft VC-1; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MPEG-2. </li>
+    </ul>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Supported audiocodecs: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AAC; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AC3 / E-AC3(DD+); </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Dolby True HD (for streams with AC3 core only); </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">DTS/ DTS-HD; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">LPCM. </li>
+    </ul>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Supported subtitle types: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS Presentation graphic stream. </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SRT text subtitles </li>
+    </ul>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Supported containers and formats: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Elementary stream; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Transport stream TS and M2TS; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Program stream EVO/VOB/MPG; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Matroska MKV/MKA. </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4/MOV. </li>
+    </ul>
+    <p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">
+      <span style=" font-size:8pt;">Main features: </span>
+    </p>
+    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">3D Blu-ray support;</li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">UHD, HDR10, HDR10+ and Dolby Vision support; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Automatic or manual fps adjustment while mixing; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Audio tracks and subtitles time shifting; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract DTS core from DTS-HD; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract AC3 core from True-HD; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to join files; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to adjust fps for subtitles; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert LPCM streams into WAVE and vice versa; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Track language information injection into blu-ray structure and TS header; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to cut source files; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to split output file; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to remove pulldown info from stream; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to open Blu-ray playlist (MPLS) files; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert SRT subtitles to PGS; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; </li>
+      <li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">United cross-platform GUI - Windows, Linux, MacOS. </li>
+    </ul>
+  </body>
+</html>

--- a/tsMuxerGUI/translations/about_en.html
+++ b/tsMuxerGUI/translations/about_en.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html><head><meta name="qrichtext" content="1" /><title>tsMuxeR</title><style type="text/css">
+p, li { white-space: pre-wrap; }
+</style></head><body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><a href="https://github.com/justdan96/tsMuxer"><span style=" font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;">tsMuxeR</span></a><span style=" font-size:8pt;"> – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). </span></p>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">tsMuxeR is open source. </span></p>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported incoming formats: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SIFF;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MOV;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MKV;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Blu-ray; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Demux option. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported videocodecs: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.264/MVC </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H.265/HEVC; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Microsoft VC-1; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MPEG-2. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported audiocodecs: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AAC; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">AC3 / E-AC3(DD+); </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Dolby True HD (for streams with AC3 core only); </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">DTS/ DTS-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">LPCM. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported subtitle types: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">M2TS Presentation graphic stream. </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">SRT text subtitles </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Supported containers and formats: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Elementary stream; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Transport stream TS and M2TS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Program stream EVO/VOB/MPG; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Matroska MKV/MKA. </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">MP4/MOV. </li></ul>
+<p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:8pt;">Main features: </span></p>
+<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;">
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">3D Blu-ray support;</li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">UHD, HDR10, HDR10+ and Dolby Vision support; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Automatic or manual fps adjustment while mixing; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Audio tracks and subtitles time shifting; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract DTS core from DTS-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to extract AC3 core from True-HD; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to join files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to adjust fps for subtitles; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert LPCM streams into WAVE and vice versa; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Track language information injection into blu-ray structure and TS header; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to cut source files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to split output file; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to remove pulldown info from stream; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to open Blu-ray playlist (MPLS) files; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Ability to convert SRT subtitles to PGS; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; </li>
+<li style=" font-size:8pt;" style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">United cross-platform GUI - Windows, Linux, MacOS. </li></ul></body></html>

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -563,236 +563,236 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1966"/>
-        <location filename="../tsmuxerwindow.ui" line="1971"/>
-        <location filename="../tsmuxerwindow.ui" line="1976"/>
-        <location filename="../tsmuxerwindow.ui" line="1981"/>
-        <location filename="../tsmuxerwindow.ui" line="1986"/>
+        <location filename="../tsmuxerwindow.ui" line="1975"/>
+        <location filename="../tsmuxerwindow.ui" line="1980"/>
+        <location filename="../tsmuxerwindow.ui" line="1985"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
+        <location filename="../tsmuxerwindow.ui" line="1995"/>
         <source>New Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1991"/>
-        <location filename="../tsmuxerwindow.ui" line="1996"/>
+        <location filename="../tsmuxerwindow.ui" line="2000"/>
+        <location filename="../tsmuxerwindow.ui" line="2005"/>
         <source>New Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2001"/>
+        <location filename="../tsmuxerwindow.ui" line="2010"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2011"/>
+        <location filename="../tsmuxerwindow.ui" line="2020"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2016"/>
+        <location filename="../tsmuxerwindow.ui" line="2025"/>
         <source>65</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2021"/>
+        <location filename="../tsmuxerwindow.ui" line="2030"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2026"/>
+        <location filename="../tsmuxerwindow.ui" line="2035"/>
         <source>0xffffffff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2031"/>
+        <location filename="../tsmuxerwindow.ui" line="2040"/>
         <source>Charset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2036"/>
+        <location filename="../tsmuxerwindow.ui" line="2045"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2041"/>
+        <location filename="../tsmuxerwindow.ui" line="2050"/>
         <source>Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2062"/>
+        <location filename="../tsmuxerwindow.ui" line="2071"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2069"/>
+        <location filename="../tsmuxerwindow.ui" line="2078"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2093"/>
+        <location filename="../tsmuxerwindow.ui" line="2102"/>
         <source>Additional border, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2119"/>
+        <location filename="../tsmuxerwindow.ui" line="2128"/>
         <source>line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2145"/>
+        <location filename="../tsmuxerwindow.ui" line="2154"/>
         <source>Fade in/out animation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2156"/>
+        <location filename="../tsmuxerwindow.ui" line="2165"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2161"/>
+        <location filename="../tsmuxerwindow.ui" line="2170"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2166"/>
+        <location filename="../tsmuxerwindow.ui" line="2175"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2171"/>
+        <location filename="../tsmuxerwindow.ui" line="2180"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2176"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>Very slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2212"/>
+        <location filename="../tsmuxerwindow.ui" line="2221"/>
         <source> Vertical position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2223"/>
+        <location filename="../tsmuxerwindow.ui" line="2232"/>
         <source>Top of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2257"/>
+        <location filename="../tsmuxerwindow.ui" line="2266"/>
         <source>top offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2291"/>
-        <location filename="../tsmuxerwindow.ui" line="2463"/>
+        <location filename="../tsmuxerwindow.ui" line="2300"/>
+        <location filename="../tsmuxerwindow.ui" line="2472"/>
         <source>Screen center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2298"/>
+        <location filename="../tsmuxerwindow.ui" line="2307"/>
         <source>Bottom of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2332"/>
+        <location filename="../tsmuxerwindow.ui" line="2341"/>
         <source>bottom offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2384"/>
+        <location filename="../tsmuxerwindow.ui" line="2393"/>
         <source> Horizontal position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2395"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Left of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2429"/>
+        <location filename="../tsmuxerwindow.ui" line="2438"/>
         <source>left offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2485"/>
         <source>Right of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2513"/>
+        <location filename="../tsmuxerwindow.ui" line="2522"/>
         <source>right offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2578"/>
+        <location filename="../tsmuxerwindow.ui" line="2587"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2630"/>
+        <location filename="../tsmuxerwindow.ui" line="2639"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2644"/>
+        <location filename="../tsmuxerwindow.ui" line="2653"/>
         <source>TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2660"/>
+        <location filename="../tsmuxerwindow.ui" line="2669"/>
         <source>M2TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2667"/>
+        <location filename="../tsmuxerwindow.ui" line="2676"/>
         <source>Blu-ray ISO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2689"/>
         <source>Blu-ray folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2687"/>
+        <location filename="../tsmuxerwindow.ui" line="2696"/>
         <source>AVCHD folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.ui" line="2709"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Demux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2724"/>
+        <location filename="../tsmuxerwindow.ui" line="2733"/>
         <source>Disk label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2734"/>
-        <location filename="../tsmuxerwindow.cpp" line="2384"/>
+        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.cpp" line="2379"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2760"/>
+        <location filename="../tsmuxerwindow.ui" line="2769"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2784"/>
+        <location filename="../tsmuxerwindow.ui" line="2793"/>
         <source>Meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2853"/>
-        <location filename="../tsmuxerwindow.cpp" line="2370"/>
+        <location filename="../tsmuxerwindow.ui" line="2862"/>
+        <location filename="../tsmuxerwindow.cpp" line="2365"/>
         <source>Sta&amp;rt muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2878"/>
+        <location filename="../tsmuxerwindow.ui" line="2887"/>
         <source>Save meta file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,156 +822,156 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="550"/>
+        <location filename="../tsmuxerwindow.cpp" line="545"/>
         <source>Not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="616"/>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="611"/>
+        <location filename="../tsmuxerwindow.cpp" line="1128"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="612"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="887"/>
+        <location filename="../tsmuxerwindow.cpp" line="882"/>
         <source>Add media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="924"/>
+        <location filename="../tsmuxerwindow.cpp" line="919"/>
         <source>File already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="925"/>
+        <location filename="../tsmuxerwindow.cpp" line="920"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1138"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1149"/>
+        <location filename="../tsmuxerwindow.cpp" line="1144"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Mux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1438"/>
+        <location filename="../tsmuxerwindow.cpp" line="1433"/>
         <source>tsMuxeR error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1442"/>
+        <location filename="../tsmuxerwindow.cpp" line="1437"/>
         <source>tsMuxeR not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1460"/>
+        <location filename="../tsmuxerwindow.cpp" line="1455"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2224"/>
-        <location filename="../tsmuxerwindow.cpp" line="2225"/>
+        <location filename="../tsmuxerwindow.cpp" line="2219"/>
+        <location filename="../tsmuxerwindow.cpp" line="2220"/>
         <source>No track selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2232"/>
+        <location filename="../tsmuxerwindow.cpp" line="2227"/>
         <source>Append media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2269"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Invalid file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2270"/>
+        <location filename="../tsmuxerwindow.cpp" line="2265"/>
         <source>Appended file must have same file extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2368"/>
+        <location filename="../tsmuxerwindow.cpp" line="2363"/>
         <source>Sta&amp;rt demuxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2380"/>
+        <location filename="../tsmuxerwindow.cpp" line="2375"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2470"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>Select file for muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2492"/>
-        <location filename="../tsmuxerwindow.cpp" line="2508"/>
+        <location filename="../tsmuxerwindow.cpp" line="2487"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>Invalid file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2509"/>
+        <location filename="../tsmuxerwindow.cpp" line="2504"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2525"/>
+        <location filename="../tsmuxerwindow.cpp" line="2520"/>
         <source>Overwrite existing %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2526"/>
+        <location filename="../tsmuxerwindow.cpp" line="2521"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2543"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Muxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2543"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Demuxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2572"/>
+        <location filename="../tsmuxerwindow.cpp" line="2567"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2573"/>
+        <location filename="../tsmuxerwindow.cpp" line="2568"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -106,6 +106,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
+        <location filename="../tsmuxerwindow.cpp" line="50"/>
         <source>General track options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -196,6 +197,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
+        <location filename="../tsmuxerwindow.cpp" line="52"/>
         <source>Demux options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -326,625 +328,650 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1257"/>
+        <location filename="../tsmuxerwindow.ui" line="1247"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1263"/>
+        <location filename="../tsmuxerwindow.ui" line="1253"/>
         <source>Add blank playlist for cropped video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1291"/>
+        <location filename="../tsmuxerwindow.ui" line="1281"/>
         <source>Blank playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1329"/>
+        <location filename="../tsmuxerwindow.ui" line="1319"/>
         <source>Force BD-ROM V3 format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1341"/>
+        <location filename="../tsmuxerwindow.ui" line="1331"/>
         <source>First MPLS file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1364"/>
+        <location filename="../tsmuxerwindow.ui" line="1354"/>
         <source>First M2TS file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1394"/>
+        <location filename="../tsmuxerwindow.ui" line="1384"/>
         <source>Start mux time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1420"/>
+        <location filename="../tsmuxerwindow.ui" line="1410"/>
         <source>45 Khz clock:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1445"/>
+        <location filename="../tsmuxerwindow.ui" line="1435"/>
         <source>3D settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1451"/>
+        <location filename="../tsmuxerwindow.ui" line="1441"/>
         <source>Use base video stream for right eye</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1467"/>
+        <location filename="../tsmuxerwindow.ui" line="1457"/>
         <source>PIP settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1475"/>
+        <location filename="../tsmuxerwindow.ui" line="1465"/>
         <source>Corner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1486"/>
+        <location filename="../tsmuxerwindow.ui" line="1476"/>
         <source>Top Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1491"/>
+        <location filename="../tsmuxerwindow.ui" line="1481"/>
         <source>Top Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1496"/>
+        <location filename="../tsmuxerwindow.ui" line="1486"/>
         <source>Bottom Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1501"/>
+        <location filename="../tsmuxerwindow.ui" line="1491"/>
         <source>Bottom Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1509"/>
+        <location filename="../tsmuxerwindow.ui" line="1499"/>
         <source>Horizontal offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1526"/>
+        <location filename="../tsmuxerwindow.ui" line="1516"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1537"/>
+        <location filename="../tsmuxerwindow.ui" line="1527"/>
         <source>Not scaled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1542"/>
+        <location filename="../tsmuxerwindow.ui" line="1532"/>
         <source>Half (x 1/2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1547"/>
+        <location filename="../tsmuxerwindow.ui" line="1537"/>
         <source>Quarter (x 1/4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1552"/>
+        <location filename="../tsmuxerwindow.ui" line="1542"/>
         <source>One and a Half (x 1.5)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1557"/>
+        <location filename="../tsmuxerwindow.ui" line="1547"/>
         <source>Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1578"/>
+        <location filename="../tsmuxerwindow.ui" line="1568"/>
         <source>Vertical offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1600"/>
+        <location filename="../tsmuxerwindow.ui" line="1590"/>
         <source>Default tracks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1606"/>
+        <location filename="../tsmuxerwindow.ui" line="1596"/>
         <source>Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1616"/>
+        <location filename="../tsmuxerwindow.ui" line="1606"/>
         <source>When checked, only subtitles marked as &quot;forced&quot; in the subtitle stream will appear.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1619"/>
+        <location filename="../tsmuxerwindow.ui" line="1609"/>
         <source>Forced only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1626"/>
+        <location filename="../tsmuxerwindow.ui" line="1616"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1666"/>
+        <location filename="../tsmuxerwindow.ui" line="1656"/>
         <source>Split &amp;&amp; cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1681"/>
+        <location filename="../tsmuxerwindow.ui" line="1671"/>
         <source>Splitting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1692"/>
+        <location filename="../tsmuxerwindow.ui" line="1682"/>
         <source>No split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1702"/>
+        <location filename="../tsmuxerwindow.ui" line="1692"/>
         <source>Split by duration every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1728"/>
+        <location filename="../tsmuxerwindow.ui" line="1718"/>
         <source>sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1735"/>
+        <location filename="../tsmuxerwindow.ui" line="1725"/>
         <source>Split by size every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1768"/>
+        <location filename="../tsmuxerwindow.ui" line="1758"/>
         <source>KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1773"/>
+        <location filename="../tsmuxerwindow.ui" line="1763"/>
         <source>KiB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1778"/>
+        <location filename="../tsmuxerwindow.ui" line="1768"/>
         <source>MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1783"/>
+        <location filename="../tsmuxerwindow.ui" line="1773"/>
         <source>MiB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1788"/>
+        <location filename="../tsmuxerwindow.ui" line="1778"/>
         <source>GB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1793"/>
+        <location filename="../tsmuxerwindow.ui" line="1783"/>
         <source>GiB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1825"/>
+        <location filename="../tsmuxerwindow.ui" line="1815"/>
         <source>Cutting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1836"/>
+        <location filename="../tsmuxerwindow.ui" line="1826"/>
         <source>Enable cutting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1847"/>
+        <location filename="../tsmuxerwindow.ui" line="1837"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1857"/>
+        <location filename="../tsmuxerwindow.ui" line="1847"/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1937"/>
+        <location filename="../tsmuxerwindow.ui" line="1927"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1952"/>
+        <location filename="../tsmuxerwindow.ui" line="1942"/>
         <source> Default text based subtitles font: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../tsmuxerwindow.ui" line="1966"/>
+        <location filename="../tsmuxerwindow.ui" line="1971"/>
         <location filename="../tsmuxerwindow.ui" line="1976"/>
         <location filename="../tsmuxerwindow.ui" line="1981"/>
         <location filename="../tsmuxerwindow.ui" line="1986"/>
-        <location filename="../tsmuxerwindow.ui" line="1991"/>
-        <location filename="../tsmuxerwindow.ui" line="1996"/>
         <source>New Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2001"/>
-        <location filename="../tsmuxerwindow.ui" line="2006"/>
+        <location filename="../tsmuxerwindow.ui" line="1991"/>
+        <location filename="../tsmuxerwindow.ui" line="1996"/>
         <source>New Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2011"/>
+        <location filename="../tsmuxerwindow.ui" line="2001"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2021"/>
+        <location filename="../tsmuxerwindow.ui" line="2011"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2026"/>
+        <location filename="../tsmuxerwindow.ui" line="2016"/>
         <source>65</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2031"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2036"/>
+        <location filename="../tsmuxerwindow.ui" line="2026"/>
         <source>0xffffffff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2041"/>
+        <location filename="../tsmuxerwindow.ui" line="2031"/>
         <source>Charset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2046"/>
+        <location filename="../tsmuxerwindow.ui" line="2036"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2051"/>
+        <location filename="../tsmuxerwindow.ui" line="2041"/>
         <source>Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2072"/>
+        <location filename="../tsmuxerwindow.ui" line="2062"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2079"/>
+        <location filename="../tsmuxerwindow.ui" line="2069"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2103"/>
+        <location filename="../tsmuxerwindow.ui" line="2093"/>
         <source>Additional border, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2129"/>
+        <location filename="../tsmuxerwindow.ui" line="2119"/>
         <source>line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2155"/>
+        <location filename="../tsmuxerwindow.ui" line="2145"/>
         <source>Fade in/out animation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2166"/>
+        <location filename="../tsmuxerwindow.ui" line="2156"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2171"/>
+        <location filename="../tsmuxerwindow.ui" line="2161"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2176"/>
+        <location filename="../tsmuxerwindow.ui" line="2166"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2181"/>
+        <location filename="../tsmuxerwindow.ui" line="2171"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2186"/>
+        <location filename="../tsmuxerwindow.ui" line="2176"/>
         <source>Very slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2222"/>
+        <location filename="../tsmuxerwindow.ui" line="2212"/>
         <source> Vertical position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2233"/>
+        <location filename="../tsmuxerwindow.ui" line="2223"/>
         <source>Top of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2267"/>
+        <location filename="../tsmuxerwindow.ui" line="2257"/>
         <source>top offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2301"/>
-        <location filename="../tsmuxerwindow.ui" line="2473"/>
+        <location filename="../tsmuxerwindow.ui" line="2291"/>
+        <location filename="../tsmuxerwindow.ui" line="2463"/>
         <source>Screen center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2308"/>
+        <location filename="../tsmuxerwindow.ui" line="2298"/>
         <source>Bottom of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2342"/>
+        <location filename="../tsmuxerwindow.ui" line="2332"/>
         <source>bottom offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2394"/>
+        <location filename="../tsmuxerwindow.ui" line="2384"/>
         <source> Horizontal position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2405"/>
+        <location filename="../tsmuxerwindow.ui" line="2395"/>
         <source>Left of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2439"/>
+        <location filename="../tsmuxerwindow.ui" line="2429"/>
         <source>left offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2486"/>
+        <location filename="../tsmuxerwindow.ui" line="2476"/>
         <source>Right of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2523"/>
+        <location filename="../tsmuxerwindow.ui" line="2513"/>
         <source>right offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2588"/>
+        <location filename="../tsmuxerwindow.ui" line="2578"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2630"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2707"/>
+        <location filename="../tsmuxerwindow.ui" line="2644"/>
         <source>TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2723"/>
+        <location filename="../tsmuxerwindow.ui" line="2660"/>
         <source>M2TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2730"/>
+        <location filename="../tsmuxerwindow.ui" line="2667"/>
         <source>Blu-ray ISO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.ui" line="2680"/>
         <source>Blu-ray folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2750"/>
+        <location filename="../tsmuxerwindow.ui" line="2687"/>
         <source>AVCHD folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2763"/>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.cpp" line="1419"/>
         <source>Demux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2787"/>
+        <location filename="../tsmuxerwindow.ui" line="2724"/>
         <source>Disk label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.ui" line="2734"/>
+        <location filename="../tsmuxerwindow.cpp" line="2384"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2823"/>
+        <location filename="../tsmuxerwindow.ui" line="2760"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2847"/>
+        <location filename="../tsmuxerwindow.ui" line="2784"/>
         <source>Meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2929"/>
-        <location filename="../tsmuxerwindow.cpp" line="2350"/>
+        <location filename="../tsmuxerwindow.ui" line="2853"/>
+        <location filename="../tsmuxerwindow.cpp" line="2370"/>
         <source>Sta&amp;rt muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2948"/>
+        <location filename="../tsmuxerwindow.ui" line="2878"/>
         <source>Save meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="534"/>
+        <location filename="../tsmuxerwindow.cpp" line="25"/>
+        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="48"/>
+        <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <source>Transport stream (*.ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="550"/>
         <source>Not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="600"/>
-        <location filename="../tsmuxerwindow.cpp" line="1117"/>
+        <location filename="../tsmuxerwindow.cpp" line="616"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="601"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="871"/>
+        <location filename="../tsmuxerwindow.cpp" line="887"/>
         <source>Add media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="908"/>
+        <location filename="../tsmuxerwindow.cpp" line="924"/>
         <source>File already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="909"/>
+        <location filename="../tsmuxerwindow.cpp" line="925"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1122"/>
+        <location filename="../tsmuxerwindow.cpp" line="1138"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="1149"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.cpp" line="1419"/>
         <source>Mux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1422"/>
+        <location filename="../tsmuxerwindow.cpp" line="1438"/>
         <source>tsMuxeR error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1426"/>
+        <location filename="../tsmuxerwindow.cpp" line="1442"/>
         <source>tsMuxeR not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1444"/>
+        <location filename="../tsmuxerwindow.cpp" line="1460"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2204"/>
-        <location filename="../tsmuxerwindow.cpp" line="2205"/>
+        <location filename="../tsmuxerwindow.cpp" line="2224"/>
+        <location filename="../tsmuxerwindow.cpp" line="2225"/>
         <source>No track selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2212"/>
+        <location filename="../tsmuxerwindow.cpp" line="2232"/>
         <source>Append media file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2249"/>
+        <location filename="../tsmuxerwindow.cpp" line="2269"/>
         <source>Invalid file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2250"/>
+        <location filename="../tsmuxerwindow.cpp" line="2270"/>
         <source>Appended file must have same file extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2348"/>
+        <location filename="../tsmuxerwindow.cpp" line="2368"/>
         <source>Sta&amp;rt demuxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2360"/>
+        <location filename="../tsmuxerwindow.cpp" line="2380"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2450"/>
+        <location filename="../tsmuxerwindow.cpp" line="2470"/>
         <source>Select file for muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2472"/>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2492"/>
+        <location filename="../tsmuxerwindow.cpp" line="2508"/>
         <source>Invalid file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2493"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2489"/>
+        <location filename="../tsmuxerwindow.cpp" line="2509"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2525"/>
         <source>Overwrite existing %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2506"/>
+        <location filename="../tsmuxerwindow.cpp" line="2526"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2543"/>
         <source>Muxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2543"/>
         <source>Demuxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2552"/>
+        <location filename="../tsmuxerwindow.cpp" line="2572"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2553"/>
+        <location filename="../tsmuxerwindow.cpp" line="2573"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -106,6 +106,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
+        <location filename="../tsmuxerwindow.cpp" line="50"/>
         <source>General track options</source>
         <translation>Общие параметры дорожки</translation>
     </message>
@@ -196,6 +197,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
+        <location filename="../tsmuxerwindow.cpp" line="52"/>
         <source>Demux options</source>
         <translation>Параметры записи дорожек</translation>
     </message>
@@ -326,626 +328,651 @@
         <translation>Главы:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1257"/>
+        <location filename="../tsmuxerwindow.ui" line="1247"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1263"/>
+        <location filename="../tsmuxerwindow.ui" line="1253"/>
         <source>Add blank playlist for cropped video</source>
         <translation>Добавить пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1291"/>
+        <location filename="../tsmuxerwindow.ui" line="1281"/>
         <source>Blank playlist</source>
         <translation>Пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1329"/>
+        <location filename="../tsmuxerwindow.ui" line="1319"/>
         <source>Force BD-ROM V3 format</source>
         <translation>Задать 3 версию формата BD-ROM</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1341"/>
+        <location filename="../tsmuxerwindow.ui" line="1331"/>
         <source>First MPLS file</source>
         <translation>Первый файл MPLS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1364"/>
+        <location filename="../tsmuxerwindow.ui" line="1354"/>
         <source>First M2TS file</source>
         <translation>Первый файл M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1394"/>
+        <location filename="../tsmuxerwindow.ui" line="1384"/>
         <source>Start mux time</source>
         <translation>Время начала записи</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1420"/>
+        <location filename="../tsmuxerwindow.ui" line="1410"/>
         <source>45 Khz clock:</source>
         <translation>1/45 милисекунды:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1445"/>
+        <location filename="../tsmuxerwindow.ui" line="1435"/>
         <source>3D settings</source>
         <translation>Настройки 3D</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1451"/>
+        <location filename="../tsmuxerwindow.ui" line="1441"/>
         <source>Use base video stream for right eye</source>
         <translation>Использовать основной видеопоток для правого глаза</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1467"/>
+        <location filename="../tsmuxerwindow.ui" line="1457"/>
         <source>PIP settings</source>
         <translation>Настройки PIP</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1475"/>
+        <location filename="../tsmuxerwindow.ui" line="1465"/>
         <source>Corner</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1486"/>
+        <location filename="../tsmuxerwindow.ui" line="1476"/>
         <source>Top Left</source>
         <translation>Верхний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1491"/>
+        <location filename="../tsmuxerwindow.ui" line="1481"/>
         <source>Top Right</source>
         <translation>Верхний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1496"/>
+        <location filename="../tsmuxerwindow.ui" line="1486"/>
         <source>Bottom Right</source>
         <translation>Нижний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1501"/>
+        <location filename="../tsmuxerwindow.ui" line="1491"/>
         <source>Bottom Left</source>
         <translation>Нижний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1509"/>
+        <location filename="../tsmuxerwindow.ui" line="1499"/>
         <source>Horizontal offset</source>
         <translation>Смещение по горизонтали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1526"/>
+        <location filename="../tsmuxerwindow.ui" line="1516"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1537"/>
+        <location filename="../tsmuxerwindow.ui" line="1527"/>
         <source>Not scaled</source>
         <translation>Не маштабировать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1542"/>
+        <location filename="../tsmuxerwindow.ui" line="1532"/>
         <source>Half (x 1/2)</source>
         <translation>Половина (x 1/2)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1547"/>
+        <location filename="../tsmuxerwindow.ui" line="1537"/>
         <source>Quarter (x 1/4)</source>
         <translation>Четверть (x 1/4)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1552"/>
+        <location filename="../tsmuxerwindow.ui" line="1542"/>
         <source>One and a Half (x 1.5)</source>
         <translation>Полтора (x 1.5)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1557"/>
+        <location filename="../tsmuxerwindow.ui" line="1547"/>
         <source>Full Screen</source>
         <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1578"/>
+        <location filename="../tsmuxerwindow.ui" line="1568"/>
         <source>Vertical offset</source>
         <translation>Смещение по вертикали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1600"/>
+        <location filename="../tsmuxerwindow.ui" line="1590"/>
         <source>Default tracks</source>
         <translation>Дорожки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1606"/>
+        <location filename="../tsmuxerwindow.ui" line="1596"/>
         <source>Subtitle</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1616"/>
+        <location filename="../tsmuxerwindow.ui" line="1606"/>
         <source>When checked, only subtitles marked as &quot;forced&quot; in the subtitle stream will appear.</source>
         <translation>Если установлен будут отображаться только субтитры, помеченные как &quot;принудительные&quot;.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1619"/>
+        <location filename="../tsmuxerwindow.ui" line="1609"/>
         <source>Forced only</source>
         <translation>Только принудительные</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1626"/>
+        <location filename="../tsmuxerwindow.ui" line="1616"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1666"/>
+        <location filename="../tsmuxerwindow.ui" line="1656"/>
         <source>Split &amp;&amp; cut</source>
         <translation>Нарезка &amp;&amp; обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1681"/>
+        <location filename="../tsmuxerwindow.ui" line="1671"/>
         <source>Splitting</source>
         <translation>Нарезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1692"/>
+        <location filename="../tsmuxerwindow.ui" line="1682"/>
         <source>No split</source>
         <translation>Не нарезать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1702"/>
+        <location filename="../tsmuxerwindow.ui" line="1692"/>
         <source>Split by duration every</source>
         <translation>Нарезать через каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1728"/>
+        <location filename="../tsmuxerwindow.ui" line="1718"/>
         <source>sec</source>
         <translation>сек</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1735"/>
+        <location filename="../tsmuxerwindow.ui" line="1725"/>
         <source>Split by size every</source>
         <translation>Нарезать по размеру каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1768"/>
+        <location filename="../tsmuxerwindow.ui" line="1758"/>
         <source>KB</source>
         <translation>Килобайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1773"/>
+        <location filename="../tsmuxerwindow.ui" line="1763"/>
         <source>KiB</source>
         <translation>Кибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1778"/>
+        <location filename="../tsmuxerwindow.ui" line="1768"/>
         <source>MB</source>
         <translation>Мегабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1783"/>
+        <location filename="../tsmuxerwindow.ui" line="1773"/>
         <source>MiB</source>
         <translation>Мебибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1788"/>
+        <location filename="../tsmuxerwindow.ui" line="1778"/>
         <source>GB</source>
         <translation>Гигабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1793"/>
+        <location filename="../tsmuxerwindow.ui" line="1783"/>
         <source>GiB</source>
         <translation>Гибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1825"/>
+        <location filename="../tsmuxerwindow.ui" line="1815"/>
         <source>Cutting</source>
         <translation>Обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1836"/>
+        <location filename="../tsmuxerwindow.ui" line="1826"/>
         <source>Enable cutting</source>
         <translation>Разрешить обрезку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1847"/>
+        <location filename="../tsmuxerwindow.ui" line="1837"/>
         <source>Start</source>
         <translation>Начало</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1857"/>
+        <location filename="../tsmuxerwindow.ui" line="1847"/>
         <source>End</source>
         <translation>Конец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1937"/>
+        <location filename="../tsmuxerwindow.ui" line="1927"/>
         <source>Subtitles</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1952"/>
+        <location filename="../tsmuxerwindow.ui" line="1942"/>
         <source> Default text based subtitles font: </source>
         <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1976"/>
-        <location filename="../tsmuxerwindow.ui" line="1981"/>
-        <location filename="../tsmuxerwindow.ui" line="1986"/>
-        <location filename="../tsmuxerwindow.ui" line="1991"/>
-        <location filename="../tsmuxerwindow.ui" line="1996"/>
+        <location filename="../tsmuxerwindow.ui" line="1975"/>
+        <location filename="../tsmuxerwindow.ui" line="1980"/>
+        <location filename="../tsmuxerwindow.ui" line="1985"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
+        <location filename="../tsmuxerwindow.ui" line="1995"/>
         <source>New Row</source>
         <translation>Новая Строка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2001"/>
-        <location filename="../tsmuxerwindow.ui" line="2006"/>
+        <location filename="../tsmuxerwindow.ui" line="2000"/>
+        <location filename="../tsmuxerwindow.ui" line="2005"/>
         <source>New Column</source>
         <translation>Новый Столбец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2011"/>
+        <location filename="../tsmuxerwindow.ui" line="2010"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2021"/>
+        <location filename="../tsmuxerwindow.ui" line="2020"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2026"/>
+        <location filename="../tsmuxerwindow.ui" line="2025"/>
         <source>65</source>
         <translation>65</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2031"/>
+        <location filename="../tsmuxerwindow.ui" line="2030"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2036"/>
+        <location filename="../tsmuxerwindow.ui" line="2035"/>
         <source>0xffffffff</source>
         <translation>0xffffffff</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2041"/>
+        <location filename="../tsmuxerwindow.ui" line="2040"/>
         <source>Charset:</source>
         <translation>Набор символов:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2046"/>
+        <location filename="../tsmuxerwindow.ui" line="2045"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2051"/>
+        <location filename="../tsmuxerwindow.ui" line="2050"/>
         <source>Options:</source>
         <translation>Параметры:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2072"/>
+        <location filename="../tsmuxerwindow.ui" line="2071"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2079"/>
+        <location filename="../tsmuxerwindow.ui" line="2078"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2103"/>
+        <location filename="../tsmuxerwindow.ui" line="2102"/>
         <source>Additional border, pixels:</source>
         <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2129"/>
+        <location filename="../tsmuxerwindow.ui" line="2128"/>
         <source>line spacing:</source>
         <translation>Междустрочное расстояние:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2155"/>
+        <location filename="../tsmuxerwindow.ui" line="2154"/>
         <source>Fade in/out animation:</source>
         <translation>Анимация появления/исчезания:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2166"/>
+        <location filename="../tsmuxerwindow.ui" line="2165"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2171"/>
+        <location filename="../tsmuxerwindow.ui" line="2170"/>
         <source>Fast</source>
         <translation>Быстрое</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2176"/>
+        <location filename="../tsmuxerwindow.ui" line="2175"/>
         <source>Medium</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2181"/>
+        <location filename="../tsmuxerwindow.ui" line="2180"/>
         <source>Slow</source>
         <translation>Медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2186"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>Very slow</source>
         <translation>Очень медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2222"/>
+        <location filename="../tsmuxerwindow.ui" line="2221"/>
         <source> Vertical position: </source>
         <translation> Позиция по вертикали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2233"/>
+        <location filename="../tsmuxerwindow.ui" line="2232"/>
         <source>Top of screen</source>
         <translation>Верх экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2267"/>
+        <location filename="../tsmuxerwindow.ui" line="2266"/>
         <source>top offset, pixels:</source>
         <translation>отступ от верха, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2301"/>
-        <location filename="../tsmuxerwindow.ui" line="2473"/>
+        <location filename="../tsmuxerwindow.ui" line="2300"/>
+        <location filename="../tsmuxerwindow.ui" line="2472"/>
         <source>Screen center</source>
         <translation>Центр экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2308"/>
+        <location filename="../tsmuxerwindow.ui" line="2307"/>
         <source>Bottom of screen</source>
         <translation>Низ экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2342"/>
+        <location filename="../tsmuxerwindow.ui" line="2341"/>
         <source>bottom offset, pixels:</source>
         <translation>отступ от низа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2394"/>
+        <location filename="../tsmuxerwindow.ui" line="2393"/>
         <source> Horizontal position: </source>
         <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2405"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Left of screen</source>
         <translation>слева экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2439"/>
+        <location filename="../tsmuxerwindow.ui" line="2438"/>
         <source>left offset, pixels:</source>
         <translation>отступ слева, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2486"/>
+        <location filename="../tsmuxerwindow.ui" line="2485"/>
         <source>Right of screen</source>
         <translation>справа экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2523"/>
+        <location filename="../tsmuxerwindow.ui" line="2522"/>
         <source>right offset, pixels:</source>
         <translation>отступ справа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2588"/>
+        <location filename="../tsmuxerwindow.ui" line="2587"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2639"/>
         <source>Output</source>
         <translation>Результат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2707"/>
+        <location filename="../tsmuxerwindow.ui" line="2653"/>
         <source>TS muxing</source>
         <translation>Запись в TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2723"/>
+        <location filename="../tsmuxerwindow.ui" line="2669"/>
         <source>M2TS muxing</source>
         <translation>Запись в M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2730"/>
+        <location filename="../tsmuxerwindow.ui" line="2676"/>
         <source>Blu-ray ISO</source>
         <translation>Запись блюрея в файл ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.ui" line="2689"/>
         <source>Blu-ray folder</source>
         <translation>Запись блюрея в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2750"/>
+        <location filename="../tsmuxerwindow.ui" line="2696"/>
         <source>AVCHD folder</source>
         <translation>Запись AVCHD в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2763"/>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.ui" line="2709"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2787"/>
+        <location filename="../tsmuxerwindow.ui" line="2733"/>
         <source>Disk label</source>
         <translation>Имя диска</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.cpp" line="2379"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2823"/>
+        <location filename="../tsmuxerwindow.ui" line="2769"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2847"/>
+        <location filename="../tsmuxerwindow.ui" line="2793"/>
         <source>Meta file</source>
         <translation>Файл проекта tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2929"/>
-        <location filename="../tsmuxerwindow.cpp" line="2350"/>
+        <location filename="../tsmuxerwindow.ui" line="2862"/>
+        <location filename="../tsmuxerwindow.cpp" line="2365"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2948"/>
+        <location filename="../tsmuxerwindow.ui" line="2887"/>
         <source>Save meta file</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="534"/>
+        <location filename="../tsmuxerwindow.cpp" line="25"/>
+        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="48"/>
+        <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <source>Transport stream (*.ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="545"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="600"/>
-        <location filename="../tsmuxerwindow.cpp" line="1117"/>
+        <location filename="../tsmuxerwindow.cpp" line="611"/>
+        <location filename="../tsmuxerwindow.cpp" line="1128"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="601"/>
+        <location filename="../tsmuxerwindow.cpp" line="612"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="871"/>
+        <location filename="../tsmuxerwindow.cpp" line="882"/>
         <source>Add media file</source>
         <translation>Добавить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="908"/>
+        <location filename="../tsmuxerwindow.cpp" line="919"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="909"/>
+        <location filename="../tsmuxerwindow.cpp" line="920"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1122"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="1144"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation>Некоторые дорожки не распознаны. Эта дорожка была проигнорирована. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1422"/>
+        <location filename="../tsmuxerwindow.cpp" line="1433"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1426"/>
+        <location filename="../tsmuxerwindow.cpp" line="1437"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1444"/>
+        <location filename="../tsmuxerwindow.cpp" line="1455"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2204"/>
-        <location filename="../tsmuxerwindow.cpp" line="2205"/>
+        <location filename="../tsmuxerwindow.cpp" line="2219"/>
+        <location filename="../tsmuxerwindow.cpp" line="2220"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2212"/>
+        <location filename="../tsmuxerwindow.cpp" line="2227"/>
         <source>Append media file</source>
         <translation>Присоединить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2249"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2250"/>
+        <location filename="../tsmuxerwindow.cpp" line="2265"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2348"/>
+        <location filename="../tsmuxerwindow.cpp" line="2363"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2360"/>
+        <location filename="../tsmuxerwindow.cpp" line="2375"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2450"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2472"/>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2487"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2489"/>
+        <location filename="../tsmuxerwindow.cpp" line="2504"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2520"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2506"/>
+        <location filename="../tsmuxerwindow.cpp" line="2521"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2552"/>
+        <location filename="../tsmuxerwindow.cpp" line="2567"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2553"/>
+        <location filename="../tsmuxerwindow.cpp" line="2568"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -563,236 +563,236 @@
         <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1966"/>
-        <location filename="../tsmuxerwindow.ui" line="1971"/>
-        <location filename="../tsmuxerwindow.ui" line="1976"/>
-        <location filename="../tsmuxerwindow.ui" line="1981"/>
-        <location filename="../tsmuxerwindow.ui" line="1986"/>
+        <location filename="../tsmuxerwindow.ui" line="1975"/>
+        <location filename="../tsmuxerwindow.ui" line="1980"/>
+        <location filename="../tsmuxerwindow.ui" line="1985"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
+        <location filename="../tsmuxerwindow.ui" line="1995"/>
         <source>New Row</source>
         <translation>Новая Строка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1991"/>
-        <location filename="../tsmuxerwindow.ui" line="1996"/>
+        <location filename="../tsmuxerwindow.ui" line="2000"/>
+        <location filename="../tsmuxerwindow.ui" line="2005"/>
         <source>New Column</source>
         <translation>Новый Столбец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2001"/>
+        <location filename="../tsmuxerwindow.ui" line="2010"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2011"/>
+        <location filename="../tsmuxerwindow.ui" line="2020"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2016"/>
+        <location filename="../tsmuxerwindow.ui" line="2025"/>
         <source>65</source>
         <translation>65</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2021"/>
+        <location filename="../tsmuxerwindow.ui" line="2030"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2026"/>
+        <location filename="../tsmuxerwindow.ui" line="2035"/>
         <source>0xffffffff</source>
         <translation>0xffffffff</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2031"/>
+        <location filename="../tsmuxerwindow.ui" line="2040"/>
         <source>Charset:</source>
         <translation>Набор символов:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2036"/>
+        <location filename="../tsmuxerwindow.ui" line="2045"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2041"/>
+        <location filename="../tsmuxerwindow.ui" line="2050"/>
         <source>Options:</source>
         <translation>Параметры:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2062"/>
+        <location filename="../tsmuxerwindow.ui" line="2071"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2069"/>
+        <location filename="../tsmuxerwindow.ui" line="2078"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2093"/>
+        <location filename="../tsmuxerwindow.ui" line="2102"/>
         <source>Additional border, pixels:</source>
         <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2119"/>
+        <location filename="../tsmuxerwindow.ui" line="2128"/>
         <source>line spacing:</source>
         <translation>Междустрочное расстояние:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2145"/>
+        <location filename="../tsmuxerwindow.ui" line="2154"/>
         <source>Fade in/out animation:</source>
         <translation>Анимация появления/исчезания:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2156"/>
+        <location filename="../tsmuxerwindow.ui" line="2165"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2161"/>
+        <location filename="../tsmuxerwindow.ui" line="2170"/>
         <source>Fast</source>
         <translation>Быстрое</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2166"/>
+        <location filename="../tsmuxerwindow.ui" line="2175"/>
         <source>Medium</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2171"/>
+        <location filename="../tsmuxerwindow.ui" line="2180"/>
         <source>Slow</source>
         <translation>Медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2176"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>Very slow</source>
         <translation>Очень медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2212"/>
+        <location filename="../tsmuxerwindow.ui" line="2221"/>
         <source> Vertical position: </source>
         <translation> Позиция по вертикали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2223"/>
+        <location filename="../tsmuxerwindow.ui" line="2232"/>
         <source>Top of screen</source>
         <translation>Верх экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2257"/>
+        <location filename="../tsmuxerwindow.ui" line="2266"/>
         <source>top offset, pixels:</source>
         <translation>отступ от верха, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2291"/>
-        <location filename="../tsmuxerwindow.ui" line="2463"/>
+        <location filename="../tsmuxerwindow.ui" line="2300"/>
+        <location filename="../tsmuxerwindow.ui" line="2472"/>
         <source>Screen center</source>
         <translation>Центр экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2298"/>
+        <location filename="../tsmuxerwindow.ui" line="2307"/>
         <source>Bottom of screen</source>
         <translation>Низ экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2332"/>
+        <location filename="../tsmuxerwindow.ui" line="2341"/>
         <source>bottom offset, pixels:</source>
         <translation>отступ от низа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2384"/>
+        <location filename="../tsmuxerwindow.ui" line="2393"/>
         <source> Horizontal position: </source>
         <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2395"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Left of screen</source>
         <translation>слева экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2429"/>
+        <location filename="../tsmuxerwindow.ui" line="2438"/>
         <source>left offset, pixels:</source>
         <translation>отступ слева, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2485"/>
         <source>Right of screen</source>
         <translation>справа экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2513"/>
+        <location filename="../tsmuxerwindow.ui" line="2522"/>
         <source>right offset, pixels:</source>
         <translation>отступ справа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2578"/>
+        <location filename="../tsmuxerwindow.ui" line="2587"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2630"/>
+        <location filename="../tsmuxerwindow.ui" line="2639"/>
         <source>Output</source>
         <translation>Результат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2644"/>
+        <location filename="../tsmuxerwindow.ui" line="2653"/>
         <source>TS muxing</source>
         <translation>Запись в TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2660"/>
+        <location filename="../tsmuxerwindow.ui" line="2669"/>
         <source>M2TS muxing</source>
         <translation>Запись в M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2667"/>
+        <location filename="../tsmuxerwindow.ui" line="2676"/>
         <source>Blu-ray ISO</source>
         <translation>Запись блюрея в файл ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2689"/>
         <source>Blu-ray folder</source>
         <translation>Запись блюрея в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2687"/>
+        <location filename="../tsmuxerwindow.ui" line="2696"/>
         <source>AVCHD folder</source>
         <translation>Запись AVCHD в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.ui" line="2709"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2724"/>
+        <location filename="../tsmuxerwindow.ui" line="2733"/>
         <source>Disk label</source>
         <translation>Имя диска</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2734"/>
-        <location filename="../tsmuxerwindow.cpp" line="2384"/>
+        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.cpp" line="2379"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2760"/>
+        <location filename="../tsmuxerwindow.ui" line="2769"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2784"/>
+        <location filename="../tsmuxerwindow.ui" line="2793"/>
         <source>Meta file</source>
         <translation>Файл проекта tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2853"/>
-        <location filename="../tsmuxerwindow.cpp" line="2370"/>
+        <location filename="../tsmuxerwindow.ui" line="2862"/>
+        <location filename="../tsmuxerwindow.cpp" line="2365"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2878"/>
+        <location filename="../tsmuxerwindow.ui" line="2887"/>
         <source>Save meta file</source>
         <translation>Сохранить проект</translation>
     </message>
@@ -822,157 +822,157 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="550"/>
+        <location filename="../tsmuxerwindow.cpp" line="545"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="616"/>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="611"/>
+        <location filename="../tsmuxerwindow.cpp" line="1128"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="612"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="887"/>
+        <location filename="../tsmuxerwindow.cpp" line="882"/>
         <source>Add media file</source>
         <translation>Добавить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="924"/>
+        <location filename="../tsmuxerwindow.cpp" line="919"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="925"/>
+        <location filename="../tsmuxerwindow.cpp" line="920"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1138"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1149"/>
+        <location filename="../tsmuxerwindow.cpp" line="1144"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation>Некоторые дорожки не распознаны. Эта дорожка была проигнорирована. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1419"/>
+        <location filename="../tsmuxerwindow.cpp" line="1414"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1438"/>
+        <location filename="../tsmuxerwindow.cpp" line="1433"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1442"/>
+        <location filename="../tsmuxerwindow.cpp" line="1437"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1460"/>
+        <location filename="../tsmuxerwindow.cpp" line="1455"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2224"/>
-        <location filename="../tsmuxerwindow.cpp" line="2225"/>
+        <location filename="../tsmuxerwindow.cpp" line="2219"/>
+        <location filename="../tsmuxerwindow.cpp" line="2220"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2232"/>
+        <location filename="../tsmuxerwindow.cpp" line="2227"/>
         <source>Append media file</source>
         <translation>Присоединить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2269"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2270"/>
+        <location filename="../tsmuxerwindow.cpp" line="2265"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2368"/>
+        <location filename="../tsmuxerwindow.cpp" line="2363"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2380"/>
+        <location filename="../tsmuxerwindow.cpp" line="2375"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2470"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2492"/>
-        <location filename="../tsmuxerwindow.cpp" line="2508"/>
+        <location filename="../tsmuxerwindow.cpp" line="2487"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2509"/>
+        <location filename="../tsmuxerwindow.cpp" line="2504"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2518"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2525"/>
+        <location filename="../tsmuxerwindow.cpp" line="2520"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2526"/>
+        <location filename="../tsmuxerwindow.cpp" line="2521"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2543"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2543"/>
+        <location filename="../tsmuxerwindow.cpp" line="2538"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2572"/>
+        <location filename="../tsmuxerwindow.cpp" line="2567"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2573"/>
+        <location filename="../tsmuxerwindow.cpp" line="2568"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -106,6 +106,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
+        <location filename="../tsmuxerwindow.cpp" line="50"/>
         <source>General track options</source>
         <translation>Общие параметры дорожки</translation>
     </message>
@@ -196,6 +197,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
+        <location filename="../tsmuxerwindow.cpp" line="52"/>
         <source>Demux options</source>
         <translation>Параметры записи дорожек</translation>
     </message>
@@ -326,626 +328,651 @@
         <translation>Главы:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1257"/>
+        <location filename="../tsmuxerwindow.ui" line="1247"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1263"/>
+        <location filename="../tsmuxerwindow.ui" line="1253"/>
         <source>Add blank playlist for cropped video</source>
         <translation>Добавить пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1291"/>
+        <location filename="../tsmuxerwindow.ui" line="1281"/>
         <source>Blank playlist</source>
         <translation>Пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1329"/>
+        <location filename="../tsmuxerwindow.ui" line="1319"/>
         <source>Force BD-ROM V3 format</source>
         <translation>Задать 3 версию формата BD-ROM</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1341"/>
+        <location filename="../tsmuxerwindow.ui" line="1331"/>
         <source>First MPLS file</source>
         <translation>Первый файл MPLS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1364"/>
+        <location filename="../tsmuxerwindow.ui" line="1354"/>
         <source>First M2TS file</source>
         <translation>Первый файл M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1394"/>
+        <location filename="../tsmuxerwindow.ui" line="1384"/>
         <source>Start mux time</source>
         <translation>Время начала записи</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1420"/>
+        <location filename="../tsmuxerwindow.ui" line="1410"/>
         <source>45 Khz clock:</source>
         <translation>1/45 милисекунды:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1445"/>
+        <location filename="../tsmuxerwindow.ui" line="1435"/>
         <source>3D settings</source>
         <translation>Настройки 3D</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1451"/>
+        <location filename="../tsmuxerwindow.ui" line="1441"/>
         <source>Use base video stream for right eye</source>
         <translation>Использовать основной видеопоток для правого глаза</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1467"/>
+        <location filename="../tsmuxerwindow.ui" line="1457"/>
         <source>PIP settings</source>
         <translation>Настройки PIP</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1475"/>
+        <location filename="../tsmuxerwindow.ui" line="1465"/>
         <source>Corner</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1486"/>
+        <location filename="../tsmuxerwindow.ui" line="1476"/>
         <source>Top Left</source>
         <translation>Верхний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1491"/>
+        <location filename="../tsmuxerwindow.ui" line="1481"/>
         <source>Top Right</source>
         <translation>Верхний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1496"/>
+        <location filename="../tsmuxerwindow.ui" line="1486"/>
         <source>Bottom Right</source>
         <translation>Нижний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1501"/>
+        <location filename="../tsmuxerwindow.ui" line="1491"/>
         <source>Bottom Left</source>
         <translation>Нижний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1509"/>
+        <location filename="../tsmuxerwindow.ui" line="1499"/>
         <source>Horizontal offset</source>
         <translation>Смещение по горизонтали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1526"/>
+        <location filename="../tsmuxerwindow.ui" line="1516"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1537"/>
+        <location filename="../tsmuxerwindow.ui" line="1527"/>
         <source>Not scaled</source>
         <translation>Не маштабировать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1542"/>
+        <location filename="../tsmuxerwindow.ui" line="1532"/>
         <source>Half (x 1/2)</source>
         <translation>Половина (x 1/2)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1547"/>
+        <location filename="../tsmuxerwindow.ui" line="1537"/>
         <source>Quarter (x 1/4)</source>
         <translation>Четверть (x 1/4)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1552"/>
+        <location filename="../tsmuxerwindow.ui" line="1542"/>
         <source>One and a Half (x 1.5)</source>
         <translation>Полтора (x 1.5)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1557"/>
+        <location filename="../tsmuxerwindow.ui" line="1547"/>
         <source>Full Screen</source>
         <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1578"/>
+        <location filename="../tsmuxerwindow.ui" line="1568"/>
         <source>Vertical offset</source>
         <translation>Смещение по вертикали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1600"/>
+        <location filename="../tsmuxerwindow.ui" line="1590"/>
         <source>Default tracks</source>
         <translation>Дорожки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1606"/>
+        <location filename="../tsmuxerwindow.ui" line="1596"/>
         <source>Subtitle</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1616"/>
+        <location filename="../tsmuxerwindow.ui" line="1606"/>
         <source>When checked, only subtitles marked as &quot;forced&quot; in the subtitle stream will appear.</source>
         <translation>Если установлен будут отображаться только субтитры, помеченные как &quot;принудительные&quot;.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1619"/>
+        <location filename="../tsmuxerwindow.ui" line="1609"/>
         <source>Forced only</source>
         <translation>Только принудительные</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1626"/>
+        <location filename="../tsmuxerwindow.ui" line="1616"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1666"/>
+        <location filename="../tsmuxerwindow.ui" line="1656"/>
         <source>Split &amp;&amp; cut</source>
         <translation>Нарезка &amp;&amp; обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1681"/>
+        <location filename="../tsmuxerwindow.ui" line="1671"/>
         <source>Splitting</source>
         <translation>Нарезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1692"/>
+        <location filename="../tsmuxerwindow.ui" line="1682"/>
         <source>No split</source>
         <translation>Не нарезать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1702"/>
+        <location filename="../tsmuxerwindow.ui" line="1692"/>
         <source>Split by duration every</source>
         <translation>Нарезать через каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1728"/>
+        <location filename="../tsmuxerwindow.ui" line="1718"/>
         <source>sec</source>
         <translation>сек</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1735"/>
+        <location filename="../tsmuxerwindow.ui" line="1725"/>
         <source>Split by size every</source>
         <translation>Нарезать по размеру каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1768"/>
+        <location filename="../tsmuxerwindow.ui" line="1758"/>
         <source>KB</source>
         <translation>Килобайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1773"/>
+        <location filename="../tsmuxerwindow.ui" line="1763"/>
         <source>KiB</source>
         <translation>Кибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1778"/>
+        <location filename="../tsmuxerwindow.ui" line="1768"/>
         <source>MB</source>
         <translation>Мегабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1783"/>
+        <location filename="../tsmuxerwindow.ui" line="1773"/>
         <source>MiB</source>
         <translation>Мебибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1788"/>
+        <location filename="../tsmuxerwindow.ui" line="1778"/>
         <source>GB</source>
         <translation>Гигабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1793"/>
+        <location filename="../tsmuxerwindow.ui" line="1783"/>
         <source>GiB</source>
         <translation>Гибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1825"/>
+        <location filename="../tsmuxerwindow.ui" line="1815"/>
         <source>Cutting</source>
         <translation>Обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1836"/>
+        <location filename="../tsmuxerwindow.ui" line="1826"/>
         <source>Enable cutting</source>
         <translation>Разрешить обрезку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1847"/>
+        <location filename="../tsmuxerwindow.ui" line="1837"/>
         <source>Start</source>
         <translation>Начало</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1857"/>
+        <location filename="../tsmuxerwindow.ui" line="1847"/>
         <source>End</source>
         <translation>Конец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1937"/>
+        <location filename="../tsmuxerwindow.ui" line="1927"/>
         <source>Subtitles</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1952"/>
+        <location filename="../tsmuxerwindow.ui" line="1942"/>
         <source> Default text based subtitles font: </source>
         <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
+        <location filename="../tsmuxerwindow.ui" line="1966"/>
+        <location filename="../tsmuxerwindow.ui" line="1971"/>
         <location filename="../tsmuxerwindow.ui" line="1976"/>
         <location filename="../tsmuxerwindow.ui" line="1981"/>
         <location filename="../tsmuxerwindow.ui" line="1986"/>
-        <location filename="../tsmuxerwindow.ui" line="1991"/>
-        <location filename="../tsmuxerwindow.ui" line="1996"/>
         <source>New Row</source>
         <translation>Новая Строка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2001"/>
-        <location filename="../tsmuxerwindow.ui" line="2006"/>
+        <location filename="../tsmuxerwindow.ui" line="1991"/>
+        <location filename="../tsmuxerwindow.ui" line="1996"/>
         <source>New Column</source>
         <translation>Новый Столбец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2011"/>
+        <location filename="../tsmuxerwindow.ui" line="2001"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2021"/>
+        <location filename="../tsmuxerwindow.ui" line="2011"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2026"/>
+        <location filename="../tsmuxerwindow.ui" line="2016"/>
         <source>65</source>
         <translation>65</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2031"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2036"/>
+        <location filename="../tsmuxerwindow.ui" line="2026"/>
         <source>0xffffffff</source>
         <translation>0xffffffff</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2041"/>
+        <location filename="../tsmuxerwindow.ui" line="2031"/>
         <source>Charset:</source>
         <translation>Набор символов:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2046"/>
+        <location filename="../tsmuxerwindow.ui" line="2036"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2051"/>
+        <location filename="../tsmuxerwindow.ui" line="2041"/>
         <source>Options:</source>
         <translation>Параметры:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2072"/>
+        <location filename="../tsmuxerwindow.ui" line="2062"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2079"/>
+        <location filename="../tsmuxerwindow.ui" line="2069"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2103"/>
+        <location filename="../tsmuxerwindow.ui" line="2093"/>
         <source>Additional border, pixels:</source>
         <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2129"/>
+        <location filename="../tsmuxerwindow.ui" line="2119"/>
         <source>line spacing:</source>
         <translation>Междустрочное расстояние:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2155"/>
+        <location filename="../tsmuxerwindow.ui" line="2145"/>
         <source>Fade in/out animation:</source>
         <translation>Анимация появления/исчезания:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2166"/>
+        <location filename="../tsmuxerwindow.ui" line="2156"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2171"/>
+        <location filename="../tsmuxerwindow.ui" line="2161"/>
         <source>Fast</source>
         <translation>Быстрое</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2176"/>
+        <location filename="../tsmuxerwindow.ui" line="2166"/>
         <source>Medium</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2181"/>
+        <location filename="../tsmuxerwindow.ui" line="2171"/>
         <source>Slow</source>
         <translation>Медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2186"/>
+        <location filename="../tsmuxerwindow.ui" line="2176"/>
         <source>Very slow</source>
         <translation>Очень медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2222"/>
+        <location filename="../tsmuxerwindow.ui" line="2212"/>
         <source> Vertical position: </source>
         <translation> Позиция по вертикали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2233"/>
+        <location filename="../tsmuxerwindow.ui" line="2223"/>
         <source>Top of screen</source>
         <translation>Верх экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2267"/>
+        <location filename="../tsmuxerwindow.ui" line="2257"/>
         <source>top offset, pixels:</source>
         <translation>отступ от верха, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2301"/>
-        <location filename="../tsmuxerwindow.ui" line="2473"/>
+        <location filename="../tsmuxerwindow.ui" line="2291"/>
+        <location filename="../tsmuxerwindow.ui" line="2463"/>
         <source>Screen center</source>
         <translation>Центр экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2308"/>
+        <location filename="../tsmuxerwindow.ui" line="2298"/>
         <source>Bottom of screen</source>
         <translation>Низ экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2342"/>
+        <location filename="../tsmuxerwindow.ui" line="2332"/>
         <source>bottom offset, pixels:</source>
         <translation>отступ от низа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2394"/>
+        <location filename="../tsmuxerwindow.ui" line="2384"/>
         <source> Horizontal position: </source>
         <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2405"/>
+        <location filename="../tsmuxerwindow.ui" line="2395"/>
         <source>Left of screen</source>
         <translation>слева экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2439"/>
+        <location filename="../tsmuxerwindow.ui" line="2429"/>
         <source>left offset, pixels:</source>
         <translation>отступ слева, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2486"/>
+        <location filename="../tsmuxerwindow.ui" line="2476"/>
         <source>Right of screen</source>
         <translation>справа экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2523"/>
+        <location filename="../tsmuxerwindow.ui" line="2513"/>
         <source>right offset, pixels:</source>
         <translation>отступ справа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2588"/>
+        <location filename="../tsmuxerwindow.ui" line="2578"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2630"/>
         <source>Output</source>
         <translation>Результат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2707"/>
+        <location filename="../tsmuxerwindow.ui" line="2644"/>
         <source>TS muxing</source>
         <translation>Запись в TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2723"/>
+        <location filename="../tsmuxerwindow.ui" line="2660"/>
         <source>M2TS muxing</source>
         <translation>Запись в M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2730"/>
+        <location filename="../tsmuxerwindow.ui" line="2667"/>
         <source>Blu-ray ISO</source>
         <translation>Запись блюрея в файл ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2743"/>
+        <location filename="../tsmuxerwindow.ui" line="2680"/>
         <source>Blu-ray folder</source>
         <translation>Запись блюрея в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2750"/>
+        <location filename="../tsmuxerwindow.ui" line="2687"/>
         <source>AVCHD folder</source>
         <translation>Запись AVCHD в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2763"/>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.cpp" line="1419"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2787"/>
+        <location filename="../tsmuxerwindow.ui" line="2724"/>
         <source>Disk label</source>
         <translation>Имя диска</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.ui" line="2734"/>
+        <location filename="../tsmuxerwindow.cpp" line="2384"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2823"/>
+        <location filename="../tsmuxerwindow.ui" line="2760"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2847"/>
+        <location filename="../tsmuxerwindow.ui" line="2784"/>
         <source>Meta file</source>
         <translation>Файл проекта tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2929"/>
-        <location filename="../tsmuxerwindow.cpp" line="2350"/>
+        <location filename="../tsmuxerwindow.ui" line="2853"/>
+        <location filename="../tsmuxerwindow.cpp" line="2370"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2948"/>
+        <location filename="../tsmuxerwindow.ui" line="2878"/>
         <source>Save meta file</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="534"/>
+        <location filename="../tsmuxerwindow.cpp" line="25"/>
+        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="48"/>
+        <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <source>Transport stream (*.ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="550"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="600"/>
-        <location filename="../tsmuxerwindow.cpp" line="1117"/>
+        <location filename="../tsmuxerwindow.cpp" line="616"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="601"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="871"/>
+        <location filename="../tsmuxerwindow.cpp" line="887"/>
         <source>Add media file</source>
         <translation>Добавить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="908"/>
+        <location filename="../tsmuxerwindow.cpp" line="924"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="909"/>
+        <location filename="../tsmuxerwindow.cpp" line="925"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1122"/>
+        <location filename="../tsmuxerwindow.cpp" line="1138"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="1149"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation>Некоторые дорожки не распознаны. Эта дорожка была проигнорирована. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1403"/>
+        <location filename="../tsmuxerwindow.cpp" line="1419"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1422"/>
+        <location filename="../tsmuxerwindow.cpp" line="1438"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1426"/>
+        <location filename="../tsmuxerwindow.cpp" line="1442"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1444"/>
+        <location filename="../tsmuxerwindow.cpp" line="1460"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2204"/>
-        <location filename="../tsmuxerwindow.cpp" line="2205"/>
+        <location filename="../tsmuxerwindow.cpp" line="2224"/>
+        <location filename="../tsmuxerwindow.cpp" line="2225"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2212"/>
+        <location filename="../tsmuxerwindow.cpp" line="2232"/>
         <source>Append media file</source>
         <translation>Присоединить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2249"/>
+        <location filename="../tsmuxerwindow.cpp" line="2269"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2250"/>
+        <location filename="../tsmuxerwindow.cpp" line="2270"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2348"/>
+        <location filename="../tsmuxerwindow.cpp" line="2368"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2360"/>
+        <location filename="../tsmuxerwindow.cpp" line="2380"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2450"/>
+        <location filename="../tsmuxerwindow.cpp" line="2470"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2472"/>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2492"/>
+        <location filename="../tsmuxerwindow.cpp" line="2508"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2493"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2489"/>
+        <location filename="../tsmuxerwindow.cpp" line="2509"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2505"/>
+        <location filename="../tsmuxerwindow.cpp" line="2525"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2506"/>
+        <location filename="../tsmuxerwindow.cpp" line="2526"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2543"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2543"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2552"/>
+        <location filename="../tsmuxerwindow.cpp" line="2572"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2553"/>
+        <location filename="../tsmuxerwindow.cpp" line="2573"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -106,7 +106,6 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="50"/>
         <source>General track options</source>
         <translation>Общие параметры дорожки</translation>
     </message>
@@ -197,7 +196,6 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="52"/>
         <source>Demux options</source>
         <translation>Параметры записи дорожек</translation>
     </message>
@@ -328,651 +326,626 @@
         <translation>Главы:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1247"/>
+        <location filename="../tsmuxerwindow.ui" line="1257"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1253"/>
+        <location filename="../tsmuxerwindow.ui" line="1263"/>
         <source>Add blank playlist for cropped video</source>
         <translation>Добавить пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1281"/>
+        <location filename="../tsmuxerwindow.ui" line="1291"/>
         <source>Blank playlist</source>
         <translation>Пустой плэйлист</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1319"/>
+        <location filename="../tsmuxerwindow.ui" line="1329"/>
         <source>Force BD-ROM V3 format</source>
         <translation>Задать 3 версию формата BD-ROM</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1331"/>
+        <location filename="../tsmuxerwindow.ui" line="1341"/>
         <source>First MPLS file</source>
         <translation>Первый файл MPLS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1354"/>
+        <location filename="../tsmuxerwindow.ui" line="1364"/>
         <source>First M2TS file</source>
         <translation>Первый файл M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1384"/>
+        <location filename="../tsmuxerwindow.ui" line="1394"/>
         <source>Start mux time</source>
         <translation>Время начала записи</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1410"/>
+        <location filename="../tsmuxerwindow.ui" line="1420"/>
         <source>45 Khz clock:</source>
         <translation>1/45 милисекунды:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1435"/>
+        <location filename="../tsmuxerwindow.ui" line="1445"/>
         <source>3D settings</source>
         <translation>Настройки 3D</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1441"/>
+        <location filename="../tsmuxerwindow.ui" line="1451"/>
         <source>Use base video stream for right eye</source>
         <translation>Использовать основной видеопоток для правого глаза</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1457"/>
+        <location filename="../tsmuxerwindow.ui" line="1467"/>
         <source>PIP settings</source>
         <translation>Настройки PIP</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1465"/>
+        <location filename="../tsmuxerwindow.ui" line="1475"/>
         <source>Corner</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1476"/>
+        <location filename="../tsmuxerwindow.ui" line="1486"/>
         <source>Top Left</source>
         <translation>Верхний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1481"/>
+        <location filename="../tsmuxerwindow.ui" line="1491"/>
         <source>Top Right</source>
         <translation>Верхний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1486"/>
+        <location filename="../tsmuxerwindow.ui" line="1496"/>
         <source>Bottom Right</source>
         <translation>Нижний Правый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1491"/>
+        <location filename="../tsmuxerwindow.ui" line="1501"/>
         <source>Bottom Left</source>
         <translation>Нижний Левый</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1499"/>
+        <location filename="../tsmuxerwindow.ui" line="1509"/>
         <source>Horizontal offset</source>
         <translation>Смещение по горизонтали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1516"/>
+        <location filename="../tsmuxerwindow.ui" line="1526"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1527"/>
+        <location filename="../tsmuxerwindow.ui" line="1537"/>
         <source>Not scaled</source>
         <translation>Не маштабировать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1532"/>
+        <location filename="../tsmuxerwindow.ui" line="1542"/>
         <source>Half (x 1/2)</source>
         <translation>Половина (x 1/2)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1537"/>
+        <location filename="../tsmuxerwindow.ui" line="1547"/>
         <source>Quarter (x 1/4)</source>
         <translation>Четверть (x 1/4)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1542"/>
+        <location filename="../tsmuxerwindow.ui" line="1552"/>
         <source>One and a Half (x 1.5)</source>
         <translation>Полтора (x 1.5)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1547"/>
+        <location filename="../tsmuxerwindow.ui" line="1557"/>
         <source>Full Screen</source>
         <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1568"/>
+        <location filename="../tsmuxerwindow.ui" line="1578"/>
         <source>Vertical offset</source>
         <translation>Смещение по вертикали</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1590"/>
+        <location filename="../tsmuxerwindow.ui" line="1600"/>
         <source>Default tracks</source>
         <translation>Дорожки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1596"/>
+        <location filename="../tsmuxerwindow.ui" line="1606"/>
         <source>Subtitle</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1606"/>
+        <location filename="../tsmuxerwindow.ui" line="1616"/>
         <source>When checked, only subtitles marked as &quot;forced&quot; in the subtitle stream will appear.</source>
         <translation>Если установлен будут отображаться только субтитры, помеченные как &quot;принудительные&quot;.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1609"/>
+        <location filename="../tsmuxerwindow.ui" line="1619"/>
         <source>Forced only</source>
         <translation>Только принудительные</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1616"/>
+        <location filename="../tsmuxerwindow.ui" line="1626"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1656"/>
+        <location filename="../tsmuxerwindow.ui" line="1666"/>
         <source>Split &amp;&amp; cut</source>
         <translation>Нарезка &amp;&amp; обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1671"/>
+        <location filename="../tsmuxerwindow.ui" line="1681"/>
         <source>Splitting</source>
         <translation>Нарезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1682"/>
+        <location filename="../tsmuxerwindow.ui" line="1692"/>
         <source>No split</source>
         <translation>Не нарезать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1692"/>
+        <location filename="../tsmuxerwindow.ui" line="1702"/>
         <source>Split by duration every</source>
         <translation>Нарезать через каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1718"/>
+        <location filename="../tsmuxerwindow.ui" line="1728"/>
         <source>sec</source>
         <translation>сек</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1725"/>
+        <location filename="../tsmuxerwindow.ui" line="1735"/>
         <source>Split by size every</source>
         <translation>Нарезать по размеру каждые</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1758"/>
+        <location filename="../tsmuxerwindow.ui" line="1768"/>
         <source>KB</source>
         <translation>Килобайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1763"/>
+        <location filename="../tsmuxerwindow.ui" line="1773"/>
         <source>KiB</source>
         <translation>Кибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1768"/>
+        <location filename="../tsmuxerwindow.ui" line="1778"/>
         <source>MB</source>
         <translation>Мегабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1773"/>
+        <location filename="../tsmuxerwindow.ui" line="1783"/>
         <source>MiB</source>
         <translation>Мебибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1778"/>
+        <location filename="../tsmuxerwindow.ui" line="1788"/>
         <source>GB</source>
         <translation>Гигабайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1783"/>
+        <location filename="../tsmuxerwindow.ui" line="1793"/>
         <source>GiB</source>
         <translation>Гибибайт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1815"/>
+        <location filename="../tsmuxerwindow.ui" line="1825"/>
         <source>Cutting</source>
         <translation>Обрезка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1826"/>
+        <location filename="../tsmuxerwindow.ui" line="1836"/>
         <source>Enable cutting</source>
         <translation>Разрешить обрезку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1837"/>
+        <location filename="../tsmuxerwindow.ui" line="1847"/>
         <source>Start</source>
         <translation>Начало</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1847"/>
+        <location filename="../tsmuxerwindow.ui" line="1857"/>
         <source>End</source>
         <translation>Конец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1927"/>
+        <location filename="../tsmuxerwindow.ui" line="1937"/>
         <source>Subtitles</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1942"/>
+        <location filename="../tsmuxerwindow.ui" line="1952"/>
         <source> Default text based subtitles font: </source>
         <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1975"/>
-        <location filename="../tsmuxerwindow.ui" line="1980"/>
-        <location filename="../tsmuxerwindow.ui" line="1985"/>
-        <location filename="../tsmuxerwindow.ui" line="1990"/>
-        <location filename="../tsmuxerwindow.ui" line="1995"/>
+        <location filename="../tsmuxerwindow.ui" line="1976"/>
+        <location filename="../tsmuxerwindow.ui" line="1981"/>
+        <location filename="../tsmuxerwindow.ui" line="1986"/>
+        <location filename="../tsmuxerwindow.ui" line="1991"/>
+        <location filename="../tsmuxerwindow.ui" line="1996"/>
         <source>New Row</source>
         <translation>Новая Строка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2000"/>
-        <location filename="../tsmuxerwindow.ui" line="2005"/>
+        <location filename="../tsmuxerwindow.ui" line="2001"/>
+        <location filename="../tsmuxerwindow.ui" line="2006"/>
         <source>New Column</source>
         <translation>Новый Столбец</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2010"/>
+        <location filename="../tsmuxerwindow.ui" line="2011"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2020"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2025"/>
+        <location filename="../tsmuxerwindow.ui" line="2026"/>
         <source>65</source>
         <translation>65</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2030"/>
+        <location filename="../tsmuxerwindow.ui" line="2031"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2035"/>
+        <location filename="../tsmuxerwindow.ui" line="2036"/>
         <source>0xffffffff</source>
         <translation>0xffffffff</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2040"/>
+        <location filename="../tsmuxerwindow.ui" line="2041"/>
         <source>Charset:</source>
         <translation>Набор символов:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2045"/>
+        <location filename="../tsmuxerwindow.ui" line="2046"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2050"/>
+        <location filename="../tsmuxerwindow.ui" line="2051"/>
         <source>Options:</source>
         <translation>Параметры:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2071"/>
+        <location filename="../tsmuxerwindow.ui" line="2072"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2078"/>
+        <location filename="../tsmuxerwindow.ui" line="2079"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2102"/>
+        <location filename="../tsmuxerwindow.ui" line="2103"/>
         <source>Additional border, pixels:</source>
         <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2128"/>
+        <location filename="../tsmuxerwindow.ui" line="2129"/>
         <source>line spacing:</source>
         <translation>Междустрочное расстояние:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2154"/>
+        <location filename="../tsmuxerwindow.ui" line="2155"/>
         <source>Fade in/out animation:</source>
         <translation>Анимация появления/исчезания:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2165"/>
+        <location filename="../tsmuxerwindow.ui" line="2166"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2170"/>
+        <location filename="../tsmuxerwindow.ui" line="2171"/>
         <source>Fast</source>
         <translation>Быстрое</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2175"/>
+        <location filename="../tsmuxerwindow.ui" line="2176"/>
         <source>Medium</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2180"/>
+        <location filename="../tsmuxerwindow.ui" line="2181"/>
         <source>Slow</source>
         <translation>Медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2185"/>
+        <location filename="../tsmuxerwindow.ui" line="2186"/>
         <source>Very slow</source>
         <translation>Очень медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2221"/>
+        <location filename="../tsmuxerwindow.ui" line="2222"/>
         <source> Vertical position: </source>
         <translation> Позиция по вертикали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2232"/>
+        <location filename="../tsmuxerwindow.ui" line="2233"/>
         <source>Top of screen</source>
         <translation>Верх экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2266"/>
+        <location filename="../tsmuxerwindow.ui" line="2267"/>
         <source>top offset, pixels:</source>
         <translation>отступ от верха, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2300"/>
-        <location filename="../tsmuxerwindow.ui" line="2472"/>
+        <location filename="../tsmuxerwindow.ui" line="2301"/>
+        <location filename="../tsmuxerwindow.ui" line="2473"/>
         <source>Screen center</source>
         <translation>Центр экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2307"/>
+        <location filename="../tsmuxerwindow.ui" line="2308"/>
         <source>Bottom of screen</source>
         <translation>Низ экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2341"/>
+        <location filename="../tsmuxerwindow.ui" line="2342"/>
         <source>bottom offset, pixels:</source>
         <translation>отступ от низа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2393"/>
+        <location filename="../tsmuxerwindow.ui" line="2394"/>
         <source> Horizontal position: </source>
         <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2404"/>
+        <location filename="../tsmuxerwindow.ui" line="2405"/>
         <source>Left of screen</source>
         <translation>слева экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2438"/>
+        <location filename="../tsmuxerwindow.ui" line="2439"/>
         <source>left offset, pixels:</source>
         <translation>отступ слева, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2485"/>
+        <location filename="../tsmuxerwindow.ui" line="2486"/>
         <source>Right of screen</source>
         <translation>справа экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2522"/>
+        <location filename="../tsmuxerwindow.ui" line="2523"/>
         <source>right offset, pixels:</source>
         <translation>отступ справа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2587"/>
+        <location filename="../tsmuxerwindow.ui" line="2588"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2639"/>
+        <location filename="../tsmuxerwindow.ui" line="2693"/>
         <source>Output</source>
         <translation>Результат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2653"/>
+        <location filename="../tsmuxerwindow.ui" line="2707"/>
         <source>TS muxing</source>
         <translation>Запись в TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2669"/>
+        <location filename="../tsmuxerwindow.ui" line="2723"/>
         <source>M2TS muxing</source>
         <translation>Запись в M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2676"/>
+        <location filename="../tsmuxerwindow.ui" line="2730"/>
         <source>Blu-ray ISO</source>
         <translation>Запись блюрея в файл ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2689"/>
+        <location filename="../tsmuxerwindow.ui" line="2743"/>
         <source>Blu-ray folder</source>
         <translation>Запись блюрея в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2696"/>
+        <location filename="../tsmuxerwindow.ui" line="2750"/>
         <source>AVCHD folder</source>
         <translation>Запись AVCHD в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2709"/>
-        <location filename="../tsmuxerwindow.cpp" line="1414"/>
+        <location filename="../tsmuxerwindow.ui" line="2763"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2733"/>
+        <location filename="../tsmuxerwindow.ui" line="2787"/>
         <source>Disk label</source>
         <translation>Имя диска</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2743"/>
-        <location filename="../tsmuxerwindow.cpp" line="2379"/>
+        <location filename="../tsmuxerwindow.ui" line="2797"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2769"/>
+        <location filename="../tsmuxerwindow.ui" line="2823"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2793"/>
+        <location filename="../tsmuxerwindow.ui" line="2847"/>
         <source>Meta file</source>
         <translation>Файл проекта tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2862"/>
-        <location filename="../tsmuxerwindow.cpp" line="2365"/>
+        <location filename="../tsmuxerwindow.ui" line="2929"/>
+        <location filename="../tsmuxerwindow.cpp" line="2350"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2887"/>
+        <location filename="../tsmuxerwindow.ui" line="2948"/>
         <source>Save meta file</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="25"/>
-        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="48"/>
-        <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="54"/>
-        <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="56"/>
-        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="58"/>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="545"/>
+        <location filename="../tsmuxerwindow.cpp" line="534"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="611"/>
-        <location filename="../tsmuxerwindow.cpp" line="1128"/>
+        <location filename="../tsmuxerwindow.cpp" line="600"/>
+        <location filename="../tsmuxerwindow.cpp" line="1117"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="612"/>
+        <location filename="../tsmuxerwindow.cpp" line="601"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="882"/>
+        <location filename="../tsmuxerwindow.cpp" line="871"/>
         <source>Add media file</source>
         <translation>Добавить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="919"/>
+        <location filename="../tsmuxerwindow.cpp" line="908"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="920"/>
+        <location filename="../tsmuxerwindow.cpp" line="909"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1133"/>
+        <location filename="../tsmuxerwindow.cpp" line="1122"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1144"/>
+        <location filename="../tsmuxerwindow.cpp" line="1133"/>
         <source>Some tracks not recognized. This tracks was ignored. File name: &quot;%1&quot;</source>
         <translation>Некоторые дорожки не распознаны. Эта дорожка была проигнорирована. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1414"/>
+        <location filename="../tsmuxerwindow.cpp" line="1403"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1433"/>
+        <location filename="../tsmuxerwindow.cpp" line="1422"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1437"/>
+        <location filename="../tsmuxerwindow.cpp" line="1426"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1455"/>
+        <location filename="../tsmuxerwindow.cpp" line="1444"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2219"/>
-        <location filename="../tsmuxerwindow.cpp" line="2220"/>
+        <location filename="../tsmuxerwindow.cpp" line="2204"/>
+        <location filename="../tsmuxerwindow.cpp" line="2205"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2227"/>
+        <location filename="../tsmuxerwindow.cpp" line="2212"/>
         <source>Append media file</source>
         <translation>Присоединить медиафайл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2264"/>
+        <location filename="../tsmuxerwindow.cpp" line="2249"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2265"/>
+        <location filename="../tsmuxerwindow.cpp" line="2250"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2363"/>
+        <location filename="../tsmuxerwindow.cpp" line="2348"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2375"/>
+        <location filename="../tsmuxerwindow.cpp" line="2360"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2465"/>
+        <location filename="../tsmuxerwindow.cpp" line="2450"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2487"/>
-        <location filename="../tsmuxerwindow.cpp" line="2503"/>
+        <location filename="../tsmuxerwindow.cpp" line="2472"/>
+        <location filename="../tsmuxerwindow.cpp" line="2488"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2488"/>
+        <location filename="../tsmuxerwindow.cpp" line="2473"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2504"/>
+        <location filename="../tsmuxerwindow.cpp" line="2489"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2518"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2518"/>
+        <location filename="../tsmuxerwindow.cpp" line="2503"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2520"/>
+        <location filename="../tsmuxerwindow.cpp" line="2505"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2521"/>
+        <location filename="../tsmuxerwindow.cpp" line="2506"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2538"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2538"/>
+        <location filename="../tsmuxerwindow.cpp" line="2523"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2567"/>
+        <location filename="../tsmuxerwindow.cpp" line="2552"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2568"/>
+        <location filename="../tsmuxerwindow.cpp" line="2553"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1895,7 +1895,8 @@ void TsMuxerWindow::updateMetaLines()
         return;
 
     ui->memoMeta->clear();
-    ui->memoMeta->append(getMuxOpts());
+    QString metaContent;
+    metaContent.append(getMuxOpts() + '\n');
     QString tmpFps;
     for (int i = 0; i < ui->trackLV->rowCount(); ++i)
     {
@@ -1960,7 +1961,7 @@ void TsMuxerWindow::updateMetaLines()
         if (codecInfo->subTrack != 0)
             postfix += QString(", subTrack=") + QString::number(codecInfo->subTrack);
         if (isVideoCodec(codecInfo->displayName))
-            ui->memoMeta->append(prefix + getVideoMetaInfo(codecInfo) + postfix);
+            metaContent.append(prefix + getVideoMetaInfo(codecInfo) + postfix + '\n');
         else
         {
             if (isDiskOutput() && ui->defaultAudioTrackCheckBox->isChecked() &&
@@ -1968,9 +1969,10 @@ void TsMuxerWindow::updateMetaLines()
             {
                 postfix += QString(", default");
             }
-            ui->memoMeta->append(prefix + getAudioMetaInfo(codecInfo) + postfix);
+            metaContent.append(prefix + getAudioMetaInfo(codecInfo) + postfix + '\n');
         }
     }
+    ui->memoMeta->setPlainText(metaContent);
 }
 
 void TsMuxerWindow::onFontBtnClicked()

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -309,11 +309,6 @@ TsMuxerWindow::TsMuxerWindow()
 
     ui->outFileName->setText(getDefaultOutputFileName());
 
-    // next properties supported by Designer in version 4.5 only.
-    ui->listViewFont->horizontalHeader()->setVisible(false);
-    ui->listViewFont->verticalHeader()->setVisible(false);
-    ui->listViewFont->horizontalHeader()->setStretchLastSection(true);
-
     m_header = new QnCheckBoxedHeaderView(this);
     ui->trackLV->setHorizontalHeader(m_header);
     ui->trackLV->horizontalHeader()->setStretchLastSection(true);

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -382,7 +382,7 @@ TsMuxerWindow::TsMuxerWindow()
     connect(ui->radioButtonNoChapters, &QAbstractButton::clicked, this, &TsMuxerWindow::onChapterParamsChanged);
     connect(ui->radioButtonCustomChapters, &QAbstractButton::clicked, this, &TsMuxerWindow::onChapterParamsChanged);
     connect(ui->spinEditChapterLen, spinBoxValueChanged, this, &TsMuxerWindow::onChapterParamsChanged);
-    connect(ui->memoChapters, &QTextEdit::textChanged, this, &TsMuxerWindow::onChapterParamsChanged);
+    connect(ui->memoChapters, &QPlainTextEdit::textChanged, this, &TsMuxerWindow::onChapterParamsChanged);
     connect(ui->noSplit, &QAbstractButton::clicked, this, &TsMuxerWindow::onSplitCutParamsChanged);
     connect(ui->splitByDuration, &QAbstractButton::clicked, this, &TsMuxerWindow::onSplitCutParamsChanged);
     connect(ui->splitBySize, &QAbstractButton::clicked, this, &TsMuxerWindow::onSplitCutParamsChanged);

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -229,6 +229,13 @@ QString getComboBoxTrackText(int idx, const QtvCodecInfo &codecInfo)
     return text;
 }
 
+void initLanguageComboBox(QComboBox *comboBox)
+{
+    comboBox->addItem("English", "en");
+    comboBox->addItem(QString::fromUtf8("Русский"), "ru");
+    comboBox->setCurrentIndex(-1);  // makes sure currentIndexChanged() is emitted when reading settings.
+}
+
 }  // namespace
 
 // ----------------------- TsMuxerWindow -------------------------------------
@@ -269,6 +276,7 @@ TsMuxerWindow::TsMuxerWindow()
     ui->setupUi(this);
     qApp->installTranslator(&qtCoreTranslator);
     qApp->installTranslator(&tsMuxerTranslator);
+    initLanguageComboBox(ui->languageSelectComboBox);
     setWindowTitle("tsMuxeR GUI " TSMUXER_VERSION);
     lastInputDir = QDir::homePath();
     lastOutputDir = QDir::homePath();
@@ -369,8 +377,6 @@ TsMuxerWindow::TsMuxerWindow()
     connect(ui->checkBoxCrop, &QCheckBox::stateChanged, this, &TsMuxerWindow::onSavedParamChanged);
     connect(ui->checkBoxRVBR, &QAbstractButton::clicked, this, &TsMuxerWindow::onGeneralCheckboxClicked);
     connect(ui->checkBoxCBR, &QAbstractButton::clicked, this, &TsMuxerWindow::onGeneralCheckboxClicked);
-    // connect(ui->checkBoxuseAsynIO,	   SIGNAL(stateChanged(int)), this,
-    // SLOT(onSavedParamChanged()));
     connect(ui->radioButtonStoreOutput, &QAbstractButton::clicked, this, &TsMuxerWindow::onSavedParamChanged);
     connect(ui->radioButtonOutoutInInput, &QAbstractButton::clicked, this, &TsMuxerWindow::onSavedParamChanged);
     connect(ui->editVBVLen, spinBoxValueChanged, this, &TsMuxerWindow::onGeneralSpinboxValueChanged);
@@ -1872,10 +1878,9 @@ void TsMuxerWindow::updateMuxTime2()
     updateMetaLines();
 }
 
-void TsMuxerWindow::onLanguageComboBoxIndexChanged(int x)
+void TsMuxerWindow::onLanguageComboBoxIndexChanged(int idx)
 {
-    static const QString languages[] = {"en", "ru"};
-    auto lang = languages[x];
+    auto lang = ui->languageSelectComboBox->itemData(idx).toString();
     qtCoreTranslator.load(QString("qtbase_%1").arg(lang), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     tsMuxerTranslator.load(QString("tsmuxergui_%1").arg(lang), ":/i18n");
     QFile aboutContent(QString(":/about_%1.html").arg(lang));
@@ -1886,6 +1891,7 @@ void TsMuxerWindow::onLanguageComboBoxIndexChanged(int x)
     else
     {
         qWarning() << "Failed to open about.html for language" << lang << aboutContent.errorString();
+        ui->textEdit->clear();
     }
 }
 

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1878,6 +1878,15 @@ void TsMuxerWindow::onLanguageComboBoxIndexChanged(int x)
     auto lang = languages[x];
     qtCoreTranslator.load(QString("qtbase_%1").arg(lang), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     tsMuxerTranslator.load(QString("tsmuxergui_%1").arg(lang), ":/i18n");
+    QFile aboutContent(QString(":/about_%1.html").arg(lang));
+    if (aboutContent.open(QIODevice::ReadOnly))
+    {
+        ui->textEdit->setHtml(QString::fromUtf8(aboutContent.readAll()));
+    }
+    else
+    {
+        qWarning() << "Failed to open about.html for language" << lang << aboutContent.errorString();
+    }
 }
 
 void TsMuxerWindow::updateMetaLines()

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -20,8 +20,10 @@
 #include "muxForm.h"
 #include "ui_tsmuxerwindow.h"
 
-const char fileDialogFilter[] =
-    "All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;\
+QString fileDialogFilter()
+{
+    return TsMuxerWindow::tr(
+        "All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;\
 AC3/E-AC3 (*.ac3 *.ddp);;\
 AAC (advanced audio coding) (*.aac);;\
 AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;\
@@ -40,14 +42,20 @@ Blu-ray PGS subtitles (*.sup);;\
 Text subtitles (*.srt);;\
 WAVE - Uncompressed PCM audio (*.wav *.w64);;\
 RAW LPCM Stream (*.pcm);;\
-All files (*.*)";
-const char saveMetaFilter[] = "tsMuxeR project file (*.meta);;All files (*.*)";
+All files (*.*)");
+}
 
-const char TI_DEFAULT_TAB_NAME[] = "General track options";
-const char TI_DEMUX_TAB_NAME[] = "Demux options";
-const char TS_SAVE_DIALOG_FILTER[] = "Transport stream (*.ts);;all files (*.*)";
-const char M2TS_SAVE_DIALOG_FILTER[] = "BDAV Transport Stream (*.m2ts);;all files (*.*)";
-const char ISO_SAVE_DIALOG_FILTER[] = "Disk image (*.iso);;all files (*.*)";
+QString saveMetaFilter() { return TsMuxerWindow::tr("tsMuxeR project file (*.meta);;All files (*.*)"); }
+
+QString TI_DEFAULT_TAB_NAME() { return TsMuxerWindow::tr("General track options"); }
+
+QString TI_DEMUX_TAB_NAME() { return TsMuxerWindow::tr("Demux options"); }
+
+QString TS_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("Transport stream (*.ts);;all files (*.*)"); }
+
+QString M2TS_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("BDAV Transport Stream (*.m2ts);;all files (*.*)"); }
+
+QString ISO_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("Disk image (*.iso);;all files (*.*)"); }
 
 QSettings *settings = nullptr;
 
@@ -318,7 +326,7 @@ TsMuxerWindow::TsMuxerWindow()
     /////////////////////////////////////////////////////////////
     for (int i = 0; i <= 3600; i += 5 * 60) ui->memoChapters->insertPlainText(floatToTime(i, '.') + '\n');
 
-    saveDialogFilter = tr(TS_SAVE_DIALOG_FILTER);
+    mSaveDialogFilter = TS_SAVE_DIALOG_FILTER();
     const static int colWidths[] = {28, 200, 62, 38, 10};
     for (unsigned i = 0u; i < sizeof(colWidths) / sizeof(int); ++i)
         ui->trackLV->horizontalHeader()->resizeSection(i, colWidths[i]);
@@ -876,7 +884,7 @@ void TsMuxerWindow::addFiles(const QList<QUrl> &files)
 void TsMuxerWindow::onAddBtnClick()
 {
     QString fileName = QDir::toNativeSeparators(
-        QFileDialog::getOpenFileName(this, tr("Add media file"), lastInputDir, tr(fileDialogFilter)));
+        QFileDialog::getOpenFileName(this, tr("Add media file"), lastInputDir, fileDialogFilter()));
     if (fileName.isEmpty())
         return;
     lastInputDir = fileName;
@@ -944,7 +952,7 @@ void TsMuxerWindow::trackLVItemSelectionChanged()
     while (ui->tabWidgetTracks->count()) ui->tabWidgetTracks->removeTab(0);
     if (ui->trackLV->currentRow() == -1)
     {
-        ui->tabWidgetTracks->addTab(ui->tabSheetFake, tr(TI_DEFAULT_TAB_NAME));
+        ui->tabWidgetTracks->addTab(ui->tabSheetFake, TI_DEFAULT_TAB_NAME());
         return;
     }
     QtvCodecInfo *codecInfo = getCurrentCodec();
@@ -955,7 +963,7 @@ void TsMuxerWindow::trackLVItemSelectionChanged()
     {
         if (isVideoCodec(codecInfo->displayName))
         {
-            ui->tabWidgetTracks->addTab(ui->tabSheetVideo, tr(TI_DEFAULT_TAB_NAME));
+            ui->tabWidgetTracks->addTab(ui->tabSheetVideo, TI_DEFAULT_TAB_NAME());
 
             ui->checkFPS->setChecked(codecInfo->checkFPS);
             ui->checkBoxLevel->setChecked(codecInfo->checkLevel);
@@ -986,9 +994,9 @@ void TsMuxerWindow::trackLVItemSelectionChanged()
         }
         else
         {
-            ui->tabWidgetTracks->addTab(ui->tabSheetAudio, tr(TI_DEFAULT_TAB_NAME));
+            ui->tabWidgetTracks->addTab(ui->tabSheetAudio, TI_DEFAULT_TAB_NAME());
             if (codecInfo->displayName == "LPCM")
-                ui->tabWidgetTracks->addTab(ui->demuxLpcmOptions, tr(TI_DEMUX_TAB_NAME));
+                ui->tabWidgetTracks->addTab(ui->demuxLpcmOptions, TI_DEMUX_TAB_NAME());
 
             if (codecInfo->displayName == "DTS-HD")
                 ui->dtsDwnConvert->setText("Downconvert DTS-HD to DTS");
@@ -2176,7 +2184,7 @@ void TsMuxerWindow::deleteTrack(int idx)
     {
         lastSourceDir.clear();
         while (ui->tabWidgetTracks->count()) ui->tabWidgetTracks->removeTab(0);
-        ui->tabWidgetTracks->addTab(ui->tabSheetFake, tr(TI_DEFAULT_TAB_NAME));
+        ui->tabWidgetTracks->addTab(ui->tabSheetFake, TI_DEFAULT_TAB_NAME());
         ui->outFileName->setText(getDefaultOutputFileName());
         outFileNameModified = false;
     }
@@ -2221,7 +2229,7 @@ void TsMuxerWindow::onAppendButtonClick()
         return;
     }
     QString fileName = QDir::toNativeSeparators(
-        QFileDialog::getOpenFileName(this, tr("Append media file"), lastInputDir, tr(fileDialogFilter)));
+        QFileDialog::getOpenFileName(this, tr("Append media file"), lastInputDir, fileDialogFilter()));
     if (fileName.isEmpty())
         return;
     lastInputDir = fileName;
@@ -2385,17 +2393,17 @@ void TsMuxerWindow::RadioButtonMuxClick()
         if (ui->radioButtonTS->isChecked())
         {
             ui->outFileName->setText(changeFileExt(ui->outFileName->text(), "ts"));
-            saveDialogFilter = tr(TS_SAVE_DIALOG_FILTER);
+            mSaveDialogFilter = TS_SAVE_DIALOG_FILTER();
         }
         else if (ui->radioButtonBluRayISO->isChecked())
         {
             ui->outFileName->setText(changeFileExt(ui->outFileName->text(), "iso"));
-            saveDialogFilter = tr(ISO_SAVE_DIALOG_FILTER);
+            mSaveDialogFilter = ISO_SAVE_DIALOG_FILTER();
         }
         else
         {
             ui->outFileName->setText(changeFileExt(ui->outFileName->text(), "m2ts"));
-            saveDialogFilter = tr(M2TS_SAVE_DIALOG_FILTER);
+            mSaveDialogFilter = M2TS_SAVE_DIALOG_FILTER();
         }
     }
     ui->DiskLabel->setVisible(ui->radioButtonBluRayISO->isChecked());
@@ -2459,7 +2467,7 @@ void TsMuxerWindow::saveFileDialog()
             path = QFileInfo(fileName).absolutePath();
         }
         QString fileName = QDir::toNativeSeparators(
-            QFileDialog::getSaveFileName(this, tr("Select file for muxing"), path, saveDialogFilter));
+            QFileDialog::getSaveFileName(this, tr("Select file for muxing"), path, mSaveDialogFilter));
         if (!fileName.isEmpty())
         {
             ui->outFileName->setText(fileName);
@@ -2546,7 +2554,7 @@ void TsMuxerWindow::startMuxing()
 void TsMuxerWindow::saveMetaFileBtnClick()
 {
     QString metaName =
-        QFileDialog::getSaveFileName(this, "", changeFileExt(ui->outFileName->text(), "meta"), tr(saveMetaFilter));
+        QFileDialog::getSaveFileName(this, "", changeFileExt(ui->outFileName->text(), "meta"), mSaveDialogFilter);
     if (metaName.isEmpty())
         return;
     QFileInfo fi(metaName);

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -166,7 +166,7 @@ class TsMuxerWindow : public QWidget
     bool outFileNameModified;
     QString oldFileName;
     bool outFileNameDisableChange;
-    QString saveDialogFilter;
+    QString mSaveDialogFilter;
     MuxForm* muxForm;
     QString newFileName;
     QList<QtvCodecInfo> codecList;

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2583,68 +2583,15 @@
         </property>
         <item>
          <widget class="QTextEdit" name="textEdit">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
           <property name="html">
            <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;tsMuxeR&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/justdan96/tsMuxer&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;tsMuxeR&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; – the software utility to create TS and M2TS files for IP broadcasting as well as for viewing at hardware video players (i.e., Dune HD Ultra, Sony Playstation3, Samsung Smart TV and others). &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;tsMuxeR is open source. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Supported incoming formats: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;TS; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;M2TS; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;SIFF;&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;MOV;&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;MP4;&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;MKV;&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Blu-ray; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Demux option. &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Supported videocodecs: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;H.264/MVC &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;H.265/HEVC; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Microsoft VC-1; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;MPEG-2. &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Supported audiocodecs: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;AAC; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;AC3 / E-AC3(DD+); &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Dolby True HD (for streams with AC3 core only); &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;DTS/ DTS-HD; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;LPCM. &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Supported subtitle types: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;M2TS Presentation graphic stream. &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;SRT text subtitles &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Supported containers and formats: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Elementary stream; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Transport stream TS and M2TS; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Program stream EVO/VOB/MPG; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Matroska MKV/MKA. &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;MP4/MOV. &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Main features: &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;3D Blu-ray support;&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;UHD, HDR10, HDR10+ and Dolby Vision support; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Automatic or manual fps adjustment while mixing; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Level changing as well as SEI, SPS/PPS elements and NAL unit delimiter cycle insertion while mixing H.264; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Audio tracks and subtitles time shifting; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to extract DTS core from DTS-HD; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to extract AC3 core from True-HD; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to join files; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to adjust fps for subtitles; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to convert LPCM streams into WAVE and vice versa; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Track language information injection into blu-ray structure and TS header; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to cut source files; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to split output file; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to detect audio delay for TS/M2TS/MPG/VOB/EVO sources; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to remove pulldown info from stream; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to open Blu-ray playlist (MPLS) files; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ability to convert SRT subtitles to PGS; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Tags for SRT subtitles support - tags for changing font, color, size, etc.; tag's syntax is similar to HTML; &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;United cross-platform GUI - Windows, Linux, MacOS. &lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2932,6 +2932,12 @@ p, li { white-space: pre-wrap; }
      </item>
      <item>
       <widget class="QPushButton" name="buttonSaveMeta">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>128</width>
@@ -2940,7 +2946,7 @@ p, li { white-space: pre-wrap; }
        </property>
        <property name="maximumSize">
         <size>
-         <width>128</width>
+         <width>256</width>
          <height>16777215</height>
         </size>
        </property>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1961,6 +1961,15 @@
                  <height>84</height>
                 </size>
                </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="horizontalHeaderStretchLastSection">
+                <bool>true</bool>
+               </attribute>
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
                <row>
                 <property name="text">
                  <string>New Row</string>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2820,16 +2820,6 @@ p, li { white-space: pre-wrap; }
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <item>
-        <property name="text">
-         <string notr="true">English</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string notr="true">Русский</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2785,15 +2785,12 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
-           <widget class="QTextEdit" name="memoMeta">
+           <widget class="QPlainTextEdit" name="memoMeta">
             <property name="undoRedoEnabled">
              <bool>false</bool>
             </property>
             <property name="readOnly">
              <bool>true</bool>
-            </property>
-            <property name="acceptRichText">
-             <bool>false</bool>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1233,13 +1233,6 @@
              <property name="tabChangesFocus">
               <bool>true</bool>
              </property>
-             <property name="html">
-              <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
              <property name="tabStopWidth">
               <number>20</number>
              </property>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1226,7 +1226,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QTextEdit" name="memoChapters">
+            <widget class="QPlainTextEdit" name="memoChapters">
              <property name="enabled">
               <bool>false</bool>
              </property>
@@ -1235,9 +1235,6 @@
              </property>
              <property name="tabStopWidth">
               <number>20</number>
-             </property>
-             <property name="acceptRichText">
-              <bool>false</bool>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
The contents of the UI tab were saved as inline HTML in the UI file for `TsMuxerWindow`. Making them translatable would've exported the content to `.ts` files, which means that translators would have to put up with not only HTML, but HTML with XML escaping applied into it.
Moving the content to an external file seems like a best approach in this case. The content of the file is loaded in the appropriate language when switching languages. The HTML files themselves are included as resources at build time.
Other changes :
- The language combo box initialisation has been moved to the source file, which allows us to associate an additional `QVariant` with a particular combobox entry. Currently, this is used to save the language code which makes it unnecessary to have an external array that has to be kept synchronised with the combobox.
- Setting some properties of `listViewFont` has been moved to the UI file.
- The types of `memoChapters` and `memoMeta` have been changed from `QTextEdit` to `QPlainTextEdit`, since they never display formatted content.
- Strings used as file type filters have been made translatable.
- The size policy of the "Save meta file" button has been changed to "Preferred" in order to possibly accommodate bigger translated strings.