### PR TITLE
Use memmove when buffers can overlap.

### DIFF
--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -787,7 +787,7 @@ int LPCMStreamReader::readPacket(AVPacket& avPacket)
     avPacket.dts = avPacket.pts = m_curPts * m_stretch + m_timeOffset;
     if (m_bufEnd - m_curPos < getHeaderLen())
     {
-        memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+        memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
         m_tmpBufferLen = m_bufEnd - m_curPos;
         m_curPos = m_bufEnd;
         return NEED_MORE_DATA;
@@ -797,7 +797,7 @@ int LPCMStreamReader::readPacket(AVPacket& avPacket)
     int frameLen = decodeFrame(m_curPos, m_bufEnd, skipBytes, skipBeforeBytes);
     if (frameLen == NOT_ENOUGH_BUFFER)
     {
-        memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+        memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
         m_tmpBufferLen = m_bufEnd - m_curPos;
         m_curPos = m_bufEnd;
         return NEED_MORE_DATA;
@@ -810,7 +810,7 @@ int LPCMStreamReader::readPacket(AVPacket& avPacket)
     }
     if (m_bufEnd - m_curPos < frameLen + skipBytes + skipBeforeBytes)
     {
-        memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+        memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
         m_tmpBufferLen = m_bufEnd - m_curPos;
         m_curPos = m_bufEnd;
         return NEED_MORE_DATA;

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -1291,7 +1291,7 @@ uint8_t* ContainerToReaderWrapper::readBlock(uint32_t readerID, uint32_t& readCn
         if (currentSize > lastReadCnt)
         {
             uint8_t* dataStart = streamData.data() + m_readBuffOffset;
-            memcpy(dataStart, dataStart + lastReadCnt, currentSize - lastReadCnt);
+            memmove(dataStart, dataStart + lastReadCnt, currentSize - lastReadCnt);
         }
         streamData.resize(m_readBuffOffset + currentSize - lastReadCnt);
         demuxerData.lastReadCnt[pid] = 0;

--- a/tsMuxer/mpegStreamReader.cpp
+++ b/tsMuxer/mpegStreamReader.cpp
@@ -85,7 +85,7 @@ void MPEGStreamReader::onShiftBuffer(int offset) {}
 void MPEGStreamReader::storeBufferRest()
 {
     onShiftBuffer(m_curPos - m_tmpBuffer);
-    memcpy(m_tmpBuffer, m_curPos, m_bufEnd - m_curPos);
+    memmove(m_tmpBuffer, m_curPos, m_bufEnd - m_curPos);
     m_tmpBufferLen = m_bufEnd - m_curPos;
     if (m_lastDecodedPos > m_curPos)
         m_lastDecodedPos = m_tmpBuffer + (m_lastDecodedPos - m_curPos);

--- a/tsMuxer/programStreamDemuxer.cpp
+++ b/tsMuxer/programStreamDemuxer.cpp
@@ -395,7 +395,7 @@ int ProgramStreamDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSe
     }
     m_tmpBufferLen = end - curBuf;
     if (m_tmpBufferLen > 0)
-        memcpy(m_tmpBuffer, curBuf, end - curBuf);
+        memmove(m_tmpBuffer, curBuf, end - curBuf);
     return 0;
 }
 

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -522,7 +522,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     if (m_bufEnd - m_curPos < 3)
     {
         m_tmpBufferLen = m_bufEnd - m_curPos;
-        memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+        memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
         return NEED_MORE_DATA;
     }
     bool pgStartCode = m_curPos[0] == 'P' && m_curPos[1] == 'G';
@@ -531,7 +531,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         if (m_bufEnd - m_curPos < 10)
         {
             m_tmpBufferLen = m_bufEnd - m_curPos;
-            memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+            memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
             return NEED_MORE_DATA;
         }
         m_lastPTS = getTimeValueNano(m_curPos + 2) * m_scale;
@@ -561,7 +561,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         if (m_bufEnd - m_curPos < 8)
         {
             m_tmpBufferLen = m_bufEnd - m_curPos;
-            memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+            memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
             return NEED_MORE_DATA;
         }
         PESPacket* pesPacket = (PESPacket*)m_curPos;
@@ -570,7 +570,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         if (m_bufEnd - m_curPos < pesHeaderLen)
         {
             m_tmpBufferLen = m_bufEnd - m_curPos;
-            memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+            memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
             return NEED_MORE_DATA;
         }
         if (pesPacket->flagsLo & 0x80)
@@ -600,7 +600,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     if (m_bufEnd - m_curPos < 3)
     {
         m_tmpBufferLen = m_bufEnd - m_curPos;
-        memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+        memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
         return NEED_MORE_DATA;
     }
     uint8_t segment_type = *m_curPos;
@@ -608,7 +608,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     if (m_bufEnd - m_curPos < 3 + segment_len)
     {
         m_tmpBufferLen = m_bufEnd - m_curPos;
-        memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+        memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
         return NEED_MORE_DATA;
     }
     m_curPos += 3;
@@ -638,7 +638,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
                 if (readObjectDef(m_curPos, m_curPos + segment_len) == NEED_MORE_DATA)
                 {
                     m_tmpBufferLen = m_bufEnd - m_curPos;
-                    memcpy(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
+                    memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
                     return NEED_MORE_DATA;
                 }
                 renderTextShow(m_maxPTS);
@@ -740,7 +740,7 @@ void PGSStreamReader::setBuffer(uint8_t* data, int dataLen, bool lastBlock)
         m_tmpBuffer.resize(m_tmpBufferLen + dataLen);
 
     if (m_tmpBuffer.size() > 0)
-        memcpy(&m_tmpBuffer[0] + m_tmpBufferLen, data + MAX_AV_PACKET_SIZE, dataLen);
+        memmove(&m_tmpBuffer[0] + m_tmpBufferLen, data + MAX_AV_PACKET_SIZE, dataLen);
     m_tmpBufferLen += dataLen;
 
     if (m_tmpBuffer.size() > 0)

--- a/tsMuxer/simplePacketizerReader.cpp
+++ b/tsMuxer/simplePacketizerReader.cpp
@@ -128,7 +128,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
                 if (m_bufEnd - frame > DEFAULT_FILE_BLOCK_SIZE)
                     THROW(ERR_COMMON,
                           getCodecInfo().displayName << " stream (track " << m_streamIndex << "): invalid stream.");
-                memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+                memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
                 m_tmpBufferLen = m_bufEnd - m_curPos;
                 m_curPos = m_bufEnd;
                 return NEED_MORE_DATA;
@@ -149,7 +149,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
         avPacket.dts = avPacket.pts = m_curPts * m_stretch + m_timeOffset;
         if (m_bufEnd - m_curPos < getHeaderLen())
         {
-            memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+            memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
             m_tmpBufferLen = m_bufEnd - m_curPos;
             m_curPos = m_bufEnd;
             return NEED_MORE_DATA;
@@ -162,7 +162,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
             if (m_bufEnd - m_curPos > DEFAULT_FILE_BLOCK_SIZE)
                 THROW(ERR_COMMON,
                       getCodecInfo().displayName << " stream (track " << m_streamIndex << "): invalid stream.");
-            memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+            memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
             m_tmpBufferLen = m_bufEnd - m_curPos;
             m_curPos = m_bufEnd;
             return NEED_MORE_DATA;
@@ -178,7 +178,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
         }
         if (m_bufEnd - m_curPos < frameLen + skipBytes + skipBeforeBytes)
         {
-            memcpy(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
+            memmove(&m_tmpBuffer[0], m_curPos, m_bufEnd - m_curPos);
             m_tmpBufferLen = m_bufEnd - m_curPos;
             m_curPos = m_bufEnd;
             return NEED_MORE_DATA;

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -189,7 +189,7 @@ void SingleFileMuxer::writeOutBuffer(StreamInfo* streamInfo)
         else
         {
             m_owner->syncWriteBuffer(this, streamInfo->m_buffer, toFileLen, &streamInfo->m_file);
-            memcpy(streamInfo->m_buffer, streamInfo->m_buffer + toFileLen, streamInfo->m_bufLen - toFileLen);
+            memmove(streamInfo->m_buffer, streamInfo->m_buffer + toFileLen, streamInfo->m_bufLen - toFileLen);
         }
         streamInfo->m_totalWrited += toFileLen;
         streamInfo->m_bufLen -= toFileLen;
@@ -274,7 +274,7 @@ bool SingleFileMuxer::doFlush()
         else
         {
             m_owner->syncWriteBuffer(this, streamInfo->m_buffer, roundBufLen, &streamInfo->m_file);
-            memcpy(streamInfo->m_buffer, streamInfo->m_buffer + roundBufLen, lastBlockSize);
+            memmove(streamInfo->m_buffer, streamInfo->m_buffer + roundBufLen, lastBlockSize);
         }
         streamInfo->m_bufLen = lastBlockSize;
     }

--- a/tsMuxer/srtStreamReader.cpp
+++ b/tsMuxer/srtStreamReader.cpp
@@ -39,14 +39,14 @@ void SRTStreamReader::setBuffer(uint8_t* data, int dataLen, bool lastBlock)
     m_lastBlock = lastBlock;
     uint8_t* dataBegin = data + MAX_AV_PACKET_SIZE - m_tmpBuffer.size();
     if (m_tmpBuffer.size() > 0)
-        memcpy(dataBegin, &m_tmpBuffer[0], m_tmpBuffer.size());
+        memmove(dataBegin, &m_tmpBuffer[0], m_tmpBuffer.size());
     int parsedLen = parseText(dataBegin, dataLen + m_tmpBuffer.size());
     int rest = dataLen + m_tmpBuffer.size() - parsedLen;
     if (rest > MAX_AV_PACKET_SIZE)
         THROW(ERR_COMMON, "Invalid SRT file or too large text message (>" << MAX_AV_PACKET_SIZE << " bytes)");
     m_tmpBuffer.resize(rest);
     if (rest > 0)
-        memcpy(&m_tmpBuffer[0], dataBegin + dataLen + m_tmpBuffer.size() - rest, rest);
+        memmove(&m_tmpBuffer[0], dataBegin + dataLen + m_tmpBuffer.size() - rest, rest);
 }
 
 bool SRTStreamReader::detectSrcFormat(uint8_t* dataStart, int len, int& prefixLen)

--- a/tsMuxer/tsDemuxer.cpp
+++ b/tsMuxer/tsDemuxer.cpp
@@ -146,7 +146,7 @@ void TSDemuxer::getTrackList(std::map<uint32_t, TrackInfo>& trackList)
         if (curPos < data + readedBytes)
         {
             tmpBufferLen = data + readedBytes - curPos;
-            memcpy(m_tmpBuffer, curPos, tmpBufferLen);
+            memmove(m_tmpBuffer, curPos, tmpBufferLen);
         }
     }
 
@@ -446,7 +446,7 @@ int TSDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& accepted
     if (m_curPos < data + readedBytes)
     {
         m_tmpBufferLen = data + readedBytes - m_curPos;
-        memcpy(m_tmpBuffer, m_curPos, m_tmpBufferLen);
+        memmove(m_tmpBuffer, m_curPos, m_tmpBufferLen);
     }
 
     return 0;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -464,7 +464,7 @@ bool TSMuxer::doFlush(uint64_t newPCR, int64_t pcrGAP)
     else
     {
         m_owner->syncWriteBuffer(this, m_outBuf, roundBufLen, m_muxFile);
-        memcpy(m_outBuf, m_outBuf + roundBufLen, lastBlockSize);
+        memmove(m_outBuf, m_outBuf + roundBufLen, lastBlockSize);
     }
     m_outBufLen = lastBlockSize;
     assert(!m_sectorSize || m_outBufLen == 0);
@@ -1358,7 +1358,7 @@ void TSMuxer::writeOutBuffer()
                     m_m2tsDelayBlocks.push_back(std::make_pair(newBuf, toFileLen));
                 }
             }
-            memcpy(m_outBuf, m_outBuf + toFileLen, m_outBufLen - toFileLen);
+            memmove(m_outBuf, m_outBuf + toFileLen, m_outBufLen - toFileLen);
         }
         m_outBufLen -= toFileLen;
     }


### PR DESCRIPTION
BluRay m2ts failure for linux 64-bit tsMuxeR

This bug was caused by using memcpy() in metaDemuxer.cpp with
overlapping buffers.  Use memmove() instead.  The other
changes were the result of a bench check of the sources.

This fixes (#316)