### PR TITLE
Prefer the currently entered file name when opening the browse dialog

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -2416,13 +2416,9 @@ void TsMuxerWindow::saveFileDialog()
     }
     else
     {
-        QString path = getOutputDir();
-        if (path.isEmpty())
-        {
-            QString fileName = unquoteStr(ui->outFileName->text());
-            path = QFileInfo(fileName).absolutePath();
-        }
-        QString fileName = QDir::toNativeSeparators(
+        auto fileName = unquoteStr(ui->outFileName->text());
+        auto path = fileName.isEmpty() ? getOutputDir() : QFileInfo(fileName).absoluteFilePath();
+        fileName = QDir::toNativeSeparators(
             QFileDialog::getSaveFileName(this, tr("Select file for muxing"), path, mSaveDialogFilter));
         if (!fileName.isEmpty())
         {


### PR DESCRIPTION
Previous versions used the "last output directory" when opening the "Browse"
dialog in the main window, using the current "File name" only if the "last
output directory " is not yet defined. This change reverses this, which means
that the folder of the path currently entered as the "File name" will be used
as the folder to display. The file name will be carried over to the dialog.

Fixes #372.