### PR TITLE
[bug] keep non timing SEIs

### DIFF
--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -911,19 +911,15 @@ bool H264StreamReader::skipNal(uint8_t* nal)
     }
     else if (nalType == nuSEI)
     {
-        return true;
-        /*
         SEIUnit sei;
         uint8_t* nextNal = NALUnit::findNALWithStartCode(nal, m_bufEnd, true);
         sei.decodeBuffer(nal, nextNal);
-        sei.deserialize(*(m_spsMap.begin()->second), orig_hrd_parameters_present_flag);
+        sei.deserialize(*(m_spsMap.begin()->second),
+                        orig_hrd_parameters_present_flag || orig_vcl_parameters_present_flag);
 
-        for (std::set<int>::iterator itr = sei.m_processedMessages.begin(); itr != sei.m_processedMessages.end(); ++itr)
-        {
-            if (*itr == SEI_MSG_BUFFERING_PERIOD || *itr == SEI_MSG_PIC_TIMING)
+        if (sei.m_processedMessages.find(SEI_MSG_BUFFERING_PERIOD) != sei.m_processedMessages.end() ||
+            sei.m_processedMessages.find(SEI_MSG_PIC_TIMING) != sei.m_processedMessages.end())
                 return true;
-        }
-        */
     }
     return false;
 }

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -919,7 +919,7 @@ bool H264StreamReader::skipNal(uint8_t* nal)
 
         if (sei.m_processedMessages.find(SEI_MSG_BUFFERING_PERIOD) != sei.m_processedMessages.end() ||
             sei.m_processedMessages.find(SEI_MSG_PIC_TIMING) != sei.m_processedMessages.end())
-                return true;
+            return true;
     }
     return false;
 }


### PR DESCRIPTION
With the H264 option 'Insert SEI and VUI data if absent' or 'Always rebuild SEI and VUI data':
In case timing SEIs are not found, all SEIs (timing and non timing) are currently removed and replaced with timing SEIs.

This patch corrects this: only the timing SEIs are removed, the non-timing SEIs (such as private date e.g. x264 decoding parameters) are kept.

Fixes issue #349 .