### PR TITLE
Use the native MacOS build as the nightly build uploaded to Bintray

### DIFF
--- a/.github/workflows/mac_native.yml
+++ b/.github/workflows/mac_native.yml
@@ -24,5 +24,5 @@ jobs:
     - uses: actions/upload-artifact@master
       with:
          name: tsMuxer
-         path: build/bin/mac.tar.bz2
+         path: build/bin/mac.zip
       name: upload-artefact

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -36,9 +36,6 @@ jobs:
     - run: ./rebuild_mxe32_with_gui_docker.sh
       name: build-for-win32
       
-    - run: ./rebuild_osxcross_with_gui_docker.sh
-      name: build-for-mac
-      
     - run: ./bintray_nightly_upload.sh
       name: upload-to-bintray-nightly
       env:

--- a/.github/workflows/nightly-mac-native.yml
+++ b/.github/workflows/nightly-mac-native.yml
@@ -1,0 +1,32 @@
+name: Nightly native Mac build
+
+on:
+  schedule:
+    - cron:  '1 15 * * *'
+
+jobs:
+  build-mac-native:
+
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@master
+      name: checkout
+      
+    - run: ./bintray_nightly_check.sh
+      name: nightly-check
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+      
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      
+    - run: ./build_macos_native.sh
+      name: build-for-mac
+    
+    - run: ./bintray_nightly_upload.sh ./build/bin/mac.zip mac
+      name: upload-bintray-mac-build
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
     - uses: actions/checkout@master
       name: checkout
+    
+    - run: ./bintray_nightly_check.sh
+      name: nightly-check
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
       
     - run: rm -f bin/.gitkeep
       name: clean-bin-folder

--- a/bintray_nightly_check.sh
+++ b/bintray_nightly_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Checks if the commit hash of the current newest nightly build on
+# Bintray is the same as the current HEAD, in which case returns a
+# nonzero exit code. Otherwise, creates a new "version" in the Bintray
+# repostiory.
+
+# This script should be used as the entry point of "build nightly"
+# actions in order to prevent unnecessarily triggering builds if nothing
+# has changed.
+
+# BINTRAY_USER and BINTRAY_API_KEY must be present in the environment.
+
+BINTRAY_REPO=tsMuxer
+PCK_NAME=tsMuxerGUI-Nightly
+repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/commit.txt)
+local_commit=$(git rev-parse HEAD)
+version_date=$(date +%Y-%m-%d--%H-%M-%S)
+
+if [[ $repo_commit == $local_commit ]]; then
+  echo "latest nightly build already in bintray!"
+  exit 1
+fi
+
+# create a new version with the timestamp
+version_data='{ "name": "'
+version_data+=$version_date
+version_data+='", "desc": "tsMuxer CLI and GUI binaries built on '
+version_data+=$version_date
+version_data+='"}'
+echo "$version_data"
+
+version_created=$(curl -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --write-out %{http_code} --silent --output /dev/null --request POST --data "$version_data" https://api.bintray.com/packages/$BINTRAY_USER/$BINTRAY_REPO/$PCK_NAME/versions)
+if [[ $version_created -eq 201 ]]; then
+  echo "version $version_date has been created!"
+  exit 0
+else
+  echo "error creating version $version_date!"
+  exit 2
+fi

--- a/bintray_nightly_check.sh
+++ b/bintray_nightly_check.sh
@@ -2,8 +2,8 @@
 
 # Checks if the commit hash of the current newest nightly build on
 # Bintray is the same as the current HEAD, in which case returns a
-# nonzero exit code. Otherwise, creates a new "version" in the Bintray
-# repostiory.
+# nonzero exit code. Otherwise, tries to create a new "version" in the
+# Bintray repository.
 
 # This script should be used as the entry point of "build nightly"
 # actions in order to prevent unnecessarily triggering builds if nothing
@@ -15,7 +15,7 @@ BINTRAY_REPO=tsMuxer
 PCK_NAME=tsMuxerGUI-Nightly
 repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/commit.txt)
 local_commit=$(git rev-parse HEAD)
-version_date=$(date +%Y-%m-%d--%H-%M-%S)
+version_date=$(date +%Y-%m-%d)
 
 if [[ $repo_commit == $local_commit ]]; then
   echo "latest nightly build already in bintray!"
