### PR TITLE
Non blu ray dolby vision

### DIFF
--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -10,7 +10,7 @@ class AACStreamReader : public SimplePacketizerReader, public AACCodec
    public:
    public:
     AACStreamReader() : SimplePacketizerReader(){};
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override { return 0; }
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override { return 0; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return m_channels; }
 

--- a/tsMuxer/abstractStreamReader.h
+++ b/tsMuxer/abstractStreamReader.h
@@ -55,7 +55,7 @@ class AbstractStreamReader : public BaseAbstractStreamReader
     virtual int getTmpBufferSize() { return MAX_AV_PACKET_SIZE; }
     virtual int readPacket(AVPacket& avPacket) = 0;
     virtual int flushPacket(AVPacket& avPacket) = 0;
-    virtual int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
+    virtual int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) { return 0; }
     virtual int getStreamHDR() const { return 0; }
     virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) {}
     virtual void setStreamIndex(int index) { m_streamIndex = index; }

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -54,7 +54,7 @@ void AC3StreamReader::writePESExtension(PESPacket* pesPacket, const AVPacket& av
     }
 }
 
-int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode))
 {
     {
         AC3Codec::setTestMode(true);

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -54,7 +54,7 @@ void AC3StreamReader::writePESExtension(PESPacket* pesPacket, const AVPacket& av
     }
 }
 
-int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode))
+int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     {
         AC3Codec::setTestMode(true);

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -24,7 +24,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
         m_nextAc3Time = 0;
         m_thdFrameOffset = 0;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
     void setTestMode(bool value) override { AC3Codec::setTestMode(value); }
     int getFreq() override { return AC3Codec::m_sample_rate; }

--- a/tsMuxer/avPacket.h
+++ b/tsMuxer/avPacket.h
@@ -30,6 +30,7 @@ class BaseAbstractStreamReader;
 
 struct AVPacket
 {
+    AVPacket() : pts(0), dts(0), data(0), size(0), stream_index(0), flags(0), duration(0), pos(0), pcr(0), codecID(0) {}
     int64_t pts;  // presentation time stamp in time_base units
     int64_t dts;  // decompression time stamp in time_base units
     uint8_t* data;

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -66,7 +66,7 @@ const static int AOUT_CHAN_REVERSESTEREO = 0x40000;
 
 using namespace std;
 
-int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -45,7 +45,7 @@ class DTSStreamReader : public SimplePacketizerReader
         m_dtsEsChannels = 0;
         m_testMode = false;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     void setDownconvertToDTS(bool value) { m_downconvertToDTS = value; }
     bool getDownconvertToDTS() { return m_downconvertToDTS; }
     DTSHD_SUBTYPE getDTSHDMode() { return m_hdType; }

--- a/tsMuxer/dvbSubStreamReader.cpp
+++ b/tsMuxer/dvbSubStreamReader.cpp
@@ -5,7 +5,7 @@
 const static uint64_t TS_FREQ_TO_INT_FREQ_COEFF = INTERNAL_PTS_FREQ / PCR_FREQUENCY;
 static const int BAD_FRAME = -1;
 
-int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
+int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode) { return 0; }
 
 uint8_t* DVBSubStreamReader::findFrame(uint8_t* buff, uint8_t* end)
 {

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -9,7 +9,7 @@ class DVBSubStreamReader : public SimplePacketizerReader
 {
    public:
     DVBSubStreamReader() : SimplePacketizerReader(), m_big_offsets(0), m_frameDuration(0), m_firstFrame(true) {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
 
    protected:
     unsigned getHeaderLen() override { return 10; }

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -453,8 +453,8 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
     dstBuff += 5;
 
     int video_format, frame_rate_index, aspect_ratio_index;
-    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(),
-                                        getStreamAR(), &video_format, &frame_rate_index, &aspect_ratio_index);
+    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
+                                       &video_format, &frame_rate_index, &aspect_ratio_index);
 
     *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
     *dstBuff++ = (video_format << 4) + frame_rate_index;
@@ -464,7 +464,7 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 
     // For future use: ATSC desciptor
     for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
-            nal = NALUnit::findNextNAL(nal, m_bufEnd))
+         nal = NALUnit::findNextNAL(nal, m_bufEnd))
     {
         uint8_t nalType = *nal & 0x1f;
         if (nalType == nuSPS || nalType == nuSubSPS)

--- a/tsMuxer/h264StreamReader.h
+++ b/tsMuxer/h264StreamReader.h
@@ -23,7 +23,7 @@ class H264StreamReader : public MPEGStreamReader
     H264StreamReader();
     ~H264StreamReader() override;
     void setForceLevel(uint8_t value) { m_forcedLevel = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     void setH264SPSCont(bool val) { m_h264SPSCont = val; }
 

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -3,6 +3,7 @@
 #include <fs/systemlog.h>
 
 #include <algorithm>
+
 #include "tsMuxer.h"
 #include "vodCoreException.h"
 #include "vod_common.h"
@@ -847,14 +848,7 @@ int HevcPpsUnit::deserialize()
 }
 
 // ----------------------- HevcHdrUnit ------------------------
-HevcHdrUnit::HevcHdrUnit()
-  : isHDR10(false),
-    isHDR10plus(false),
-    isDVRPU(false),
-    isDVEL(false),
-    DVCompatibility(0)
-{
-}
+HevcHdrUnit::HevcHdrUnit() : isHDR10(false), isHDR10plus(false), isDVRPU(false), isDVEL(false), DVCompatibility(0) {}
 
 int HevcHdrUnit::deserialize()
 {

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -3,9 +3,6 @@
 
 #include "nalUnits.h"
 
-extern int HDR10_metadata[6];
-extern int V3_flags;
-
 enum HevcSliceTypes
 {
     HEVC_BFRAME_SLICE = 0,
@@ -46,8 +43,8 @@ enum HEVCUnitType
     NAL_RSV_NVCL45 = 45,
     NAL_RSV_NVCL47 = 47,
     NAL_UNSPEC56 = 56,
-    NAL_DV = 62,
-    NAL_UNSPEC63 = 63
+    NAL_DVRPU = 62,
+    NAL_DVEL = 63,
 };
 
 struct HevcUnit
@@ -136,7 +133,7 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     int vps_id;
     int max_sub_layers;
     int sps_id;
-    int crhomaFormat;
+    int chromaFormat;
     bool separate_colour_plane_flag;
     int pic_width_in_luma_samples;
     int pic_height_in_luma_samples;
@@ -163,6 +160,8 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     int colour_primaries;
     int transfer_characteristics;
     int matrix_coeffs;
+    int chroma_sample_loc_type_top_field;
+    int chroma_sample_loc_type_bottom_field;
 
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;
@@ -190,15 +189,17 @@ struct HevcPpsUnit : public HevcUnit
     int num_extra_slice_header_bits;
 };
 
-struct HevcSeiUnit : public HevcUnit
+struct HevcHdrUnit : public HevcUnit
 {
-    HevcSeiUnit();
+    HevcHdrUnit();
     int deserialize() override;
 
    public:
     bool isHDR10;
     bool isHDR10plus;
-    bool isDV;
+    bool isDVRPU;
+    bool isDVEL;
+    int DVCompatibility;
 };
 
 struct HevcSliceHeader : public HevcUnit

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -4,6 +4,7 @@
 
 #include "hevc.h"
 #include "nalUnits.h"
+#include "tsMuxer.h"
 #include "tsPacket.h"
 #include "vodCoreException.h"
 
@@ -12,15 +13,12 @@ using namespace std;
 static const int MAX_SLICE_HEADER = 64;
 static const int HEVC_DESCRIPTOR_TAG = 0x38;
 
-int V3_flags = 0;  // flags : isV3, reserved, 4K, HDR10+, SL-HDR2, DV, HDR10, SDR
-int HDR10_metadata[6] = {0, 0, 0, 0, 0, 0};
-
 HEVCStreamReader::HEVCStreamReader()
     : MPEGStreamReader(),
       m_vps(0),
       m_sps(0),
       m_pps(0),
-      m_sei(0),
+      m_hdr(0),
       m_firstFrame(true),
       m_frameNum(0),
       m_fullPicOrder(0),
@@ -41,7 +39,7 @@ HEVCStreamReader::~HEVCStreamReader()
     delete m_vps;
     delete m_sps;
     delete m_pps;
-    delete m_sei;
+    delete m_hdr;
 }
 
 CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
