### PR TITLE
[bug] MP4 If no moof, return at first mdat

### DIFF
--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -836,8 +836,7 @@ int MovDemuxer::mov_read_default(MOVAtom atom)
                 break;
             }
         }
-        if ((!found_moof && m_mdat_pos && found_moov) ||
-            (found_moof && m_processedBytes + left >= m_fileSize))
+        if ((!found_moof && m_mdat_pos && found_moov) || (found_moof && m_processedBytes + left >= m_fileSize))
             return 0;
 
         skip_bytes(left);

--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -836,7 +836,8 @@ int MovDemuxer::mov_read_default(MOVAtom atom)
                 break;
             }
         }
-        if (m_processedBytes + left >= m_fileSize)
+        if ((!found_moof && m_mdat_pos && found_moov) ||
+            (found_moof && m_processedBytes + left >= m_fileSize))
             return 0;
 
         skip_bytes(left);


### PR DESCRIPTION
Bug created by #205 .
If no moof atom met, stop atom parsing as soon as an mdat data atom is found.