@@ -33,8 +33,8 @@ echo "$version_data"
 version_created=$(curl -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --write-out %{http_code} --silent --output /dev/null --request POST --data "$version_data" https://api.bintray.com/packages/$BINTRAY_USER/$BINTRAY_REPO/$PCK_NAME/versions)
 if [[ $version_created -eq 201 ]]; then
   echo "version $version_date has been created!"
-  exit 0
 else
-  echo "error creating version $version_date!"
-  exit 2
+  echo "error creating version $version_date : server returned $version_created"
 fi
+
+exit 0 # don't return an error in case the version already exists

--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -18,7 +18,7 @@ upload_to_bintray() {
 
 # upload the ZIP files to the version we just created on bintray
 echo "uploading files..."
-for i in w32 w64 lnx mac; do
+for i in w32 w64 lnx; do
   upload_to_bintray "$i"
 done
 echo "files uploaded!"

--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -1,52 +1,39 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # BINTRAY_USER
 # BINTRAY_API_KEY
+
 BINTRAY_REPO=tsMuxer
 PCK_NAME=tsMuxerGUI-Nightly
-repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/commit.txt)
-local_commit=$(git rev-parse HEAD)
 version_date=$(date +%Y-%m-%d--%H-%M-%S)
 
-if [ "$repo_commit" = "$local_commit" ] ; then
-  echo "latest nightly build already in bintray!"
-  exit 1
-else
-  # create a new version with the timestamp
-  version_data='{ "name": "'
-  version_data+=$version_date
-  version_data+='", "desc": "tsMuxer CLI and GUI binaries built on '
-  version_data+=$version_date
-  version_data+='"}'
-  echo $version_data
-  version_created=$(curl -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --write-out %{http_code} --silent --output /dev/null --request POST --data "$version_data" https://api.bintray.com/packages/$BINTRAY_USER/$BINTRAY_REPO/$PCK_NAME/versions)
-  if [ $version_created -eq 201 ] ; then
-    echo "version $version_date has been created!"
-    
-    # upload the ZIP files to the version we just created on bintray
-    echo "uploading files..."
-    curl -T ./bin/mac.zip -u$BINTRAY_USER:$BINTRAY_API_KEY -H "X-Bintray-Package:$PCK_NAME" -H "X-Bintray-Version:$version_date"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/mac-nightly-$version_date.zip
-    curl -T ./bin/w32.zip -u$BINTRAY_USER:$BINTRAY_API_KEY -H "X-Bintray-Package:$PCK_NAME" -H "X-Bintray-Version:$version_date"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/w32-nightly-$version_date.zip
-    curl -T ./bin/w64.zip -u$BINTRAY_USER:$BINTRAY_API_KEY -H "X-Bintray-Package:$PCK_NAME" -H "X-Bintray-Version:$version_date"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/w64-nightly-$version_date.zip
-    curl -T ./bin/lnx.zip -u$BINTRAY_USER:$BINTRAY_API_KEY -H "X-Bintray-Package:$PCK_NAME" -H "X-Bintray-Version:$version_date"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/lnx-nightly-$version_date.zip
-    echo "files uploaded!"
-    
-    # update the latest commit on bintray
-    echo "updating commit record on bintray..."
-    echo $local_commit > commit.txt
-    curl -T commit.txt -u$BINTRAY_USER:$BINTRAY_API_KEY -H "X-Bintray-Package:commit" -H "X-Bintray-Version:latest"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/commit.txt
-    rm -f commit.txt
-    echo "commit record updated!"
-  else
-    echo "error creating version $version_date !"
-    exit 2
-  fi
-  # try to trigger a new build in OBS
-  obs_trigger=$(curl --user $OBS_USER:$OBS_SECRET --write-out %{http_code} --silent --output /dev/null -H 'Accept-Encoding: identity' -H 'User-agent: osc/0.164.2' -H 'Content-type: application/x-www-form-urlencoded' -X POST https://api.opensuse.org/build/home:justdan96?cmd=rebuild&package=tsMuxer)
-  echo $obs_trigger
-  #if [ $obs_trigger -eq 200 ] ; then
-  #  echo "build has been triggered in OBS!"
-  #else
-  #  echo "error triggering build in OBS!"
-  #  exit 3
-  #fi
-fi
+upload_to_bintray() {
+  local buildname=$1
+  curl -T "./bin/${buildname}.zip" "-u$BINTRAY_USER:$BINTRAY_API_KEY" \
+    -H "X-Bintray-Package:$PCK_NAME" \
+    -H "X-Bintray-Version:$version_date" \
+    -H "X-Bintray-Publish:1" \
+    -H "X-Bintray-Override:1" \
+    "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/${buildname}-nightly-$version_date.zip"
+}
+
+# upload the ZIP files to the version we just created on bintray
+echo "uploading files..."
+for i in w32 w64 lnx mac; do
+  upload_to_bintray "$i"
+done
+echo "files uploaded!"
+
+# update the latest commit on bintray
+echo "updating commit record on bintray..."
+git rev-parse HEAD | curl -T - "-u$BINTRAY_USER:$BINTRAY_API_KEY" -H "X-Bintray-Package:commit" -H "X-Bintray-Version:latest"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/commit.txt"0
+echo "commit record updated!"
+
+# try to trigger a new build in OBS
+obs_trigger=$(curl --user $OBS_USER:$OBS_SECRET --write-out %{http_code} --silent --output /dev/null -H 'Accept-Encoding: identity' -H 'User-agent: osc/0.164.2' -H 'Content-type: application/x-www-form-urlencoded' -X POST https://api.opensuse.org/build/home:justdan96?cmd=rebuild&package=tsMuxer)
+echo $obs_trigger
+#if [ $obs_trigger -eq 200 ] ; then
+#  echo "build has been triggered in OBS!"
+#else
+#  echo "error triggering build in OBS!"
+#  exit 3
+#fi

--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -4,11 +4,12 @@
 
 BINTRAY_REPO=tsMuxer
 PCK_NAME=tsMuxerGUI-Nightly
-version_date=$(date +%Y-%m-%d--%H-%M-%S)
+version_date=$(date +%Y-%m-%d)
 
 upload_to_bintray() {
-  local buildname=$1
-  curl -T "./bin/${buildname}.zip" "-u$BINTRAY_USER:$BINTRAY_API_KEY" \
+  local localpath="$1"
+  local buildname="$2"
+  curl -T "$localpath" "-u$BINTRAY_USER:$BINTRAY_API_KEY" \
     -H "X-Bintray-Package:$PCK_NAME" \
     -H "X-Bintray-Version:$version_date" \
     -H "X-Bintray-Publish:1" \
@@ -16,10 +17,16 @@ upload_to_bintray() {
     "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/${buildname}-nightly-$version_date.zip"
 }
 
+# when triggered with arguments, just upload the given file and exit.
+if [[ "$@" ]]; then
+  upload_to_bintray "$@"
+  exit 0
+fi
+
 # upload the ZIP files to the version we just created on bintray
 echo "uploading files..."
 for i in w32 w64 lnx; do
-  upload_to_bintray "$i"
+  upload_to_bintray "./bin/${buildname}.zip" "$i"
 done
 echo "files uploaded!"
 

--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -25,8 +25,8 @@ fi
 
 # upload the ZIP files to the version we just created on bintray
 echo "uploading files..."
-for i in w32 w64 lnx; do
-  upload_to_bintray "./bin/${buildname}.zip" "$i"
+for buildname in w32 w64 lnx; do
+  upload_to_bintray "./bin/${buildname}.zip" "$buildname"
 done
 echo "files uploaded!"
 

--- a/build_macos_native.sh
+++ b/build_macos_native.sh
@@ -31,6 +31,6 @@ pushd bin
 mv ../tsMuxer/tsmuxer tsMuxeR
 mv ../tsMuxerGUI/tsMuxerGUI.app .
 cp tsMuxeR tsMuxerGUI.app/Contents/MacOS/
-BZIP2=-9 tar cjf mac.tar.bz2 tsMuxeR tsMuxerGUI.app
+zip -9 -r mac.zip tsMuxeR tsMuxerGUI.app
 popd
 popd

--- a/build_macos_native.sh
+++ b/build_macos_native.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-export MACOSX_DEPLOYMENT_TARGET=10.10
+export MACOSX_DEPLOYMENT_TARGET=10.13
 
 brew install pkg-config
 brew install freetype


### PR DESCRIPTION
In line with #373, it doesn't really make sense to keep the osxcross build as the one that's available on Bintray.

This PR switches to using the MacOS native build as the Bintray nightly build for the Mac platform.