### PR TITLE
[bug] Precheck Frame Depth

### DIFF
--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -45,6 +45,7 @@ HEVCStreamReader::~HEVCStreamReader()
 CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
 {
     CheckStreamRez rez;
+    HevcSliceHeader slice;
 
     uint8_t* end = buffer + len;
     for (uint8_t* nal = NALUnit::findNextNAL(buffer, end); nal < end - 4; nal = NALUnit::findNextNAL(nal, end))
@@ -57,7 +58,6 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
         switch (nalType)
         {
         case NAL_VPS:
-        {
             if (!m_vps)
                 m_vps = new HevcVpsUnit();
             m_vps->decodeBuffer(nal, nextNal);
@@ -67,9 +67,7 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
             if (m_vps->num_units_in_tick)
                 updateFPS(m_vps, nal, nextNal, 0);
             break;
-        }
         case NAL_SPS:
-        {
             if (!m_sps)
                 m_sps = new HevcSpsUnit();
             m_sps->decodeBuffer(nal, nextNal);
@@ -78,28 +76,22 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
             m_spsPpsFound = true;
             updateFPS(m_sps, nal, nextNal, 0);
             break;
-        }
         case NAL_PPS:
-        {
             if (!m_pps)
                 m_pps = new HevcPpsUnit();
             m_pps->decodeBuffer(nal, nextNal);
             if (m_pps->deserialize() != 0)
                 return rez;
             break;
-        }
         case NAL_SEI_PREFIX:
-        {
             if (!m_hdr)
                 m_hdr = new HevcHdrUnit();
             m_hdr->decodeBuffer(nal, nextNal);
             if (m_hdr->deserialize() != 0)
                 return rez;
             break;
-        }
         case NAL_DVRPU:
         case NAL_DVEL:
-        {
             if (!m_hdr)
                 m_hdr = new HevcHdrUnit();
             if (nal[1] == 1)
@@ -110,15 +102,24 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
                     m_hdr->isDVRPU = true;
                 V3_flags |= DV;
             }
-            break;
         }
+
+        // check Frame Depth
+        if (isSlice(nalType))
+        {
+            slice.decodeBuffer(nal, FFMIN(nal + MAX_SLICE_HEADER, nextNal));
+            if (slice.deserialize(m_sps, m_pps))
+                return rez;  // not enough buffer or error
+            m_fullPicOrder = toFullPicOrder(&slice, m_sps->log2_max_pic_order_cnt_lsb);
+            incTimings();
         }
     }
 
+    // Set HDR10 flag if PQ detected
     if (m_vps && m_sps && m_pps && m_sps->vps_id == m_vps->vps_id && m_pps->sps_id == m_sps->sps_id)
     {
         if (m_sps->colour_primaries == 9 && m_sps->transfer_characteristics == 16 &&
-            m_sps->matrix_coeffs == 9)  // BT.2100
+            m_sps->matrix_coeffs == 9)  // SMPTE.ST.2084 (PQ)
         {
             if (!m_hdr)
                 m_hdr = new HevcHdrUnit();


### PR DESCRIPTION
tsMuxer currently sets back the DTS (Decoding Time Stamp) during the muxing if the frame depth (i.e. difference between encoded picture number and decoded picture number) is found >1.
This is wrong: the frame depth should be checked -and the DTS set back- before the muxing commences.

This commits solves this.
This also solves the problem of bitrate reading with BDInfo (cf. https://forum.doom9.org/showthread.php?p=1922760) with frame depth >1.