### PR TITLE
[bug] Fix Subtitle Delay when concatenating M2ts

### DIFF
--- a/tsMuxer/tsDemuxer.cpp
+++ b/tsMuxer/tsDemuxer.cpp
@@ -36,6 +36,9 @@ TSDemuxer::TSDemuxer(const BufferedReaderManager& readManager, const char* strea
     m_firstPTS = -1;
     m_lastPTS = -1;
     m_firstVideoPTS = -1;
+    m_lastVideoPTS = -1;
+    m_lastVideoDTS = -1;
+    m_videoDtsGap = -1;
     m_firstCall = true;
     m_prevFileLen = 0;
     m_curFileNum = 0;
@@ -229,12 +232,19 @@ int TSDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& accepted
     {
         if (m_curFileNum < m_mplsInfo.size())
             m_prevFileLen +=
-                (m_mplsInfo[m_curFileNum].OUT_time - m_mplsInfo[m_curFileNum].IN_time) * 2;  // in 90Khz clock
+                (int64_t)(m_mplsInfo[m_curFileNum].OUT_time - m_mplsInfo[m_curFileNum].IN_time) * 2;  // in 90Khz clock
         else
-            m_prevFileLen += (m_lastPTS - m_firstPTS);
+        {
+            if (m_firstVideoPTS != -1 && m_lastVideoPTS != -1)
+                m_prevFileLen += (m_lastVideoPTS - m_firstVideoPTS + m_videoDtsGap);
+            else  // no video file
+                m_prevFileLen += (m_lastPTS - m_firstPTS);
+            ;
+        }
         m_firstPTS = -1;
         m_lastPTS = -1;
         m_firstVideoPTS = -1;
+        m_lastVideoPTS = -1;
         m_curFileNum++;
     }
 
@@ -375,11 +385,21 @@ int TSDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& accepted
                 if (m_firstPTS == -1 || curPts < m_firstPTS)
                     m_firstPTS = curPts;
 
-                if (streamInfo != m_pmt.pidList.end() && isVideoPID(streamInfo->second.m_streamType) &&
-                    (m_firstVideoPTS == -1 || curPts < m_firstVideoPTS))
-                    m_firstVideoPTS = curPts;
+                if (streamInfo != m_pmt.pidList.end() && isVideoPID(streamInfo->second.m_streamType))
+                {
+                    if (m_firstVideoPTS == -1 || curPts < m_firstVideoPTS)
+                        m_firstVideoPTS = curPts;
+                    if (curPts > m_lastVideoPTS)
+                        m_lastVideoPTS = curPts;
+                    if (m_lastVideoDTS == -1)
+                        m_lastVideoDTS = curDts;
+                    if (m_videoDtsGap == -1 && curDts > m_lastVideoDTS)
+                        m_videoDtsGap = curDts - m_lastVideoDTS;
+                }
+
                 if (m_firstPtsTime.find(pid) == m_firstPtsTime.end())
                     m_firstPtsTime[pid] = curPts;
+
                 else if (m_curFileNum == 0 && curPts < m_firstPtsTime[pid])
                     m_firstPtsTime[pid] = curPts;
             }

--- a/tsMuxer/tsDemuxer.h
+++ b/tsMuxer/tsDemuxer.h
@@ -72,6 +72,9 @@ class TSDemuxer : public AbstractDemuxer
     int64_t m_prevFileLen;
     int m_curFileNum;
     int64_t m_firstVideoPTS;
+    int64_t m_lastVideoPTS;
+    int64_t m_lastVideoDTS;
+    int64_t m_videoDtsGap;
     std::vector<MPLSPlayItem> m_mplsInfo;
     int64_t m_lastPCRVal;
     bool m_nonMVCVideoFound;


### PR DESCRIPTION
For subtitles, tsMuxer currently calculates the length of each m2ts relative to the last PTS.
The length of the m2ts should be calculated relative to the last video PTS, as there can be some audio/subtitle tracks longer than the video track.

Should fix issue #262 .