@@ -92,25 +90,58 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
         }
         case NAL_SEI_PREFIX:
         {
-            if (!m_sei)
-                m_sei = new HevcSeiUnit();
-            m_sei->decodeBuffer(nal, nextNal);
-            if (m_sei->deserialize() != 0)
+            if (!m_hdr)
+                m_hdr = new HevcHdrUnit();
+            m_hdr->decodeBuffer(nal, nextNal);
+            if (m_hdr->deserialize() != 0)
                 return rez;
             break;
         }
-        case NAL_DV:
+        case NAL_DVRPU:
+        case NAL_DVEL:
         {
-            if (!m_sei)
-                m_sei = new HevcSeiUnit();
-            if (nal[1] == 1 && !m_sei->isDV)
+            if (!m_hdr)
+                m_hdr = new HevcHdrUnit();
+            if (nal[1] == 1)
             {
-                m_sei->isDV = true;
-                V3_flags |= 4;  // Dolby Vision flag
+                if (nalType == NAL_DVEL)
+                    m_hdr->isDVEL = true;
+                else
+                    m_hdr->isDVRPU = true;
+                V3_flags |= DV;
             }
             break;
         }
         }
+    }
+
+    int cp = m_sps->colour_primaries;
+    int tc = m_sps->transfer_characteristics;
+    int mc = m_sps->matrix_coeffs;
+    int cslt = m_sps->chroma_sample_loc_type_top_field;
+
+    // cf. "DolbyVisionProfilesLevels_v1_3_2_2019_09_16.pdf"
+    if (cp == 9 && tc == 16 && mc == 9)  // BT.2100 colorspace
+    {
+        m_hdr->isHDR10 = true;
+        if (cslt == 2)
+            m_hdr->DVCompatibility = 6;
+        else if (cslt == 0)
+            m_hdr->DVCompatibility = 1;
+        V3_flags |= HDR10;
+    }
+    else if (cp == 9 && tc == 18 && mc == 9 && cslt == 2)  // ARIB HLG
+        m_hdr->DVCompatibility = 4;
+    else if (cp == 9 && tc == 14 && mc == 9 && cslt == 0)  // DVB HLG
+        m_hdr->DVCompatibility = 4;
+    else if (cp == 1 && tc == 1 && mc == 1 && cslt == 0)  // SDR
+        m_hdr->DVCompatibility = 2;
+    else if (cp == 2 && tc == 2 && mc == 2 && cslt == 0)  // Undefined
+    {
+        if (V3_flags & BASE_LAYER)
+            m_hdr->DVCompatibility = 2;
+        else
+            m_hdr->DVCompatibility = 0;
     }
 
     if (m_vps && m_sps && m_pps && m_sps->vps_id == m_vps->vps_id && m_pps->sps_id == m_sps->sps_id)
