### PR TITLE
[bug] Fix num_applicable_ops_minus1 size

### DIFF
--- a/tsMuxer/nalUnits.cpp
+++ b/tsMuxer/nalUnits.cpp
@@ -1144,15 +1144,12 @@ void SPSUnit::seq_parameter_set_mvc_extension()
     std::vector<int> num_anchor_refs_l0;
     std::vector<int> num_anchor_refs_l1;
     std::vector<int> num_non_anchor_refs_l0;
-    std::vector<int> non_anchor_ref_l1;
     std::vector<int> num_applicable_ops_minus1;
     std::vector<int> num_non_anchor_refs_l1;
 
     num_anchor_refs_l0.resize(num_views);
     num_anchor_refs_l1.resize(num_views);
     num_non_anchor_refs_l0.resize(num_views);
-    non_anchor_ref_l1.resize(num_views);
-    num_applicable_ops_minus1.resize(num_views);
     num_non_anchor_refs_l1.resize(num_views);
 
     for (int i = 1; i < num_views; i++)
@@ -1172,6 +1169,7 @@ void SPSUnit::seq_parameter_set_mvc_extension()
     }
 
     int num_level_values_signalled_minus1 = extractUEGolombCode();
+    num_applicable_ops_minus1.resize(num_level_values_signalled_minus1 + 1);
     level_idc_ext.resize(num_level_values_signalled_minus1 + 1);
     for (int i = 0; i <= num_level_values_signalled_minus1; i++)
     {


### PR DESCRIPTION
Fixes bug notified here: https://forum.doom9.org/showthread.php?p=1904881#post1904881

Note that it fixes the "vector subscript out of range" error, it does not fix the fact that the notification window does not show any error message !