### PR TITLE
[bug] SEI nal does not always end by 0x80

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -913,7 +913,7 @@ int HevcHdrUnit::deserialize()
             }
             else
                 for (int i = 0; i < payloadSize; i++) m_reader.skipBits(8);
-        } while (m_reader.showBits(8) != 0x80);
+        } while (m_reader.getBitsLeft() > 16);
 
         return 0;
     }


### PR DESCRIPTION
In the rare case where the SEI payload is not byte aligned, the nal does not end with `b1000 0000`.
Fixes issue #252 .