### PR TITLE
[bug] 4K flag set in non-hdmv mode

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -687,6 +687,8 @@ int HevcSpsUnit::deserialize()
             separate_colour_plane_flag = m_reader.getBit();
         pic_width_in_luma_samples = extractUEGolombCode();
         pic_height_in_luma_samples = extractUEGolombCode();
+        if (pic_width_in_luma_samples >= 3840)
+            V3_flags |= FOUR_K;
 
         bool conformance_window_flag = m_reader.getBit();
         if (conformance_window_flag)

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -2649,10 +2649,7 @@ void M2TSStreamInfo::blurayStreamParams(double fps, bool interlaced, int width, 
     else if (isPal)
         *video_format = interlaced ? 2 : 7;
     else if (width >= 2600)
-    {
         *video_format = 8;
-        V3_flags |= FOUR_K;
-    }
     else if (width >= 1300)
         *video_format = interlaced ? 4 : 6;  // as 1920x1080
     else


### PR DESCRIPTION
The blurayStreamParams method is currently called only in hdmv mode, therefore the 4K flag is never set in non-hdmv mode.
This commit fixes this.