@@ -125,29 +156,13 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
     return rez;
 }
 
-int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     if (m_firstFrame)
-        checkStream(m_buffer, m_bufEnd - m_buffer);
+        CheckStreamRez rez = checkStream(m_buffer, m_bufEnd - m_buffer);
 
-    if (isM2ts)
-    {
-        // put 'HDMV' registration descriptor
-        *dstBuff++ = 0x05;  // registration descriptor tag
-        *dstBuff++ = 8;     // descriptor length
-        memcpy(dstBuff, "HDMV\xff\x24", 6);
-        dstBuff += 6;
-
-        int video_format, frame_rate_index, aspect_ratio_index;
-        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(),
-                                           getStreamAR(), &video_format, &frame_rate_index, &aspect_ratio_index);
-
-        *dstBuff++ = (video_format << 4) + frame_rate_index;
-        *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
-
-        return 10;
-    }
-    else
+    /* non-HDMV descriptor, for future use
+    if (!blurayMode && (V3_flags & DV))
         for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
              nal = NALUnit::findNextNAL(nal, m_bufEnd))
         {
@@ -159,19 +174,153 @@ int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
                 uint8_t tmpBuffer[512];
                 int toDecode = FFMIN(sizeof(tmpBuffer) - 8, nextNal - nal);
                 int decodedLen = NALUnit::decodeNAL(nal, nal + toDecode, tmpBuffer, sizeof(tmpBuffer));
+
+                int lenDoviDesc = 0;
+                if (m_hdr->isDVEL || m_hdr->isDVRPU)
+                {
+                    lenDoviDesc = setDoViDescriptor(dstBuff);
+                    dstBuff += lenDoviDesc;
+                }
+
                 *dstBuff++ = HEVC_DESCRIPTOR_TAG;
                 *dstBuff++ = 13;  // descriptor length
                 memcpy(dstBuff, tmpBuffer + 3, 12);
                 dstBuff += 12;
-                // temporal_layer_subset, HEVC_still_present, HEVC_24hr_picture_present, sub_pic_hrd_params_not_present
-                *dstBuff = 0x1c;
+                // temporal_layer_subset, HEVC_still_present, HEVC_24hr_picture_present, HDR_WCG unspecified
+                *dstBuff = 0x0f;
 
-                if (V3_flags & 0x1e)
-                    *dstBuff |= 3;  // HDR & WGC (Wide Gamut Color) flags
+                if (!m_sps->sub_pic_hrd_params_present_flag)
+                    *dstBuff |= 0x10;
+                dstBuff++;
 
-                return 15;
+                // HEVC_timing_and_HRD_descriptor
+                memcpy(dstBuff, "\x3f\x0f\x03\x7f\x7f", 5);
+                dstBuff += 5;
+
+                uint32_t N = 1001 * getFPS();
+                uint32_t K = 27000000;
+                uint32_t num_units_in_tick = 1001;
+                if (N % 1000)
+                {
+                    N = 1000 * getFPS();
+                    num_units_in_tick = 1000;
+                }
+                N = my_htonl(N);
+                K = my_htonl(K);
+                num_units_in_tick = my_htonl(num_units_in_tick);
+                memcpy(dstBuff, &N, 4);
+                dstBuff += 4;
+                memcpy(dstBuff, &K, 4);
+                dstBuff += 4;
+                memcpy(dstBuff, &num_units_in_tick, 4);
+                dstBuff += 4;
+
+                return 32 + lenDoviDesc;
             }
-        }
+        } */
+
+    // 'HDMV' registration descriptor
+    *dstBuff++ = 0x05;
+    *dstBuff++ = 8;
+    memcpy(dstBuff, "HDMV\xff\x24", 6);
+    dstBuff += 6;
+
+    int video_format, frame_rate_index, aspect_ratio_index;
+    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
+                                       &video_format, &frame_rate_index, &aspect_ratio_index);
+
+    *dstBuff++ = (video_format << 4) + frame_rate_index;
+    *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
+
+    int lenDoviDesc = 0;
+    if (!blurayMode && (m_hdr->isDVEL || m_hdr->isDVRPU))
+    {
+        lenDoviDesc = setDoViDescriptor(dstBuff);
+        dstBuff += lenDoviDesc;
+    }
+
+    return 10 + lenDoviDesc;
+}
+
+int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
+{
+    int isDVBL = true;
+    bool DualLayers = V3_flags & BASE_LAYER;
+    // For Dual Layer, both RPU and EL substreams are multiplexed in the RPU stream
+    if (DualLayers && m_hdr->isDVRPU)
+    {
+        m_hdr->isDVEL = true;
+        isDVBL = false;
+    }
+
+    int width = getStreamWidth();
+    int pixelRate = width * getStreamHeight() * getFPS();
+    // BL has twice the width and height of EL
+    if (DualLayers)
+    {
+        width *= 2;
+        pixelRate *= 4;
+    }
+
+    int level = 0;
+    if (width <= 1280 && pixelRate <= 22118400)
+        level = 1;
+    else if (width <= 1280 && pixelRate <= 27648000)
+        level = 2;
+    else if (width <= 1920 && pixelRate <= 49766400)
+        level = 3;
+    else if (width <= 2560 && pixelRate <= 62208000)
+        level = 4;
+    else if (width <= 3840 && pixelRate <= 124416000)
+        level = 5;
+    else if (width <= 3840 && pixelRate <= 199065600)
+        level = 6;
+    else if (width <= 3840 && pixelRate <= 248832000)
+        level = 7;
+    else if (width <= 3840 && pixelRate <= 398131200)
+        level = 8;
+    else if (width <= 3840 && pixelRate <= 497664000)
+        level = 9;
+    else if (width <= 3840 && pixelRate <= 995328000)
+        level = 10;
+    else if (width <= 7680 && pixelRate <= 995328000)
+        level = 11;
+    else if (width <= 7680 && pixelRate <= 1990656000)
+        level = 12;
+    else if (width <= 7680 && pixelRate <= 3981312000)
+        level = 13;
+
+    BitStreamWriter bitWriter;
+    bitWriter.setBuffer(dstBuff, dstBuff + 128);
+
+    // 'DOVI' registration descriptor
+    bitWriter.putBits(8, 5);
+    bitWriter.putBits(8, 4);
+    bitWriter.putBits(32, 0x444f5649);
+
+    bitWriter.putBits(8, 0xb0);            // DoVi descriptor tag
+    bitWriter.putBits(8, isDVBL ? 5 : 7);  // Length
+    bitWriter.putBits(8, 1);               // dv version major
+    bitWriter.putBits(8, 0);               // dv version minor
+    // DV profile
+    if (DualLayers)
+        bitWriter.putBits(7,m_hdr->isHDR10 ? 7 : 4);
+    else
+        bitWriter.putBits(7, m_hdr->DVCompatibility ? 8 : 5);
+    bitWriter.putBits(6, level);        // dv level
+    bitWriter.putBits(1, m_hdr->isDVRPU);  // rpu_present_flag
+    bitWriter.putBits(1, m_hdr->isDVEL);   // el_present_flag
+    bitWriter.putBits(1, isDVBL);       // bl_present_flag
+    if (!isDVBL)
+    {
+        bitWriter.putBits(13, 0x1011);  // dependency_pid
+        bitWriter.putBits(3, 7);        // reserved
+    }
+    bitWriter.putBits(4, m_hdr->DVCompatibility);  // dv_bl_signal_compatibility_id
+    bitWriter.putBits(4, 15);                   // reserved
+
+    bitWriter.flushBits();
+    return 8 + (isDVBL ? 5 : 7);
 }
 
 void HEVCStreamReader::updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int)
