### PR TITLE
[Bug] prevent bitstream exception in hevc.cpp

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -895,7 +895,7 @@ int HevcHdrUnit::deserialize()
                     HDR10_metadata[5] = (maxCLL << 16) + maxFALL;
                 }
             }
-            else if (payloadType == 4 && !isHDR10plus)
+            else if (payloadType == 4 && payloadSize >= 8 && !isHDR10plus)
             {                           // HDR10Plus Metadata
                 m_reader.skipBits(8);   // country_code
                 m_reader.skipBits(32);  // terminal_provider


### PR DESCRIPTION
HDR10+ metadata is transmitted in the hevc stream via SEI nal with payloadType=4 'User data registered by Recommendation ITU-T T.35 SEI message syntax'. However the SEI 4 can have other uses, e.g. a single byte T.35 country code.

This fix prevents bitstream exception std::exception when SEI payloadSize is too short.