### PR TITLE
Check for Invalid Characters in Output Filename

### DIFF
--- a/libmediation/fs/directory.cpp
+++ b/libmediation/fs/directory.cpp
@@ -33,14 +33,9 @@ char getDirSeparator()
 
 string extractFileDir(const string& fileName)
 {
-    size_t index = fileName.find_last_of('/');
+    size_t index = fileName.find_last_of(getDirSeparator());
     if (index != string::npos)
         return fileName.substr(0, index + 1);
-#ifdef _WIN32
-    index = fileName.find_last_of('\\');
-    if (index != string::npos)
-        return fileName.substr(0, index + 1);
-#endif
 
     return "";
 }

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -25,11 +25,11 @@ using namespace std;
 regex invalidChars()
 {
 #ifndef _WIN32
-    // NULL and /
-    regex invalid("[\\/\\x00]");
+    // / and ASCII 0 to 31
+    regex invalid("[/\x00-\x1F]");
 #else
-    // <>:"/|?* and ASCII 0 to 31
-    regex invalid("[:<>I\"\\/|?\\*\\x00-\\x1F]");
+    // <>:"/|?\* and ASCII 0 to 31
+    regex invalid("[:<>\"/|?\\*\x00-\x1F]");
 #endif
     return invalid;
 }

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -20,20 +20,26 @@
 
 #include "fs/directory.h"
 
-using namespace std;
-
-regex invalidChars()
+namespace
 {
+const std::regex& invalidChars()
+{
+    static const std::regex invalid(
 #ifndef _WIN32
-    // / and ASCII 0 to 31
-    regex invalid("[/\x00-\x1F]");
+        // / and ASCII 0 to 31
+        "[/\\x00-\\x1F]"
 #else
-    // <>:"/|?\*, ASCII 0 to 31 and all reserved names such as CON or LPT1
-    // see here: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-    regex invalid("[:<>\"/|?\\*\x00-\x1F]|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d$");
+        // <>:"/|?\*, ASCII 0 to 31 and all reserved names such as CON or LPT1
+        // see here: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+        "[:<>\"/|?\\*\\x00-\\x1F]|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d$"
 #endif
+        ,
+        std::regex_constants::ECMAScript | std::regex_constants::optimize);
     return invalid;
 }
+}  // namespace
+
+using namespace std;
 
 uint64_t my_ntohll(const uint64_t& original)
 {
@@ -372,8 +378,7 @@ bool isValidFileName(const string& src)
     string filename = extractFileName(src);
 
     // invalidChars() returns a different regex pattern for Windows or Unix
-    regex ourInvalidChars = invalidChars();
-    bool isvalid = !(std::regex_search(filename, ourInvalidChars));
+    bool isvalid = !(std::regex_search(filename, invalidChars()));
     return isvalid;
 }
 

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -28,8 +28,9 @@ regex invalidChars()
     // / and ASCII 0 to 31
     regex invalid("[/\x00-\x1F]");
 #else
-    // <>:"/|?\* and ASCII 0 to 31
-    regex invalid("[:<>\"/|?\\*\x00-\x1F]");
+    // <>:"/|?\*, ASCII 0 to 31 and all reserved names such as CON or LPT1
+    // see here: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    regex invalid("[:<>\"/|?\\*\x00-\x1F]|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d$");
 #endif
     return invalid;
 }

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -2,6 +2,7 @@
 #define __T_TYPES_H
 
 #include <cstdint>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -9,6 +10,8 @@
 #define strcasecmp stricmp
 #endif
 char* strnstr(const char* s1, const char* s2, size_t len);
+
+std::regex invalidChars();
 
 uint64_t my_ntohll(const uint64_t& original);
 uint64_t my_htonll(const uint64_t& original);
@@ -45,7 +48,6 @@ std::string extractFileName(const std::string& src);
 std::string extractFileName2(const std::string& src, bool withExt = true);
 std::string extractFilePath(const std::string& src);
 std::string closeDirPath(const std::string& src, char delimiter = ' ');
-bool isInvalidChar(const char& ch);
 bool isValidFileName(const std::string& src);
 
 std::vector<std::string> splitQuotedStr(const char* str, char splitter);

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -45,6 +45,8 @@ std::string extractFileName(const std::string& src);
 std::string extractFileName2(const std::string& src, bool withExt = true);
 std::string extractFilePath(const std::string& src);
 std::string closeDirPath(const std::string& src, char delimiter = ' ');
+bool isInvalidChar(const char& ch);
+bool isValidFileName(const std::string& src);
 
 std::vector<std::string> splitQuotedStr(const char* str, char splitter);
 

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -11,8 +11,6 @@
 #endif
 char* strnstr(const char* s1, const char* s2, size_t len);
 
-std::regex invalidChars();
-
 uint64_t my_ntohll(const uint64_t& original);
 uint64_t my_htonll(const uint64_t& original);
 uint32_t my_ntohl(const uint32_t val);

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -733,7 +733,12 @@ int main(int argc, char** argv)
                 LTRACE(LT_INFO, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
                 V3_flags |= HDMV_V3;
             }
+
+            // output path - is checked for invalid characters on our platform
             string dstFile = unquoteStr(argv[2]);
+
+            if (!isValidFileName(dstFile))
+                throw runtime_error(string("Output filename is invalid: ") + dstFile);
 
             if (dt != DT_NONE)
             {
@@ -801,8 +806,15 @@ int main(int argc, char** argv)
             sMuxer.openMetaFile(argv[1]);
             if (sMuxer.getTrackCnt() == 0)
                 THROW(ERR_COMMON, "No tracks selected");
-            createDir(unquoteStr(argv[2]), true);
-            sMuxer.doMux(unquoteStr(argv[2]), 0);
+
+            // output path - is checked for invalid characters on our platform
+            string dstFile = unquoteStr(argv[2]);
+
+            if (!isValidFileName(dstFile))
+                throw runtime_error(string("Output filename is invalid: ") + dstFile);
+
+            createDir(dstFile, true);
+            sMuxer.doMux(dstFile, 0);
             LTRACE(LT_INFO, 2, "Demux complete.");
         }
         auto endTime = std::chrono::steady_clock::now();


### PR DESCRIPTION
We use different regex patterns for Unix and Windows to check for invalid characters in the output filename. If invalid characters are found we throw a runtime error.

Additionally some changes were made to make sure there was more uniform use of the getDirSeparator() function.

Should resolve #268 

Output strings tested:

```
Alita: Battle Angel (2019).ts
Alita Battle Angel (2019).ts
Alita Battle Angel (2019)для Константина.ts
```

Only the first should fail on Windows.