### PR TITLE
Fix broken ISO labels when using non-ASCII characters

### DIFF
--- a/tsMuxer/convertUTF.cpp
+++ b/tsMuxer/convertUTF.cpp
@@ -103,6 +103,20 @@ ConversionResult ConvertUTF32toUTF16(const UTF32** sourceStart, const UTF32* sou
     return result;
 }
 
+std::tuple<UTF16, UTF16> ConvertUTF32toUTF16(UTF32 ch)
+{
+    if (ch <= UNI_MAX_BMP)
+    {
+        return std::make_tuple(static_cast<UTF16>(ch), 0);
+    }
+    else
+    {
+        ch -= halfBase;
+        return std::make_tuple((UTF16)((ch >> halfShift) + UNI_SUR_HIGH_START),
+                               (UTF16)((ch & halfMask) + UNI_SUR_LOW_START));
+    }
+}
+
 /* --------------------------------------------------------------------- */
 
 ConversionResult ConvertUTF16toUTF32(const UTF16** sourceStart, const UTF16* sourceEnd, UTF32** targetStart,

--- a/tsMuxer/convertUTF.h
+++ b/tsMuxer/convertUTF.h
@@ -89,6 +89,7 @@
 
 #include <cstdint>
 #include <string>
+#include <tuple>
 
 namespace convertUTF
 {
@@ -135,6 +136,8 @@ ConversionResult ConvertUTF16toUTF32(const UTF16** sourceStart, const UTF16* sou
 
 ConversionResult ConvertUTF32toUTF16(const UTF32** sourceStart, const UTF32* sourceEnd, UTF16** targetStart,
                                      UTF16* targetEnd, ConversionFlags flags);
+
+std::tuple<UTF16, UTF16> ConvertUTF32toUTF16(UTF32);
 
 Boolean isLegalUTF8Sequence(const UTF8* source, const UTF8* sourceEnd);
 

--- a/tsMuxer/convertUTF.h
+++ b/tsMuxer/convertUTF.h
@@ -170,7 +170,8 @@ template <typename Fn>
 void IterateUTF8Chars(const std::string& utf8String, Fn f)
 {
     auto it = std::begin(utf8String);
-    while (it != std::end(utf8String))
+    bool keep_going = true;
+    while (keep_going && it != std::end(utf8String))
     {
         UTF32 ch = 0;
         unsigned short extraBytesToRead = trailingBytesForUTF8[static_cast<unsigned char>(*it)];
@@ -196,7 +197,7 @@ void IterateUTF8Chars(const std::string& utf8String, Fn f)
             ch += get_as_uchar();
         }
         ch -= offsetsFromUTF8[extraBytesToRead];
-        f(ch);
+        keep_going = f(ch);
     }
 }
 

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -124,9 +124,10 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
 {
     std::vector<std::uint8_t> rv;
 #ifdef _WIN32
-    auto utf8Str = convertUTF::isLegalUTF8String(utf8Str.c_str(), utf8Str.length())
+    auto str_u8 = reinterpret_cast<const std::uint8_t*>(str.c_str());
+    auto utf8Str = convertUTF::isLegalUTF8String(str_u8, str.length())
                        ? str
-                       : UtfConverter::toUtf8(utf8Str.c_str(), utf8Str.length(), UtfConverter::sfANSI);
+                       : UtfConverter::toUtf8(str_u8, str.length(), UtfConverter::sfANSI);
 #else
     auto& utf8Str = str;
 #endif
@@ -136,7 +137,7 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
     {
         rv.reserve(numChars);
         rv.push_back(8);
-        IterateUTF8Chars(utf8Str, [&](auto c) { rv.push_back(c & 0xff); });
+        IterateUTF8Chars(utf8Str, [&](auto c) { rv.push_back(c); });
     }
     else
     {

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -135,7 +135,7 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
     using namespace convertUTF;
     if (canUse8BitUnicode(utf8Str, numChars))
     {
-        rv.reserve(numChars);
+        rv.reserve(numChars + 1);
         rv.push_back(8);
         IterateUTF8Chars(utf8Str, [&](auto c) { rv.push_back(c); });
     }

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -143,7 +143,15 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
         rv.reserve(numChars * 3);
         rv.push_back(16);
         IterateUTF8Chars(utf8Str, [&](auto c) {
-
+            UTF16 high_surrogate, low_surrogate;
+            std::tie(high_surrogate, low_surrogate) = ConvertUTF32toUTF16(c);
+            rv.push_back(high_surrogate >> 8);
+            rv.push_back(high_surrogate);
+            if (low_surrogate)
+            {
+                rv.push_back(low_surrogate >> 8);
+                rv.push_back(low_surrogate);
+            }
         });
     }
     return rv;

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -8,7 +8,6 @@
 
 #include "convertUTF.h"
 #include "utf8Converter.h"
-#include "vodCoreException.h"
 #include "vod_common.h"
 
 // ----------- routines --------------
@@ -66,10 +65,12 @@ void writeDescriptorTag(uint8_t* buffer, uint16_t tag, uint32_t tagLocation)
 
 std::string toIsoSeparator(const std::string& path)
 {
-    std::string result;
-    result.reserve(path.size());
-    std::transform(std::begin(path), std::end(path), std::back_inserter(result),
-                   [](auto c) { return c == '\\' ? '/' : c; });
+    std::string result = path;
+    for (int i = 0; i < result.size(); ++i)
+    {
+        if (result[i] == '\\')
+            result[i] = '/';
+    }
     return result;
 }
 

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -109,19 +109,22 @@ void writeTimestamp(uint8_t* buffer, time_t time)
     buffer[11] = 0;
 }
 
-bool canUse8BitUnicode(const std::string& utf8Str, unsigned int& numChars)
+bool canUse8BitUnicode(const std::string& utf8Str)
 {
     bool rv = true;
-    numChars = 0;
     convertUTF::IterateUTF8Chars(utf8Str, [&](auto c) {
-        rv &= (c >= 0x100);
-        ++numChars;
+        rv = (c < 0x100);
+        return rv;
     });
     return rv;
 }
 
-std::vector<std::uint8_t> serializeDString(const std::string& str)
+std::vector<std::uint8_t> serializeDString(const std::string& str, int fieldLen)
 {
+    if (str.empty())
+    {
+        return std::vector<std::uint8_t>(fieldLen, 0);
+    }
     std::vector<std::uint8_t> rv;
 #ifdef _WIN32
     auto str_u8 = reinterpret_cast<const std::uint8_t*>(str.c_str());
@@ -131,21 +134,28 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
 #else
     auto& utf8Str = str;
 #endif
-    unsigned int numChars;
     using namespace convertUTF;
-    if (canUse8BitUnicode(utf8Str, numChars))
+    const auto maxHeaderAndContentLength = fieldLen - 1;
+    rv.reserve(fieldLen);
+    if (canUse8BitUnicode(utf8Str))
     {
-        rv.reserve(numChars + 1);
         rv.push_back(8);
-        IterateUTF8Chars(utf8Str, [&](auto c) { rv.push_back(c); });
+        IterateUTF8Chars(utf8Str, [&](auto c) {
+            rv.push_back(c);
+            return rv.size() < maxHeaderAndContentLength;
+        });
     }
     else
     {
-        rv.reserve(numChars * 3);
         rv.push_back(16);
         IterateUTF8Chars(utf8Str, [&](auto c) {
             UTF16 high_surrogate, low_surrogate;
             std::tie(high_surrogate, low_surrogate) = ConvertUTF32toUTF16(c);
+            auto spaceLeft = maxHeaderAndContentLength - rv.size();
+            if ((spaceLeft < 2) || (low_surrogate && spaceLeft < 4))
+            {
+                return false;
+            }
             rv.push_back(high_surrogate >> 8);
             rv.push_back(high_surrogate);
             if (low_surrogate)
@@ -153,19 +163,21 @@ std::vector<std::uint8_t> serializeDString(const std::string& str)
                 rv.push_back(low_surrogate >> 8);
                 rv.push_back(low_surrogate);
             }
+            return true;
         });
     }
+    auto contentLength = rv.size();
+    auto paddingSize = maxHeaderAndContentLength - rv.size();
+    std::fill_n(std::back_inserter(rv), paddingSize, 0);
+    rv.push_back(contentLength);
     return rv;
 }
 
 void writeDString(uint8_t* buffer, const char* value, int fieldLen)
 {
-    int contentLen = FFMIN(strlen(value), fieldLen - 2);
-    buffer[fieldLen - 1] = contentLen + 1;
-    buffer[0] = 8;  // 8 bit per character string
-    memcpy(buffer + 1, value, contentLen + 1);
-    int paddingLen = fieldLen - contentLen - 2;
-    memset(buffer + 1 + contentLen, 0, paddingLen);
+    auto content = serializeDString(value, fieldLen);
+    assert(content.size() == fieldLen);
+    std::copy(std::begin(content), std::end(content), buffer);
 }
 
 void writeUDFString(uint8_t* buffer, const char* str, int len)

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -7,7 +7,6 @@
 
 #include "blank_patterns.h"
 #include "blurayHelper.h"
-#include "convertUTF.h"
 #include "iso_writer.h"
 #include "math.h"
 #include "metaDemuxer.h"
@@ -17,7 +16,6 @@
 #include "singleFileMuxer.h"
 #include "textSubtitles.h"
 #include "tsMuxer.h"
-#include "utf8Converter.h"
 
 using namespace std;
 

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -7,6 +7,7 @@
 
 #include "blank_patterns.h"
 #include "blurayHelper.h"
+#include "convertUTF.h"
 #include "iso_writer.h"
 #include "math.h"
 #include "metaDemuxer.h"
@@ -16,6 +17,7 @@
 #include "singleFileMuxer.h"
 #include "textSubtitles.h"
 #include "tsMuxer.h"
+#include "utf8Converter.h"
 
 using namespace std;
 

--- a/tsMuxer/osdep/textSubtitlesRenderFT.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderFT.cpp
@@ -537,6 +537,7 @@ void TextSubtitlesRenderFT::drawText(const string& text, RECT* rect)
         if (m_emulateBold || m_emulateItalic)
             pen.x += m_line_thickness - 1;
         maxX = pen.x + face->glyph->bitmap_left;
+        return true;
     });
     if ((m_font.m_opts & m_font.UNDERLINE) || (m_font.m_opts & m_font.STRIKE_OUT))
     {
@@ -589,6 +590,7 @@ void TextSubtitlesRenderFT::getTextSize(const string& text, SIZE* mSize)
         pen.x += m_font.m_borderWidth / 2;
         mSize->cy = face->size->metrics.height >> 6;
         mSize->cx = pen.x + face->glyph->bitmap_left;
+        return true;
     });
 }
 


