### PR TITLE
Correct EAC3 descriptor

### DIFF
--- a/tsMuxer/ac3Codec.h
+++ b/tsMuxer/ac3Codec.h
@@ -65,9 +65,11 @@ class AC3Codec
         m_extChannelsExists = false;
         m_bsid = m_bsidBase = 0;
         m_dsurmod = 0;
+        m_mixinfoexists = false;
     };
     unsigned getHeaderLen() { return AC3_HEADER_SIZE; }
     inline bool isEAC3() { return m_bsid > 10; }
+    inline bool isAC3() { return m_bsidBase > 0; }
     void setDownconvertToAC3(bool value) { m_downconvertToAC3 = value; }
     bool getDownconvertToAC3() { return m_downconvertToAC3; }
     bool isTrueHD() { return m_true_hd_mode; }
@@ -106,6 +108,7 @@ class AC3Codec
     uint32_t m_bit_rate;
     uint8_t m_channels;
     uint16_t m_frame_size;
+    bool m_mixinfoexists;
 
     MLPHeaderInfo mh;
 

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -101,7 +101,7 @@ int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
         bitWriter.putBits(4, m_acmod);  // when MSB == 0 then high (4-th) bit always 0
         bitWriter.putBit(0);            // full_svc
 
-        bitWriter.putBits(8, 0);        // langcod
+        bitWriter.putBits(8, 0);  // langcod
         bitWriter.flushBits();
 
         return 12;
@@ -127,7 +127,6 @@ int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
     if (m_extChannelsExists)
         number_of_channels = 5;
     bitWriter.putBits(3, number_of_channels);
-
 
     bitWriter.putBits(3, 1);
     bitWriter.putBits(5, m_bsid);

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -346,8 +346,10 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
         {
             if (ac3Reader->isSecondary())
                 streamType = STREAM_TYPE_AUDIO_EAC3_SECONDARY;
-            else
+            else if (ac3Reader->isAC3())
                 streamType = STREAM_TYPE_AUDIO_EAC3;
+            else
+                streamType = STREAM_TYPE_AUDIO_EAC3_ATSC;
         }
         else
             streamType = STREAM_TYPE_AUDIO_AC3;

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -318,6 +318,7 @@ bool TS_program_map_section::deserialize(uint8_t* buffer, int buf_size)
             case STREAM_TYPE_AUDIO_AAC:
             case STREAM_TYPE_AUDIO_AC3:
             case STREAM_TYPE_AUDIO_EAC3:
+            case STREAM_TYPE_AUDIO_EAC3_ATSC:
             case STREAM_TYPE_AUDIO_DTS:
                 audio_pid = elementary_pid;
                 audio_type = stream_type;

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -54,6 +54,7 @@ static const uint8_t STREAM_TYPE_AUDIO_DTS = 0x82;  // 0x8a
 static const uint8_t STREAM_TYPE_AUDIO_LPCM = 0x80;
 static const uint8_t STREAM_TYPE_AUDIO_AC3 = 0x81;
 static const uint8_t STREAM_TYPE_AUDIO_EAC3 = 0x84;
+static const uint8_t STREAM_TYPE_AUDIO_EAC3_ATSC = 0x87;
 static const uint8_t STREAM_TYPE_AUDIO_EAC3_TRUE_HD = 0x83;
 static const uint8_t STREAM_TYPE_AUDIO_DTS_HD = 0x85;
 static const uint8_t STREAM_TYPE_AUDIO_DTS_HD_MASTER_AUDIO = 0x86;


### PR DESCRIPTION
tsMuxer muxes Bluray "hybrid" AC3/EAC3 with HDMV descriptors. When muxing "pure" EAC3, the HDMV descriptor is incorrect and the audio does not play with hardware decoders.

This patch completes the stream parsing to extract the info needed by the descriptor, and adds the ATSC descriptor for pure EAC3 tracks.