@@ -204,13 +353,7 @@ int HEVCStreamReader::getStreamHeight() const { return m_sps ? m_sps->pic_height
 
 int HEVCStreamReader::getStreamHDR() const
 {
-    if (m_sps->colour_primaries == 9 && m_sps->transfer_characteristics == 16 &&
-        m_sps->matrix_coeffs == 9)  // BT.2100 colorspace
-    {
-        m_sei->isHDR10 = true;
-        V3_flags |= 2;
-    }
-    return m_sei->isDV ? 4 : (m_sei->isHDR10plus ? 16 : (m_sei->isHDR10 ? 2 : 1));
+    return (m_hdr->isDVRPU || m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
 }
 
 double HEVCStreamReader::getStreamFPS(void* curNalUnit)
@@ -237,7 +380,7 @@ bool HEVCStreamReader::isSuffix(int nalType) const
         return false;
     return (nalType == NAL_FD_NUT || nalType == NAL_SEI_SUFFIX || nalType == NAL_RSV_NVCL45 ||
             (nalType >= NAL_RSV_NVCL45 && nalType <= NAL_RSV_NVCL47) ||
-            (nalType >= NAL_UNSPEC56 && nalType <= NAL_UNSPEC63));
+            (nalType >= NAL_UNSPEC56 && nalType <= NAL_DVEL));
 }
 
 void HEVCStreamReader::incTimings()
