### PR TITLE
[bug] Integration of old Dolby Vision profiles 2, 3 and 6

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -271,11 +271,9 @@ HevcSpsUnit::HevcSpsUnit()
       vcl_hrd_parameters_present_flag(false),
       sub_pic_hrd_params_present_flag(false),
       num_short_term_ref_pic_sets(0),
-      colour_primaries(0),
-      transfer_characteristics(0),
-      matrix_coeffs(0),
-      chroma_sample_loc_type_top_field(0),
-      chroma_sample_loc_type_bottom_field(0),
+      colour_primaries(2),
+      transfer_characteristics(2),
+      matrix_coeffs(2),
       num_units_in_tick(0),
       time_scale(0),
       PicSizeInCtbsY_bits(0)
@@ -377,8 +375,8 @@ void HevcSpsUnit::vui_parameters()
     bool chroma_loc_info_present_flag = m_reader.getBit();
     if (chroma_loc_info_present_flag)
     {
-        chroma_sample_loc_type_top_field = extractUEGolombCode();
-        chroma_sample_loc_type_bottom_field = extractUEGolombCode();
+        extractUEGolombCode();  // chroma_sample_loc_type_top_field
+        extractUEGolombCode();  // chroma_sample_loc_type_bottom_field
     }
 
     m_reader.skipBit();  // neutral_chroma_indication_flag u(1)
@@ -848,7 +846,7 @@ int HevcPpsUnit::deserialize()
 }
 
 // ----------------------- HevcHdrUnit ------------------------
-HevcHdrUnit::HevcHdrUnit() : isHDR10(false), isHDR10plus(false), isDVRPU(false), isDVEL(false), DVCompatibility(0) {}
+HevcHdrUnit::HevcHdrUnit() : isHDR10(false), isHDR10plus(false), isDVRPU(false), isDVEL(false) {}
 
 int HevcHdrUnit::deserialize()
 {

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -160,8 +160,6 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     int colour_primaries;
     int transfer_characteristics;
     int matrix_coeffs;
-    int chroma_sample_loc_type_top_field;
-    int chroma_sample_loc_type_bottom_field;
 
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;
@@ -199,7 +197,6 @@ struct HevcHdrUnit : public HevcUnit
     bool isHDR10plus;
     bool isDVRPU;
     bool isDVEL;
-    int DVCompatibility;
 };
 
 struct HevcSliceHeader : public HevcUnit

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -230,7 +230,7 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
         m_hdr->isDVEL = true;
 
     int width = getStreamWidth();
-    int pixelRate = width *getStreamHeight() * getFPS();
+    int pixelRate = width * getStreamHeight() * getFPS();
 
     if (!isDVBL && V3_flags & FOUR_K)
         pixelRate *= 4;

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -230,10 +230,10 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
         m_hdr->isDVEL = true;
 
     int width = getStreamWidth();
-    if (!isDVBL && V3_flags & FOUR_K)
-        width *= 2;
+    int pixelRate = width *getStreamHeight() * getFPS();
 
-    int pixelRate = width * getStreamHeight() * getFPS();
+    if (!isDVBL && V3_flags & FOUR_K)
+        pixelRate *= 4;
 
     // cf. "http://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-profiles-levels.pdf"
     int profile;

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -235,17 +235,30 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
 
     int pixelRate = width * getStreamHeight() * getFPS();
 
-    // cf. "DolbyVisionProfilesLevels_v1_3_2_2019_09_16.pdf"
-    int profile = 0;
-    if (!isDVBL)  // dual HEVC track
-        profile = 7;
-    else if (m_hdr->isDVEL)
-        profile = 4;
-    else if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
-             m_sps->matrix_coeffs == 2)  // DV IPT color space
-        profile = 5;
-    else
-        profile = 8;
+    // cf. "http://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-profiles-levels.pdf"
+    int profile;
+    if (m_sps->bit_depth_luma_minus8 == 2)
+    {
+        if (!isDVBL)  // dual HEVC track
+            profile = 7;
+        else if (m_hdr->isDVEL && (V3_flags & HDR10))
+            profile = 6;
+        else if (m_hdr->isDVEL)
+            profile = 4;
+        else if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
+                 m_sps->matrix_coeffs == 2)  // DV IPT color space
+            profile = 5;
+        else
+            profile = 8;
+    }
+    else  // 8-bit
+    {
+        if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
+            m_sps->matrix_coeffs == 2)  // DV IPT color space
+            profile = 3;
+        else
+            profile = 2;
+    }
 
     int level = 0;
     if (width <= 1280 && pixelRate <= 22118400)

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -305,9 +305,9 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
         // For non-bluray, Dolby Vision track must be stream_type 06 = private data
         if (!m_bluRayMode && tsStreamIndex == 0x1015)
             stream_type = STREAM_TYPE_PRIVATE_DATA;
-        m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+        m_pmt.pidList.insert(std::make_pair(
+            tsStreamIndex,
+            PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer, descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -302,12 +302,12 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     else if (codecName == "V_MPEGH/ISO/HEVC")
     {
         int stream_type = STREAM_TYPE_VIDEO_H265;
-        // For non-bluray DV with two HEVC tracks, the DV EL track must be type 06
-        if (!m_bluRayMode && tsStreamIndex == 0x1015 && V3_flags & NON_DV_TRACK)
+        // For non-bluray, Dolby Vision track must be stream_type 06 = private data
+        if (!m_bluRayMode && tsStreamIndex == 0x1015)
             stream_type = STREAM_TYPE_PRIVATE_DATA;
-        m_pmt.pidList.insert(std::make_pair(
-            tsStreamIndex,
-            PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer, descriptorLen, codecReader, lang, isSecondary)));
+        m_pmt.pidList.insert(
+            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
+                                                        descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(


### PR DESCRIPTION
EDIT:
So it started with a small correction, but the more I search on DV profiles, the more I find...
From https://forum.blu-ray.com/showpost.php?p=12875562&postcount=645 I have now included DV profiles 2, 3 and 6 (deprecated on new equipment).

Plus As per T-REC-H.265 Annex E.3 VUI Semantics, Colour Primaries, Transfer Characteristics and Matrix Coefficients, when not present in the VUI, should be = 2 (Unspecified) by default. Value 0 is reserved for future use.

Plus code simplification: DVCompatibility is not compulsory in the DoVi descriptor.
Plus change HDMV descriptor to non-HDMV 'HEVC' registration descriptor for HEVC DV tracks.