### PR TITLE
Reversion on m_lastDTS initialization

### DIFF
--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -34,7 +34,7 @@ struct StreamInfo
         m_pid = pid;
         m_readCnt = 0;
         m_lastAVRez = AbstractStreamReader::NEED_MORE_DATA;
-        m_lastDTS = -1000000000;
+        m_lastDTS = 0;
         lastReadRez = 0;
         m_flushed = false;
         m_timeShift = 0;


### PR DESCRIPTION
The previous patch #251 solved one issue with double HEVC tracks, but created various issues with other tracks e.g. https://forum.doom9.org/showthread.php?p=1918290#post1918290
This patch puts back initialization of m_lastDTS to 0. I'll work out an alternative way to solve the double HEVC track DTS issue.