### PR TITLE
Fix initializing lastDTS

### DIFF
--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -34,7 +34,7 @@ struct StreamInfo
         m_pid = pid;
         m_readCnt = 0;
         m_lastAVRez = AbstractStreamReader::NEED_MORE_DATA;
-        m_lastDTS = 0;
+        m_lastDTS = -1000000000;
         lastReadRez = 0;
         m_flushed = false;
         m_timeShift = 0;


### PR DESCRIPTION
Currently, tsMuxer muxes the first two frames of the first video track before muxing any other video/audio/subtitle track.
This is due to metaDemuxer.cpp line 98 `minDts = streamInfo.m_lastDTS;`, with m_lastDTS being initialized at zero.

The first video packet pts is set to 0, the first dts is set back by one frame.
The lastDTS value must be initialized below the value of the first DTS.