### PR TITLE
Make SEIUnit::m_processedMessages an unordered_set

### DIFF
--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -603,9 +603,10 @@ void H264StreamReader::additionalStreamCheck(uint8_t* buff, uint8_t* end)
                     break;
                 sei.decodeBuffer(nal, nalEnd);
                 sei.deserialize(tmpsps, orig_hrd_parameters_present_flag || orig_vcl_parameters_present_flag);
-                if (sei.m_processedMessages.find(SEI_MSG_BUFFERING_PERIOD) != sei.m_processedMessages.end() ||
-                    sei.m_processedMessages.find(SEI_MSG_PIC_TIMING) != sei.m_processedMessages.end())
+                if (sei.hasProcessedMessage(SEI_MSG_BUFFERING_PERIOD) || sei.hasProcessedMessage(SEI_MSG_PIC_TIMING))
+                {
                     SEIFound = true;
+                }
 
                 if (sei.number_of_offset_sequences >= 0)
                 {
@@ -917,9 +918,10 @@ bool H264StreamReader::skipNal(uint8_t* nal)
         sei.deserialize(*(m_spsMap.begin()->second),
                         orig_hrd_parameters_present_flag || orig_vcl_parameters_present_flag);
 
-        if (sei.m_processedMessages.find(SEI_MSG_BUFFERING_PERIOD) != sei.m_processedMessages.end() ||
-            sei.m_processedMessages.find(SEI_MSG_PIC_TIMING) != sei.m_processedMessages.end())
+        if (sei.hasProcessedMessage(SEI_MSG_BUFFERING_PERIOD) || sei.hasProcessedMessage(SEI_MSG_PIC_TIMING))
+        {
             return true;
+        }
     }
     return false;
 }
@@ -944,24 +946,25 @@ int H264StreamReader::processSEI(uint8_t* buff)
 
         bool timingSEI = false;
         bool nonTimingSEI = false;
-        for (std::set<int>::iterator itr = lastSEI.m_processedMessages.begin();
-             itr != lastSEI.m_processedMessages.end(); ++itr)
+        for (auto msg : lastSEI.m_processedMessages)
         {
-            if (*itr == SEI_MSG_BUFFERING_PERIOD)
+            if (msg == SEI_MSG_BUFFERING_PERIOD)
             {
                 timingSEI = true;
             }
-            else if (*itr == SEI_MSG_PIC_TIMING)
+            else if (msg == SEI_MSG_PIC_TIMING)
             {
                 timingSEI = true;
                 m_lastPictStruct = lastSEI.pic_struct;
             }
-            else if (*itr == SEI_MSG_MVC_SCALABLE_NESTING)
+            else if (msg == SEI_MSG_MVC_SCALABLE_NESTING)
             {
                 ;
             }
             else
+            {
                 nonTimingSEI = true;
+            }
         }
 
         if (m_mvcSubStream)

--- a/tsMuxer/nalUnits.h
+++ b/tsMuxer/nalUnits.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
 #include "bitStream.h"
@@ -335,7 +336,7 @@ class SEIUnit : public NALUnit
     int pic_struct;
     uint8_t* m_cpb_removal_delay_baseaddr;
     int m_cpb_removal_delay_bitpos;
-    std::set<int> m_processedMessages;
+    std::unordered_set<int> m_processedMessages;
 
     int cpb_removal_delay;
     int dpb_output_delay;
@@ -345,6 +346,8 @@ class SEIUnit : public NALUnit
     int metadataPtsOffset;
     int m_mvcHeaderLen;
     uint8_t* m_mvcHeaderStart;
+
+    bool hasProcessedMessage(int msg) const { return m_processedMessages.find(msg) != m_processedMessages.end(); }
 
    private:
     void sei_payload(SPSUnit& sps, int payloadType, uint8_t* curBuf, int payloadSize,


### PR DESCRIPTION
`m_processedMessages` is never used in a context where the ordering of the elements matter, so it makes it a perfect candidate for converting to `std::unordered_set`.