@@ -385,10 +528,10 @@ int HEVCStreamReader::intDecodeNAL(uint8_t* buff)
                 storeBuffer(m_ppsBuffer, curPos, nextNalWithStartCode);
                 break;
             case NAL_SEI_PREFIX:
-                if (!m_sei)
-                    m_sei = new HevcSeiUnit();
-                m_sei->decodeBuffer(curPos, nextNal);
-                if (m_sei->deserialize() != 0)
+                if (!m_hdr)
+                    m_hdr = new HevcHdrUnit();
+                m_hdr->decodeBuffer(curPos, nextNal);
+                if (m_hdr->deserialize() != 0)
                     return rez;
                 break;
             }

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -304,20 +304,20 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
     bitWriter.putBits(8, 0);               // dv version minor
     // DV profile
     if (DualLayers)
-        bitWriter.putBits(7,m_hdr->isHDR10 ? 7 : 4);
+        bitWriter.putBits(7, m_hdr->isHDR10 ? 7 : 4);
     else
         bitWriter.putBits(7, m_hdr->DVCompatibility ? 8 : 5);
-    bitWriter.putBits(6, level);        // dv level
+    bitWriter.putBits(6, level);           // dv level
     bitWriter.putBits(1, m_hdr->isDVRPU);  // rpu_present_flag
     bitWriter.putBits(1, m_hdr->isDVEL);   // el_present_flag
-    bitWriter.putBits(1, isDVBL);       // bl_present_flag
+    bitWriter.putBits(1, isDVBL);          // bl_present_flag
     if (!isDVBL)
     {
         bitWriter.putBits(13, 0x1011);  // dependency_pid
         bitWriter.putBits(3, 7);        // reserved
     }
     bitWriter.putBits(4, m_hdr->DVCompatibility);  // dv_bl_signal_compatibility_id
-    bitWriter.putBits(4, 15);                   // reserved
+    bitWriter.putBits(4, 15);                      // reserved
 
     bitWriter.flushBits();
     return 8 + (isDVBL ? 5 : 7);

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -12,12 +12,13 @@ class HEVCStreamReader : public MPEGStreamReader
    public:
     HEVCStreamReader();
     ~HEVCStreamReader() override;
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int setDoViDescriptor(uint8_t* dstBuff);
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool needSPSForSplit() const override { return false; }
 
    protected:
