### PR TITLE
Fix skipbyte 4GB limit

### DIFF
--- a/tsMuxer/ioContextDemuxer.cpp
+++ b/tsMuxer/ioContextDemuxer.cpp
@@ -139,14 +139,14 @@ uint32_t IOContextDemuxer::get_buffer(uint8_t* binary, int size)
     return dst - binary;
 }
 
-void IOContextDemuxer::skip_bytes(int size)
+void IOContextDemuxer::skip_bytes(uint64_t size)
 {
     uint32_t readedBytes = 0;
     int readRez = 0;
-    int skipLeft = size;
+    uint64_t skipLeft = size;
     if (m_curPos < m_bufEnd)
     {
-        int copyLen = min(m_bufEnd - m_curPos, skipLeft);
+        uint64_t copyLen = min(m_bufEnd - m_curPos, skipLeft);
         skipLeft -= copyLen;
         m_curPos += copyLen;
         m_processedBytes += copyLen;
@@ -158,7 +158,7 @@ void IOContextDemuxer::skip_bytes(int size)
             m_bufferedReader->notify(m_readerID, readedBytes);
         m_curPos = data + 188;
         m_bufEnd = m_curPos + readedBytes;
-        int copyLen = min(m_bufEnd - m_curPos, skipLeft);
+        uint64_t copyLen = min(m_bufEnd - m_curPos, skipLeft);
         m_curPos += copyLen;
         m_processedBytes += copyLen;
         skipLeft -= copyLen;

--- a/tsMuxer/ioContextDemuxer.h
+++ b/tsMuxer/ioContextDemuxer.h
@@ -106,7 +106,7 @@ class IOContextDemuxer : public AbstractDemuxer
     uint64_t m_processedBytes;
     uint64_t m_lastProcessedBytes;
 
-    void skip_bytes(int size);
+    void skip_bytes(uint64_t size);
     uint32_t get_buffer(uint8_t* binary, int size);
     bool url_fseek(int64_t offset);
     uint64_t get_be64();


### PR DESCRIPTION
The size of bytes to skip should be unsigned 64-bit integer.

Fixes issue #285