### PR DESCRIPTION
This commit fixes the broken ISO labels when using characters outside of the character set supported by ISO-8859-1. Every dstring written to the UDF headers is now inspected whether it can use the limited encoding or if it's necessary to encode it as 16-bit. This has the advantage of leaving all the dstrings which don't need 16-bit encoding, like folder and file names, without any modification in the file structure.
Tested with the following metafile :
```
MUXOPT --no-pcr-on-video-pid --new-audio-pes --blu-ray --label="для Константина" --vbr  --auto-chapters=5 --vbv-len=500
V_MPEG4/ISO/AVC, "/home/daniel/tsMuxer_samples/video.h264", insertSEI, contSPS
```
Result :
![Screenshot_2020-03-01_21-32-45](https://user-images.githubusercontent.com/127875/75633670-3e6bcc80-5c07-11ea-87d1-12a25754730a.png)

@abakum :wave: 
Unfortunately, this cannot be merged right away since the lambdas cause crashes when building in MXE. We've seen this before :
```
/workdir/tsMuxer/iso_writer.cpp: In instantiation of '{anonymous}::serializeDString(const string&, int)::<lambda(auto:3)> [with auto:3 = unsigned int]':
/workdir/tsMuxer/convertUTF.h:200:23:   required from 'void convertUTF::IterateUTF8Chars(const string&, Fn) [with Fn = {anonymous}::serializeDString(const string&, int)::<lambda(auto:3)>; std::__cxx11::string = std::__cxx11::basic_string<char>]'
/workdir/tsMuxer/iso_writer.cpp:146:10:   required from here
/workdir/tsMuxer/iso_writer.cpp:138:53: internal compiler error: in tsubst_copy, at cp/pt.c:13040
     const auto maxHeaderAndContentLength = fieldLen - 1;
                                                     ^
/workdir/tsMuxer/iso_writer.cpp:138:53: internal compiler error: Segmentation fault
i686-w64-mingw32.static-g++: internal compiler error: Segmentation fault (program cc1plus)
```
@justdan96 Since this code is entirely valid and this is undoubtedly a bug in the compiler itself, could you look into upgrading it?

Fixes #185 .