-    const CodecInfo& getCodecInfo() override { return hevcCodecInfo; };
+    const CodecInfo& getCodecInfo() override { return hevcCodecInfo; }
     virtual int intDecodeNAL(uint8_t* buff) override;
 
     double getStreamFPS(void* curNalUnit) override;
@@ -48,7 +49,7 @@ class HEVCStreamReader : public MPEGStreamReader
     HevcVpsUnit* m_vps;
     HevcSpsUnit* m_sps;
     HevcPpsUnit* m_pps;
-    HevcSeiUnit* m_sei;
+    HevcHdrUnit* m_hdr;
     bool m_firstFrame;
 
     int m_frameNum;
@@ -63,7 +64,7 @@ class HEVCStreamReader : public MPEGStreamReader
     MemoryBlock m_vpsBuffer;
     MemoryBlock m_spsBuffer;
     MemoryBlock m_ppsBuffer;
-    MemoryBlock m_seiBuffer;
+    MemoryBlock m_hdrBuffer;
     bool m_firstFileFrame;
     int m_vpsCounter;
     int m_vpsSizeDiff;

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -64,7 +64,6 @@ class HEVCStreamReader : public MPEGStreamReader
     MemoryBlock m_vpsBuffer;
     MemoryBlock m_spsBuffer;
     MemoryBlock m_ppsBuffer;
-    MemoryBlock m_hdrBuffer;
     bool m_firstFileFrame;
     int m_vpsCounter;
     int m_vpsSizeDiff;

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -22,6 +22,7 @@ static const int MAIN_INTERLEAVE_BLOCKSIZE = 6144 * 3168;
 static const int SUB_INTERLEAVE_BLOCKSIZE = 6144 * 1312;
 
 static const int MAX_MAIN_MUXER_RATE = 48000000;
+static const int MAX_4K_MUXER_RATE = 109000000;
 static const int MAX_SUBMUXER_RATE = 35000000;
 
 enum DescriptorTag

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -19,7 +19,7 @@ static const uint32_t FMT_FOURCC = FOUR_CC('f', 'm', 't', ' ');
 
 using namespace wave_format;
 
-int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     if (m_headerType == htNone)
         if (!detectLPCMType(m_buffer, m_bufEnd - m_buffer))

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -32,7 +32,7 @@ class LPCMStreamReader : public SimplePacketizerReader
         m_lastChannelRemapPos = 0;
     }
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     int getFreq() override { return m_freq; }
     int getChannels() override { return m_channels; }
     // void setDemuxMode(bool value) {m_demuxMode = value;}

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -98,7 +98,7 @@ DiskType checkBluRayMux(const char* metaFileName, int& autoChapterLen, vector<do
             }
 
             if (str.find("--blu-ray-v3") != string::npos)
-                V3_flags |= 0x80;  // flag "V3"
+                V3_flags |= HDMV_V3;
 
             if (str.find("--blu-ray") != string::npos)
                 result = DT_BLURAY;
@@ -108,9 +108,7 @@ DiskType checkBluRayMux(const char* metaFileName, int& autoChapterLen, vector<do
                 result = DT_NONE;
         }
         else if (strStartWith(str, "V_MPEG4/ISO/MVC"))
-        {
             stereoMode = true;
-        }
 
         file.readLine(str);
     }
@@ -730,10 +728,10 @@ int main(int argc, char** argv)
             MuxerManager muxerManager(readManager, tsMuxerFactory);
             muxerManager.setAllowStereoMux(fileExt2 == "SSIF" || dt != DT_NONE);
             muxerManager.openMetaFile(argv[1]);
-            if (!V3_flags && dt == DT_BLURAY && muxerManager.getHevcFound())
+            if (!isV3() && dt == DT_BLURAY && muxerManager.getHevcFound())
             {
                 LTRACE(LT_INFO, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
-                V3_flags |= 0x80;  // flag "V3"
+                V3_flags |= HDMV_V3;
             }
             string dstFile = unquoteStr(argv[2]);
 

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -711,9 +711,7 @@ void METADemuxer::addTrack(vector<CheckStreamRez>& rez, CheckStreamRez trackRez)
         rez.push_back(trackRez);
     }
     else
