### PR TITLE
Fix Filename Truncation on Dot

### DIFF
--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -300,7 +300,7 @@ string extractFileName(const string& src)
     for (int i = src.size() - 1; i >= 0; i--)
         if (src[i] == '.')
         {
-            endPos = i;
+           if (endPos == src.size()) endPos = i;
         }
         else if (src[i] == '/' || src[i] == '\\')
         {

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -300,7 +300,8 @@ string extractFileName(const string& src)
     for (int i = src.size() - 1; i >= 0; i--)
         if (src[i] == '.')
         {
-           if (endPos == src.size()) endPos = i;
+            if (endPos == src.size())
+                endPos = i;
         }
         else if (src[i] == '/' || src[i] == '\\')
         {


### PR DESCRIPTION
method to extract the filename reads the string from right to left, this change ensures that when we extract the filename it will stop on the first period encountered

Fixes #225 