### PR TITLE
Revert to DV version 1

### DIFF
--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -343,20 +343,20 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
 
     bitWriter.putBits(8, 0xb0);            // DoVi descriptor tag
     bitWriter.putBits(8, isDVBL ? 5 : 7);  // descriptor length
-    bitWriter.putBits(8, 2);               // dv version major
+    bitWriter.putBits(8, 1);               // dv version major
     bitWriter.putBits(8, 0);               // dv version minor
     bitWriter.putBits(7, profile);         // dv profile
     bitWriter.putBits(6, level);           // dv level
     bitWriter.putBits(1, m_hdr->isDVRPU);  // rpu_present_flag
     bitWriter.putBits(1, m_hdr->isDVEL);   // el_present_flag
     bitWriter.putBits(1, isDVBL);          // bl_present_flag
-    bitWriter.putBits(4, compatibility);   // dv_bl_signal_compatibility_id
-    bitWriter.putBits(4, 15);              // reserved
     if (!isDVBL)
     {
         bitWriter.putBits(13, 0x1011);  // dependency_pid
         bitWriter.putBits(3, 7);        // reserved
     }
+    bitWriter.putBits(4, compatibility);   // dv_bl_signal_compatibility_id
+    bitWriter.putBits(4, 15);              // reserved
 
     bitWriter.flushBits();
     return isDVBL ? 7 : 9;

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -355,8 +355,8 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
         bitWriter.putBits(13, 0x1011);  // dependency_pid
         bitWriter.putBits(3, 7);        // reserved
     }
-    bitWriter.putBits(4, compatibility);   // dv_bl_signal_compatibility_id
-    bitWriter.putBits(4, 15);              // reserved
+    bitWriter.putBits(4, compatibility);  // dv_bl_signal_compatibility_id
+    bitWriter.putBits(4, 15);             // reserved
 
     bitWriter.flushBits();
     return isDVBL ? 7 : 9;


### PR DESCRIPTION
Commit #351 corrected the Mediainfo "8 compatible" to "Blu-ray compatible" info, however the Blu-ray players (eg Sony x700) do not detect anymore Dolby Vision after the change:
see https://forum.doom9.net/showthread.php?p=1924124#post1924124

So this patch reverts DV version to previous v1 -we will have to live with the Mediainfo "8 compatible" info until we can have more info on the v2 descriptor structure and players compatibility...