### PR TITLE
For double video track, DV EL stream type = 0x06

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -300,9 +300,15 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
                                                         descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MPEGH/ISO/HEVC")
+    {
+        int stream_type = STREAM_TYPE_VIDEO_H265;
+        // For non-bluray DV with two HEVC tracks, the DV EL track must be type 06
+        if (!m_bluRayMode && tsStreamIndex == 0x1015 && V3_flags & NON_DV_TRACK)
+            stream_type = STREAM_TYPE_PRIVATE_DATA;
         m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_VIDEO_H265, tsStreamIndex, descrBuffer,
+            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
                                                         descriptorLen, codecReader, lang, isSecondary)));
+    }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(
             std::make_pair(tsStreamIndex, PMTStreamInfo(STREAM_TYPE_VIDEO_VC1, tsStreamIndex, descrBuffer,

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -305,9 +305,9 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
         // For non-bluray DV with two HEVC tracks, the DV EL track must be type 06
         if (!m_bluRayMode && tsStreamIndex == 0x1015 && V3_flags & NON_DV_TRACK)
             stream_type = STREAM_TYPE_PRIVATE_DATA;
-        m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+        m_pmt.pidList.insert(std::make_pair(
+            tsStreamIndex,
+            PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer, descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(


### PR DESCRIPTION
As per 3.1.3.1 of DolbyVisionProfilesLevels_v1_3_2_2019_09_16.pdf, for the secondary Dolby Vision PID carrying the EL and RPU substream, "the value of stream_type shall be set to 0x06 (indicating PES packets containing private data)."