-    {
         rez.push_back(trackRez);
-    }
 }
 
 CheckStreamRez METADemuxer::detectTrackReader(uint8_t* tmpBuffer, int len,

--- a/tsMuxer/mpeg2StreamReader.cpp
+++ b/tsMuxer/mpeg2StreamReader.cpp
@@ -8,7 +8,7 @@
 #include "vodCoreException.h"
 #include "vod_common.h"
 
-int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     try
     {

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -21,7 +21,7 @@ class MPEG2StreamReader : public MPEGStreamReader
         m_longCodesAllowed = false;
         m_prevFrameDelay = 0;
     }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 
     int getStreamWidth() const override { return m_sequence.width; }

--- a/tsMuxer/mpegAudioStreamReader.cpp
+++ b/tsMuxer/mpegAudioStreamReader.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -9,7 +9,7 @@ class MpegAudioStreamReader : public SimplePacketizerReader, MP3Codec
    public:
     const static uint32_t DTS_HD_PREFIX = 0x64582025;
     MpegAudioStreamReader() : SimplePacketizerReader() {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     int getLayer() { return m_layer; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return 2; }

--- a/tsMuxer/tsDemuxer.cpp
+++ b/tsMuxer/tsDemuxer.cpp
@@ -101,15 +101,6 @@ void TSDemuxer::getTrackList(std::map<uint32_t, TrackInfo>& trackList)
             TSPacket* tsPacket = (TSPacket*)curPos;
             int pid = tsPacket->getPID();
 
-            /*
-            LTRACE(LT_WARN, 2, pid);
-            if (pid == 0)
-            {
-                LTRACE(LT_WARN, 2, "offset=" << curPos - 4 - data);
-                int gg = 4;
-            }
-            */
-
             if (pid == 0)
             {  // PAT
                 pat.deserialize(curPos + tsPacket->getHeaderSize(), TS_FRAME_SIZE - tsPacket->getHeaderSize());

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -317,16 +317,16 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
                                                         descriptorLen, codecReader, lang, isSecondary)));
     else if (codecName == "S_SUP")
         m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer, descriptorLen,
+                                                        codecReader, lang, isSecondary)));
     else if (codecName == "S_HDMV/PGS")
         m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer, descriptorLen,
+                                                        codecReader, lang, isSecondary)));
     else if (codecName == "S_TEXT/UTF8")
         m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_SUB_PGS, tsStreamIndex, descrBuffer, descriptorLen,
