### PR TITLE
update paths in MXE rebuild scripts

### DIFF
--- a/rebuild_mxe32_with_gui_docker.sh
+++ b/rebuild_mxe32_with_gui_docker.sh
@@ -10,7 +10,7 @@ cp tsMuxer/tsmuxer.exe ../bin/tsMuxeR.exe
 
 i686-w64-mingw32.static-qmake-qt5 ../tsMuxerGUI
 make
-cp ./release/tsMuxerGUI.exe ../bin/
+cp ./tsMuxerGUI.exe ../bin/
 cd ..
 rm -rf build
 

--- a/rebuild_mxe_with_gui_docker.sh
+++ b/rebuild_mxe_with_gui_docker.sh
@@ -10,7 +10,7 @@ cp tsMuxer/tsmuxer.exe ../bin/tsMuxeR.exe
 
 x86_64-w64-mingw32.static-qmake-qt5 ../tsMuxerGUI
 make
-cp ./release/tsMuxerGUI.exe ../bin/
+cp ./tsMuxerGUI.exe ../bin/
 cd ..
 rm -rf build
 


### PR DESCRIPTION
The output path for MXE tsMuxerGUI changed recently, so the Bash scripts for generating the tsMuxerGUI builds automatically have to be updated.

This should resolve the latest nightly build error.