### PR TITLE
Correct MPEG-2 streams Descriptors

### DIFF
--- a/tsMuxer/mpeg2StreamReader.cpp
+++ b/tsMuxer/mpeg2StreamReader.cpp
@@ -10,6 +10,7 @@
 
 int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
 {
+    m_sequence.video_format = 5;  // Unspecified video format
     try
     {
         for (uint8_t* nal = MPEGHeader::findNextMarker(m_buffer, m_bufEnd); nal <= m_bufEnd - 32;
@@ -31,13 +32,33 @@ int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
                 {
                     m_sequence.deserializeExtension(bitReader);
                 }
+                else if (extType == SEQUENCE_DISPLAY_EXT)
+                {
+                    m_sequence.deserializeDisplayExtension(bitReader);
+                }
+            }
+            else if (nal[3] == GOP_START_SHORT_CODE)
+            {
+                uint8_t* nextNal = MPEGHeader::findNextMarker(nal + 4, m_bufEnd);
+                m_gop.deserialize(nal + 4, nextNal - nal - 4);
             }
         }
     }
     catch (BitStreamException)
     {
     }
-    return 0;
+
+    // put 'HDMV' registration descriptor
+    *dstBuff++ = 0x05;  // registration descriptor tag
+    *dstBuff++ = 8;     // descriptor length
+    memcpy(dstBuff, "HDMV\xff", 5);
+    dstBuff += 5;
+
+    *dstBuff++ = 0x02;
+    *dstBuff++ = (m_sequence.video_format << 4) + m_sequence.frame_rate_index;
+    *dstBuff++ = (m_sequence.aspect_ratio_info << 4) + 0xf;
+
+    return 10;
 }
 
 CheckStreamRez MPEG2StreamReader::checkStream(uint8_t* buffer, int len)
@@ -341,5 +362,5 @@ void MPEG2StreamReader::updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* n
 void MPEG2StreamReader::updateStreamAR(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int oldSpsLen)
 {
     if (m_ar != AR_KEEP_DEFAULT)
-        m_sequence.setAspectRation(buff + 1, m_ar);  // todo: delete this line! debug only
+        m_sequence.setAspectRatio(buff + 1, m_ar);  // todo: delete this line! debug only
 }

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -48,8 +48,9 @@ class MPEG2StreamReader : public MPEGStreamReader
     bool m_lastIFrame;
     int64_t m_prevFrameDelay;
     MPEGSequenceHeader m_sequence;
+    MPEGGOPHeader m_gop;
     MPEGPictureHeader m_frame;
-    int getNextBFrames(uint8_t* buffer);
+    // int getNextBFrames(uint8_t* buffer);
     int findFrameExt(uint8_t* buffer);
     int decodePicture(uint8_t* buff);
     int processExtStartCode(uint8_t* buff);

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -150,9 +150,9 @@ uint8_t* MPEGSequenceHeader::deserializeExtension(BitStreamReader& bitReader)
 
     rc_buffer_size += bitReader.getBits(8) * 1024 * 16 << 10;
 
-    low_delay = bitReader.getBit(); // disable b-frame if true
-    frame_rate_ext.num = bitReader.getBits(2)+1;
-    frame_rate_ext.den = bitReader.getBits(5)+1;
+    low_delay = bitReader.getBit();  // disable b-frame if true
+    frame_rate_ext.num = bitReader.getBits(2) + 1;
+    frame_rate_ext.den = bitReader.getBits(5) + 1;
 
     /*
 s->codec_id= s->avctx->codec_id= CODEC_ID_MPEG2VIDEO;

--- a/tsMuxer/mpegVideo.h
+++ b/tsMuxer/mpegVideo.h
@@ -34,6 +34,7 @@ const static unsigned USER_START_SHORT_CODE = 0xb2;
 
 const static unsigned PICTURE_CODING_EXT = 0x08;
 const static unsigned SEQUENCE_EXT = 0x01;
+const static unsigned SEQUENCE_DISPLAY_EXT = 0x02;
 
 static const unsigned MAX_PICTURE_SIZE = 256 * 1024;
 static const unsigned MAX_HEADER_SIZE = 1024 * 4;
@@ -119,8 +120,8 @@ class MPEGSequenceHeader : public MPEGRawDataHeader
     int horiz_size_ext;
     int vert_size_ext;
     int bit_rate_ext;
-    // int low_delay;
-    // AVRational frame_rate_ext;
+    int low_delay;
+    AVRational frame_rate_ext;
 
     // sequence display extension
     int video_format;
@@ -140,7 +141,7 @@ class MPEGSequenceHeader : public MPEGRawDataHeader
     uint8_t* deserializeDisplayExtension(BitStreamReader& bitContext);
     double getFrameRate();
     void setFrameRate(uint8_t* buff, double fps);
-    void setAspectRation(uint8_t* buff, VideoAspectRatio ar);
+    void setAspectRatio(uint8_t* buff, VideoAspectRatio ar);
     std::string getStreamDescr();
 };
 


### PR DESCRIPTION
The TS Descriptors were not returned ('return 0') in the getTSDescriptor function.

The patch fixes the HDMV TS Descriptors for MPEG-2 streams.