### PR TITLE
Correct "General track options" layout

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -417,7 +417,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="1" rowspan="3">
+              <item row="1" column="1">
                <widget class="QComboBox" name="comboBoxLevel">
                 <property name="enabled">
                  <bool>false</bool>
@@ -505,7 +505,7 @@
                 </item>
                </widget>
               </item>
-              <item row="1" column="3" rowspan="3">
+              <item row="1" column="3">
                <widget class="QLabel" name="labelAR">
                 <property name="enabled">
                  <bool>false</bool>
@@ -524,7 +524,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="4" rowspan="3">
+              <item row="1" column="4">
                <widget class="QComboBox" name="comboBoxAR">
                 <property name="enabled">
                  <bool>false</bool>
@@ -562,14 +562,14 @@
                 </item>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="1" column="0">
                <widget class="QCheckBox" name="checkBoxLevel">
                 <property name="text">
                  <string>Change level:</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="2">
+              <item row="1" column="2">
                <widget class="QCheckBox" name="checkBoxSPS">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">


### PR DESCRIPTION
Correct the grid layout so that the data is neatly shown on the two rows.
GTO tab layout for video has now the same height as for audio and subs.

<img width="512" alt="GTO" src="https://user-images.githubusercontent.com/56721609/91611981-be87aa80-e97c-11ea-9dde-d7fef6af7f6d.png">
