### PR TITLE
[bug] Correct DV descriptor

### DIFF
--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -343,23 +343,23 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
 
     bitWriter.putBits(8, 0xb0);            // DoVi descriptor tag
     bitWriter.putBits(8, isDVBL ? 5 : 7);  // descriptor length
-    bitWriter.putBits(8, 1);               // dv version major
+    bitWriter.putBits(8, 2);               // dv version major
     bitWriter.putBits(8, 0);               // dv version minor
     bitWriter.putBits(7, profile);         // dv profile
     bitWriter.putBits(6, level);           // dv level
     bitWriter.putBits(1, m_hdr->isDVRPU);  // rpu_present_flag
     bitWriter.putBits(1, m_hdr->isDVEL);   // el_present_flag
     bitWriter.putBits(1, isDVBL);          // bl_present_flag
+    bitWriter.putBits(4, compatibility);   // dv_bl_signal_compatibility_id
+    bitWriter.putBits(4, 15);               // reserved
     if (!isDVBL)
     {
         bitWriter.putBits(13, 0x1011);  // dependency_pid
         bitWriter.putBits(3, 7);        // reserved
     }
-    bitWriter.putBits(4, compatibility);  // dv_bl_signal_compatibility_id
-    bitWriter.putBits(4, 15);             // reserved
 
     bitWriter.flushBits();
-    return 2 + (isDVBL ? 5 : 7);
+    return isDVBL ? 7 : 9;
 }
 
 void HEVCStreamReader::updateStreamFps(void* nalUnit, uint8_t* buff, uint8_t* nextNal, int)

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -351,7 +351,7 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
     bitWriter.putBits(1, m_hdr->isDVEL);   // el_present_flag
     bitWriter.putBits(1, isDVBL);          // bl_present_flag
     bitWriter.putBits(4, compatibility);   // dv_bl_signal_compatibility_id
-    bitWriter.putBits(4, 15);               // reserved
+    bitWriter.putBits(4, 15);              // reserved
     if (!isDVBL)
     {
         bitWriter.putBits(13, 0x1011);  // dependency_pid


### PR DESCRIPTION
See https://forum.doom9.net/showthread.php?p=1924053#post1924053 : from the [ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/e71d73b09652f4fc96e512a7d6d4c2ab41860f27/libavformat/mpegts.c#L2170) and [mediainfo](https://github.com/MediaArea/MediaInfoLib/blob/702d6b20c7bdaccf2dc2b7c5d6ceca673d5c608a/Source/MediaInfo/Multiple/File_Mpeg_Descriptors.cpp#L3457) source codes, the Dolby spec version 1 seems to be incorrect: the compatibility id should be directly after the bl_present flag, and this has obviously been corrected in version 2 (although I cannot get a hand on v2).

Incorrect Dolby spec v1.2 :
<img width="232" alt="Dovi" src="https://user-images.githubusercontent.com/56721609/93825898-78192900-fc66-11ea-8051-a6a8178ba50a.png">


