### PR TITLE
Changes to Dolby Vision profiles

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -362,7 +362,7 @@ void HevcSpsUnit::vui_parameters()
     if (video_signal_type_present_flag)
     {
         m_reader.skipBits(3);  // video_format u(3)
-        m_reader.skipBit();    // video_full_range_flag u(1)
+        video_full_range_flag = m_reader.getBit();
         bool colour_description_present_flag = m_reader.getBit();
         if (colour_description_present_flag)
         {
@@ -375,8 +375,8 @@ void HevcSpsUnit::vui_parameters()
     bool chroma_loc_info_present_flag = m_reader.getBit();
     if (chroma_loc_info_present_flag)
     {
-        extractUEGolombCode();  // chroma_sample_loc_type_top_field
-        extractUEGolombCode();  // chroma_sample_loc_type_bottom_field
+        chroma_sample_loc_type_top_field = extractUEGolombCode();
+        chroma_sample_loc_type_bottom_field = extractUEGolombCode();
     }
 
     m_reader.skipBit();  // neutral_chroma_indication_flag u(1)

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -157,9 +157,12 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     */
     std::vector<ShortTermRPS> st_rps;
 
+    int video_full_range_flag;
     int colour_primaries;
     int transfer_characteristics;
     int matrix_coeffs;
+    int chroma_sample_loc_type_top_field;
+    int chroma_sample_loc_type_bottom_field;
 
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -303,8 +303,8 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     else if (codecName == "V_MPEGH/ISO/HEVC")
     {
         int stream_type = STREAM_TYPE_VIDEO_H265;
-        // For non-bluray, Dolby Vision track must be stream_type 06 = private data
-        if (!m_bluRayMode && tsStreamIndex == 0x1015)
+        // For non-bluray, second Dolby Vision track must be stream_type 06 = private data
+        if (!m_bluRayMode && tsStreamIndex == 0x1015 && (V3_flags & NON_DV_TRACK))
             stream_type = STREAM_TYPE_PRIVATE_DATA;
         m_pmt.pidList.insert(std::make_pair(
             tsStreamIndex,


### PR DESCRIPTION
As per [Dolby whitebook](https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolbyvisionprofileslevels_v1_3_2_2019_09_16.pdf) , VUI parameters in the stream are compulsory for profiles 5, 8.1 and 8.4 but are optional for the other profiles.
Detection of profiles is re-written to account for the cases where the VUI parameters are unspecified.