+                                                        codecReader, lang, isSecondary)));
     else if (codecName == "A_AC3")
     {
         AC3StreamReader* ac3Reader = (AC3StreamReader*)codecReader;

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -12,6 +12,23 @@
 #include "limits.h"
 #include "vodCoreException.h"
 
+enum V3Flags
+{
+    SDR = 1,
+    HDR10 = 2,
+    DV = 4,
+    SL_HDR2 = 8,
+    HDR10PLUS = 16,
+    FOUR_K = 32,
+    BASE_LAYER = 64,
+    HDMV_V3 = 128
+};
+
+extern int V3_flags;
+extern int HDR10_metadata[6];
+extern bool isV3();
+extern bool is4K();
+
 const static int MAX_PES_HEADER_LEN = 512;
 
 class TSMuxer : public AbstractMuxer
@@ -76,7 +93,6 @@ class TSMuxer : public AbstractMuxer
     void buildSIT();
     void addData(int pesStreamID, int pid, AVPacket& avPacket);
     void buildPesHeader(int pesStreamID, AVPacket& avPacket, int pid);
-    void flushPESFrame(int tsIndex);
     void writePESPacket();
     void processM2TSPCR(int64_t pcrVal, int64_t pcrGAP);
     inline int calcM2tsFrameCnt();

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1589,12 +1589,12 @@ void MPLSParser::composeAppInfoPlayList(BitStreamWriter& writer)
     {
         writer.putBits(16, 0);  // reserved_for_future_use 16 bslbf
     }
-    writer.putBits(28, 0);                   // UO_mask_table;
+    writer.putBits(28, 0);               // UO_mask_table;
     writer.putBits(4, isV3() ? 15 : 0);  // UO_mask_table;
-    writer.putBit(0);                        // reserved
-    writer.putBit(isV3() ? 1 : 0);  // UO_mask_table: SecondaryPGStreamNumberChange
-    writer.putBits(30, 0);                   // UO_mask_table cont;
-    writer.putBit(0);                        // PlayList_random_access_flag
+    writer.putBit(0);                    // reserved
+    writer.putBit(isV3() ? 1 : 0);       // UO_mask_table: SecondaryPGStreamNumberChange
+    writer.putBits(30, 0);               // UO_mask_table cont;
+    writer.putBit(0);                    // PlayList_random_access_flag
     writer.putBit(1);  // audio_mix_app_flag. 0 == no secondary audio, 1- allow secondary audio if exist
     writer.putBit(0);  // lossless_may_bypass_mixer_flag
     writer.putBit(mvc_base_view_r);
@@ -2224,11 +2224,11 @@ void MPLSParser::composePlayItem(BitStreamWriter& writer, int playItemNum, std::
     else
         writer.putBits(32, OUT_time);  // 32 uimsbf
 
-    writer.putBits(28, 0);                 // UO_mask_table;
+    writer.putBits(28, 0);               // UO_mask_table;
     writer.putBits(4, isV3() ? 15 : 0);  // UO_mask_table;
-    writer.putBit(0);                      // reserved
+    writer.putBit(0);                    // reserved
     writer.putBit(isV3() ? 1 : 0);       // UO_mask_table: SecondaryPGStreamNumberChange
-    writer.putBits(30, 0);                 // UO_mask_table cont;
+    writer.putBits(30, 0);               // UO_mask_table cont;
 
     writer.putBit(PlayItem_random_access_flag);  // 1 bslbf
     writer.putBits(7, 0);                        // reserved_for_future_use 7 bslbf

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -40,9 +40,8 @@ static const uint8_t STREAM_TYPE_PRIVATE_SECTION = 0x05;
 static const uint8_t STREAM_TYPE_PRIVATE_DATA = 0x06;
 static const uint8_t STREAM_TYPE_VIDEO_MPEG4 = 0x10;
 static const uint8_t STREAM_TYPE_VIDEO_H264 = 0x1b;
-static const uint8_t STREAM_TYPE_VIDEO_H265 = 0x24;
-// static const uint8_t STREAM_TYPE_VIDEO_H265      = 0x25; // changed from 0x06
 static const uint8_t STREAM_TYPE_VIDEO_MVC = 0x20;
+static const uint8_t STREAM_TYPE_VIDEO_H265 = 0x24;
 static const uint8_t STREAM_TYPE_VIDEO_VC1 = 0xea;
 
 static const uint8_t STREAM_TYPE_AUDIO_MPEG1 = 0x03;
@@ -257,12 +256,11 @@ struct TS_program_map_section
     TS_program_map_section();
     bool deserialize(uint8_t* buffer, int buf_size);
     static bool isFullBuff(uint8_t* buffer, int buf_size);
-    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool addLang, bool isM2ts);
+    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool blurayMode);
 
    private:
     void extractDescriptors(uint8_t* curPos, int es_info_len, PMTStreamInfo& pmtInfo);
     void extractPMTDescriptors(uint8_t* curPos, int es_info_len);
-    void setDoViDescriptor(BitStreamWriter& bitWriter, int PID, bool isDV_EL);
     // uint32_t tmpAvCrc[257];
 };
 

--- a/tsMuxer/vc1StreamReader.cpp
+++ b/tsMuxer/vc1StreamReader.cpp
@@ -50,7 +50,7 @@ int VC1StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
     return (int)(curPtr - dstBuffer);  // afterPesData;
 }
 
-int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     for (uint8_t* nal = VC1Unit::findNextMarker(m_buffer, m_bufEnd); nal <= m_bufEnd - 32;
          nal = VC1Unit::findNextMarker(nal + 4, m_bufEnd))

--- a/tsMuxer/vc1StreamReader.h
+++ b/tsMuxer/vc1StreamReader.h
@@ -21,7 +21,7 @@ class VC1StreamReader : public MPEGStreamReader
         m_nextFrameAddr = 0;
     }
     ~VC1StreamReader() override {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool skipNal(uint8_t* nal) override;
     bool needSPSForSplit() const override { return true; }


### PR DESCRIPTION
In non-Bluray mode (TS or M2TS), when Dolby Vision is detected, include the 'DoVi' Registration Descriptor and the Dolby Vision video descriptor.

The descriptors are still HDMV, for compatibility with PGS, AC3/TrueHD and AC3/EAC3 streams.

Also includes:
 - DV descriptors moved from tsPacket to hevcStreamReader class;
- Correction of non HDMV AVC descriptor, for future use;
 - non HDMV HEVC descriptor, for future use;
 - declaration/enumeration of V3 flags, moved from hevcStreamReader to tsMuxer;

Note that there is a bug on Bluray players that I haven't managed to get rid of (see [discussion on doom9](https://forum.doom9.org/showthread.php?p=1903300#post1903300)), but I came to the conclusion that it doesn't come from the descriptors but rather from the way the packets are muxed. I will look at this separately.