### PR TITLE
[bug] Detection of coded fields

### DIFF
--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -650,8 +650,10 @@ void H264StreamReader::additionalStreamCheck(uint8_t* buff, uint8_t* end)
             rez = deserializeSliceHeader(slice, nal, end);
             if (rez == 0)
             {
-                if (slice.getSPS()->frame_mbs_only_flag == 0)
+                // coded fields
+                if (slice.getSPS()->frame_mbs_only_flag == 0 && slice.m_field_pic_flag)
                     m_forceLsbDiv = 1;
+                // coded frames
                 else if (slice.pic_order_cnt_lsb % 2 == 1)
                     m_forceLsbDiv = 0;
             }


### PR DESCRIPTION
In case coded field is detected (i.e. the picture is composed of a top field and a bottom field), the incrementation of the poc (coded picture order count) must be done every two frames.
However the detection of the coded field in tsMuxer is wrong: 
frame_mbs_only_flag = 1 means that the picture is coded frame.
frame_mbs_only_flag = 0 means that the picture can be either coded frame (m_field_pic_flag = 0) or coded field (m_field_pic_flag = 1).

This patch corrects the bug, and solves issue #306 .