### PR TITLE
Fix signed/unsigned mismatch warning messages

### DIFF
--- a/tsMuxer/aacStreamReader.cpp
+++ b/tsMuxer/aacStreamReader.cpp
@@ -9,7 +9,7 @@
 #include "vodCoreException.h"
 #include "vod_common.h"
 
-unsigned AACStreamReader::getHeaderLen() { return AAC_HEADER_LEN; }
+int AACStreamReader::getHeaderLen() { return AAC_HEADER_LEN; }
 
 const std::string AACStreamReader::getStreamInfo()
 {

--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -15,7 +15,7 @@ class AACStreamReader : public SimplePacketizerReader, public AACCodec
     int getChannels() override { return m_channels; }
 
    protected:
-    unsigned getHeaderLen() override;
+    int getHeaderLen() override;
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
     uint8_t* findFrame(uint8_t* buff, uint8_t* end) override { return findAacFrame(buff, end); }
     double getFrameDurationNano() override { return (INTERNAL_PTS_FREQ * m_samples) / (double)m_sample_rate; }

--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -119,8 +119,8 @@ int AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
     m_bsid = id;
     if (m_bsid > 10)  // bsid = 16 => EAC3
     {
-        unsigned int numblkscod, strmtyp, substreamid, number_of_blocks_per_syncframe;
-        uint8_t acmod, lfeon, bsmod, fscod, dsurmod, pgmscle, extpgmscle, mixdef, paninfoe;
+        int numblkscod, strmtyp, substreamid, number_of_blocks_per_syncframe;
+        int acmod, lfeon, bsmod, fscod, dsurmod, pgmscle, extpgmscle, mixdef, paninfoe;
         bsmod = fscod = dsurmod = pgmscle = extpgmscle = mixdef = paninfoe = 0;
 
         strmtyp = gbc.getBits(2);

--- a/tsMuxer/ac3Codec.h
+++ b/tsMuxer/ac3Codec.h
@@ -67,7 +67,7 @@ class AC3Codec
         m_dsurmod = 0;
         m_mixinfoexists = false;
     };
-    unsigned getHeaderLen() { return AC3_HEADER_SIZE; }
+    int getHeaderLen() { return AC3_HEADER_SIZE; }
     inline bool isEAC3() { return m_bsid > 10; }
     inline bool isAC3() { return m_bsidBase > 0; }
     void setDownconvertToAC3(bool value) { m_downconvertToAC3 = value; }

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -40,7 +40,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
     bool isIFrame(AVPacket* packet) override { return isPriorityData(packet); }
 
    protected:
-    unsigned getHeaderLen() override { return AC3Codec::getHeaderLen(); }
+    int getHeaderLen() override { return AC3Codec::getHeaderLen(); }
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override
     {
         skipBeforeBytes = 0;

--- a/tsMuxer/blurayHelper.cpp
+++ b/tsMuxer/blurayHelper.cpp
@@ -449,11 +449,11 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
         CLPIStreamInfo streamInfo(itr->second);
         clpiParser.m_streamInfo.insert(make_pair(streamInfo.streamPID, streamInfo));
     }
-    vector<int64_t> packetCount = muxer->getMuxedPacketCnt();
+    vector<uint64_t> packetCount = muxer->getMuxedPacketCnt();
     vector<int64_t> firstPts = muxer->getFirstPts();
     vector<int64_t> lastPts = muxer->getLastPts();
 
-    for (unsigned i = 0; i < muxer->splitFileCnt(); i++)
+    for (size_t i = 0; i < muxer->splitFileCnt(); i++)
     {
         if (muxer->isInterleaveMode())
             clpiParser.interleaveInfo = muxer->getInterleaveInfo(i);
@@ -556,7 +556,7 @@ bool BlurayHelper::createMPLSFile(TSMuxer* mainMuxer, TSMuxer* subMuxer, int aut
     }
     else
     {
-        for (int i = 0; i < customChapters.size(); i++)
+        for (size_t i = 0; i < customChapters.size(); i++)
         {
             int64_t mark = customChapters[i] * 45000.0;
             if (mark >= 0 && mark <= (mplsParser.OUT_time - mplsParser.IN_time))

--- a/tsMuxer/blurayHelper.cpp
+++ b/tsMuxer/blurayHelper.cpp
@@ -556,7 +556,7 @@ bool BlurayHelper::createMPLSFile(TSMuxer* mainMuxer, TSMuxer* subMuxer, int aut
     }
     else
     {
-        for (auto &i : customChapters)
+        for (auto& i : customChapters)
         {
             int64_t mark = i * 45000.0;
             if (mark >= 0 && mark <= (mplsParser.OUT_time - mplsParser.IN_time))

--- a/tsMuxer/blurayHelper.cpp
+++ b/tsMuxer/blurayHelper.cpp
@@ -556,9 +556,9 @@ bool BlurayHelper::createMPLSFile(TSMuxer* mainMuxer, TSMuxer* subMuxer, int aut
     }
     else
     {
-        for (size_t i = 0; i < customChapters.size(); i++)
+        for (auto &i : customChapters)
         {
-            int64_t mark = customChapters[i] * 45000.0;
+            int64_t mark = i * 45000.0;
             if (mark >= 0 && mark <= (mplsParser.OUT_time - mplsParser.IN_time))
                 mplsParser.m_marks.push_back(PlayListMark(-1, mark + mplsParser.IN_time));
         }

--- a/tsMuxer/bufferedFileReader.h
+++ b/tsMuxer/bufferedFileReader.h
@@ -41,7 +41,7 @@ class FileListIterator : public FileNameIterator
 
    private:
     std::vector<std::string> m_files;
-    int m_index;
+    size_t m_index;
 };
 
 struct FileReaderData : public ReaderData

--- a/tsMuxer/bufferedReader.cpp
+++ b/tsMuxer/bufferedReader.cpp
@@ -209,7 +209,7 @@ void BufferedReader::thread_main()
                 uint8_t* buffer = data->m_nextBlock[data->m_bufferIndex] + data->m_readOffset;
                 if (!data->m_deleted)
                 {
-                    int bytesReaded = data->readBlock(buffer, data->m_blockSize);
+                    uint32_t bytesReaded = data->readBlock(buffer, data->m_blockSize);
                     if (data->m_lastBlock)
                     {
                         data->m_lastBlock = false;

--- a/tsMuxer/bufferedReaderManager.cpp
+++ b/tsMuxer/bufferedReaderManager.cpp
@@ -27,7 +27,14 @@ void BufferedReaderManager::init(uint32_t blockSize, uint32_t allocSize, uint32_
     m_prereadThreshold = prereadThreshold > 0 ? prereadThreshold : m_blockSize / 2;
 }
 
-BufferedReaderManager::~BufferedReaderManager() { std::vector<BufferedReader*>().swap(m_fileReaders); }
+BufferedReaderManager::~BufferedReaderManager()
+{
+    for (size_t i = 0; i < m_fileReaders.size(); i++)
+    {
+        delete m_fileReaders[i];  // need to define destruction order first. This object MUST be deleted after
+                                  // MCVodStreamer
+    }
+}
 
 AbstractReader* BufferedReaderManager::getReader(const char* streamName)
 {

--- a/tsMuxer/bufferedReaderManager.cpp
+++ b/tsMuxer/bufferedReaderManager.cpp
@@ -29,11 +29,7 @@ void BufferedReaderManager::init(uint32_t blockSize, uint32_t allocSize, uint32_
 
 BufferedReaderManager::~BufferedReaderManager()
 {
-    for (size_t i = 0; i < m_fileReaders.size(); i++)
-    {
-        delete m_fileReaders[i];  // need to define destruction order first. This object MUST be deleted after
-                                  // MCVodStreamer
-    }
+    m_fileReaders.clear();
 }
 
 AbstractReader* BufferedReaderManager::getReader(const char* streamName)

--- a/tsMuxer/bufferedReaderManager.cpp
+++ b/tsMuxer/bufferedReaderManager.cpp
@@ -27,10 +27,7 @@ void BufferedReaderManager::init(uint32_t blockSize, uint32_t allocSize, uint32_
     m_prereadThreshold = prereadThreshold > 0 ? prereadThreshold : m_blockSize / 2;
 }
 
-BufferedReaderManager::~BufferedReaderManager()
-{
-    m_fileReaders.clear();
-}
+BufferedReaderManager::~BufferedReaderManager() { m_fileReaders.clear(); }
 
 AbstractReader* BufferedReaderManager::getReader(const char* streamName)
 {

--- a/tsMuxer/bufferedReaderManager.cpp
+++ b/tsMuxer/bufferedReaderManager.cpp
@@ -27,7 +27,7 @@ void BufferedReaderManager::init(uint32_t blockSize, uint32_t allocSize, uint32_
     m_prereadThreshold = prereadThreshold > 0 ? prereadThreshold : m_blockSize / 2;
 }
 
-BufferedReaderManager::~BufferedReaderManager() { m_fileReaders.clear(); }
+BufferedReaderManager::~BufferedReaderManager() { std::vector<BufferedReader*>().swap(m_fileReaders); }
 
 AbstractReader* BufferedReaderManager::getReader(const char* streamName)
 {

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -57,7 +57,7 @@ class DTSStreamReader : public SimplePacketizerReader
     void setTestMode(bool value) override { m_testMode = value; }
 
    protected:
-    unsigned getHeaderLen() override { return DTS_HEADER_SIZE; };
+    int getHeaderLen() override { return DTS_HEADER_SIZE; };
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
     uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
     double getFrameDurationNano() override;
@@ -96,7 +96,7 @@ class DTSStreamReader : public SimplePacketizerReader
 
     // unsigned int i_audio_mode;
     unsigned int nblks;
-    unsigned int i_frame_size;
+    int i_frame_size;
     unsigned int pi_audio_mode;
     unsigned int pi_sample_rate;
     unsigned int hd_pi_sample_rate;

--- a/tsMuxer/dvbSubStreamReader.cpp
+++ b/tsMuxer/dvbSubStreamReader.cpp
@@ -38,8 +38,8 @@ int DVBSubStreamReader::intDecodeFrame(uint8_t* buff, uint8_t* end)
 {
     return 0;  // not working yet
 
-    unsigned pos, cmd, x1, y1, x2, y2, offset1, offset2, next_cmd_pos;
-    unsigned cmd_pos, is_8bit = 0;
+    int pos, cmd, x1, y1, x2, y2, offset1, offset2, next_cmd_pos;
+    int cmd_pos, is_8bit = 0;
     const uint8_t* yuv_palette = 0;
     uint8_t colormap[4], alpha[256];
     int date;

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -12,7 +12,7 @@ class DVBSubStreamReader : public SimplePacketizerReader
     int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
 
    protected:
-    unsigned getHeaderLen() override { return 10; }
+    int getHeaderLen() override { return 10; }
     uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
     double getFrameDurationNano() override;

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -243,7 +243,7 @@ int H264StreamReader::writeSEIMessage(uint8_t* dstBuffer, uint8_t* dstEnd, SEIUn
         static const uint8_t DEFAULT_MVC_SEI_HEADER[] = {192, 16};
         if (!m_lastSeiMvcHeader.empty())
         {
-            for (int i = 0; i < m_lastSeiMvcHeader.size(); ++i) writer.putBits(8, m_lastSeiMvcHeader[i]);
+            for (size_t i = 0; i < m_lastSeiMvcHeader.size(); ++i) writer.putBits(8, m_lastSeiMvcHeader[i]);
         }
         else
         {

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -243,7 +243,7 @@ int H264StreamReader::writeSEIMessage(uint8_t* dstBuffer, uint8_t* dstEnd, SEIUn
         static const uint8_t DEFAULT_MVC_SEI_HEADER[] = {192, 16};
         if (!m_lastSeiMvcHeader.empty())
         {
-            for (auto &i : m_lastSeiMvcHeader) writer.putBits(8, i);
+            for (auto& i : m_lastSeiMvcHeader) writer.putBits(8, i);
         }
         else
         {
@@ -946,7 +946,7 @@ int H264StreamReader::processSEI(uint8_t* buff)
 
         bool timingSEI = false;
         bool nonTimingSEI = false;
-        for (auto &msg : lastSEI.m_processedMessages)
+        for (auto& msg : lastSEI.m_processedMessages)
         {
             if (msg == SEI_MSG_BUFFERING_PERIOD)
             {

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -243,7 +243,7 @@ int H264StreamReader::writeSEIMessage(uint8_t* dstBuffer, uint8_t* dstEnd, SEIUn
         static const uint8_t DEFAULT_MVC_SEI_HEADER[] = {192, 16};
         if (!m_lastSeiMvcHeader.empty())
         {
-            for (size_t i = 0; i < m_lastSeiMvcHeader.size(); ++i) writer.putBits(8, m_lastSeiMvcHeader[i]);
+            for (auto &i : m_lastSeiMvcHeader) writer.putBits(8, i);
         }
         else
         {
@@ -946,7 +946,7 @@ int H264StreamReader::processSEI(uint8_t* buff)
 
         bool timingSEI = false;
         bool nonTimingSEI = false;
-        for (auto msg : lastSEI.m_processedMessages)
+        for (auto &msg : lastSEI.m_processedMessages)
         {
             if (msg == SEI_MSG_BUFFERING_PERIOD)
             {

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -471,7 +471,7 @@ int HevcSpsUnit::vui_parameters()
 int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
 {
     uint8_t rps_predict = 0;
-    int delta_poc;
+    unsigned delta_poc;
     int k0 = 0;
     int k1 = 0;
     int k = 0;
@@ -524,7 +524,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
         // sort in increasing order (smallest first)
         if (rps->num_delta_pocs != 0)
         {
-            int used, tmp;
+            unsigned used, tmp;
             for (int i = 1; i < rps->num_delta_pocs; i++)
             {
                 delta_poc = rps->delta_poc[i];

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -216,7 +216,7 @@ int HevcVpsUnit::deserialize()
         unsigned vps_num_layer_sets_minus1 = extractUEGolombCode();
         if (vps_num_layer_sets_minus1 > 1023)
             return 1;
-        for (int i = 1; i <= vps_num_layer_sets_minus1; i++)
+        for (size_t i = 1; i <= vps_num_layer_sets_minus1; i++)
         {
             for (int j = 0; j <= vps_max_layer_id; j++) m_reader.skipBit();  // layer_id_included_flag[ i ][ j ] u(1)
         }
@@ -351,7 +351,7 @@ int HevcSpsUnit::hrd_parameters(bool commonInfPresentFlag, int maxNumSubLayersMi
 
 int HevcSpsUnit::sub_layer_hrd_parameters(int subLayerId)
 {
-    for (int i = 0; i <= cpb_cnt_minus1[subLayerId]; i++)
+    for (size_t i = 0; i <= cpb_cnt_minus1[subLayerId]; i++)
     {
         unsigned bit_rate_value_minus1 = extractUEGolombCode();
         if (bit_rate_value_minus1 == 0xffffffff)
@@ -471,11 +471,10 @@ int HevcSpsUnit::vui_parameters()
 int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
 {
     uint8_t rps_predict = 0;
-    unsigned delta_poc;
+    int delta_poc;
     int k0 = 0;
     int k1 = 0;
     int k = 0;
-    int i;
 
     if (stRpsIdx != 0)
         rps_predict = m_reader.getBit();
@@ -498,7 +497,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
         if (abs_delta_rps > 0x8000)
             return 1;
         delta_rps = (1 - (delta_rps_sign << 1)) * abs_delta_rps;
-        for (i = 0; i <= rps_ridx->num_delta_pocs; i++)
+        for (int i = 0; i <= rps_ridx->num_delta_pocs; i++)
         {
             int used = rps->used[k] = m_reader.getBit();
 
@@ -526,7 +525,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
         if (rps->num_delta_pocs != 0)
         {
             int used, tmp;
-            for (i = 1; i < rps->num_delta_pocs; i++)
+            for (int i = 1; i < rps->num_delta_pocs; i++)
             {
                 delta_poc = rps->delta_poc[i];
                 used = rps->used[i];
@@ -548,7 +547,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
             int used;
             k = rps->num_negative_pics - 1;
             // flip the negative values to largest first
-            for (i = 0; i < (rps->num_negative_pics >> 1); i++)
+            for (size_t i = 0; i < (rps->num_negative_pics >> 1); i++)
             {
                 delta_poc = rps->delta_poc[i];
                 used = rps->used[i];
@@ -570,7 +569,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
         if (rps->num_delta_pocs)
         {
             prev = 0;
-            for (i = 0; i < rps->num_negative_pics; i++)
+            for (size_t i = 0; i < rps->num_negative_pics; i++)
             {
                 delta_poc = extractUEGolombCode() + 1;
                 if (delta_poc > 0x8000)
@@ -580,7 +579,7 @@ int HevcSpsUnit::short_term_ref_pic_set(int stRpsIdx)
                 rps->used[i] = m_reader.getBit();
             }
             prev = 0;
-            for (i = 0; i < nb_positive_pics; i++)
+            for (size_t i = 0; i < nb_positive_pics; i++)
             {
                 delta_poc = extractUEGolombCode() + 1;
                 if (delta_poc > 0x8000)
@@ -866,7 +865,7 @@ int HevcSpsUnit::deserialize()
         */
         st_rps.resize(num_short_term_ref_pic_sets);
 
-        for (int i = 0; i < num_short_term_ref_pic_sets; i++)
+        for (size_t i = 0; i < num_short_term_ref_pic_sets; i++)
             if (short_term_ref_pic_set(i) != 0)
                 return 1;
         bool long_term_ref_pics_present_flag = m_reader.getBit();
@@ -875,7 +874,7 @@ int HevcSpsUnit::deserialize()
             unsigned num_long_term_ref_pics_sps = extractUEGolombCode();
             if (num_long_term_ref_pics_sps > 32)
                 return 1;
-            for (int i = 0; i < num_long_term_ref_pics_sps; i++)
+            for (size_t i = 0; i < num_long_term_ref_pics_sps; i++)
             {
                 m_reader.skipBits(log2_max_pic_order_cnt_lsb);  // lt_ref_pic_poc_lsb_sps[ i ] u(v)
                 m_reader.skipBit();                             // used_by_curr_pic_lt_sps_flag[ i ] u(1)

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -131,7 +131,7 @@ struct HevcSpsUnit : public HevcUnitWithProfile
 
    public:
     unsigned vps_id;
-    unsigned max_sub_layers;
+    int max_sub_layers;
     unsigned sps_id;
     unsigned chromaFormat;
     bool separate_colour_plane_flag;
@@ -212,7 +212,7 @@ struct HevcSliceHeader : public HevcUnit
     bool first_slice;
     unsigned pps_id;
     unsigned slice_type;
-    unsigned pic_order_cnt_lsb;
+    int pic_order_cnt_lsb;
 };
 
 std::vector<std::vector<uint8_t>> hevc_extract_priv_data(const uint8_t* buff, int size, int* nal_size);

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -66,7 +66,7 @@ void writeDescriptorTag(uint8_t* buffer, uint16_t tag, uint32_t tagLocation)
 std::string toIsoSeparator(const std::string& path)
 {
     std::string result = path;
-    for (auto &i : result)
+    for (auto& i : result)
     {
         if (i == '\\')
             i = '/';
@@ -422,8 +422,8 @@ void FileEntryInfo::serializeDir()
     writer.closeDescriptorTag();
 
     // ------------ 2 (entries) ---------------
-    for (auto &i : m_files) writeEntity(writer, i);
-    for (auto &i : m_subDirs) writeEntity(writer, i);
+    for (auto& i : m_files) writeEntity(writer, i);
+    for (auto& i : m_subDirs) writeEntity(writer, i);
     assert(writer.size() < SECTOR_SIZE);  // not supported
 
     m_owner->writeExtentFileDescriptor(m_fileType, writer.size(), m_sectorNum + 1, m_subDirs.size() + 1);
@@ -518,7 +518,7 @@ void FileEntryInfo::setSubMode(bool value) { m_subMode = value; }
 
 FileEntryInfo* FileEntryInfo::subDirByName(const std::string& name) const
 {
-    for (auto &i : m_subDirs)
+    for (auto& i : m_subDirs)
     {
         if (i->m_name == name)
             return i;
@@ -528,7 +528,7 @@ FileEntryInfo* FileEntryInfo::subDirByName(const std::string& name) const
 
 FileEntryInfo* FileEntryInfo::fileByName(const std::string& name) const
 {
-    for (auto &i : m_files)
+    for (auto& i : m_files)
     {
         if (i->m_name == name)
             return i;
@@ -932,8 +932,8 @@ void IsoWriter::sectorSeek(Partition partition, int pos)
 void IsoWriter::writeEntity(FileEntryInfo* dir)
 {
     dir->serialize();
-    for (auto &i : dir->m_files) writeEntity(i);
-    for (auto &i : dir->m_subDirs) writeEntity(i);
+    for (auto& i : dir->m_files) writeEntity(i);
+    for (auto& i : dir->m_subDirs) writeEntity(i);
 }
 
 int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
@@ -947,8 +947,8 @@ int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
     if (entity->m_objectId)
         m_mappingEntries[entity->m_objectId] = MappingEntry(entity->m_parent->m_sectorNum, entity->m_sectorNum);
 
-    for (auto &i : entity->m_files) sectorNum = allocateEntity(i, sectorNum);
-    for (auto &i : entity->m_subDirs) sectorNum = allocateEntity(i, sectorNum);
+    for (auto& i : entity->m_files) sectorNum = allocateEntity(i, sectorNum);
+    for (auto& i : entity->m_subDirs) sectorNum = allocateEntity(i, sectorNum);
     return sectorNum;
 }
 
@@ -1401,7 +1401,7 @@ void IsoWriter::setLayerBreakPoint(int lbn) { m_layerBreakPoint = lbn; }
 
 IsoHeaderData IsoHeaderData::normal()
 {
-    return IsoHeaderData{"*tsMuxeR ", std::string("*tsMuxeR ") + int32ToHex(random32()), time(0),
+    return IsoHeaderData{"*tsMuxeR " TSMUXER_VERSION, std::string("*tsMuxeR ") + int32ToHex(random32()), time(0),
                          random32()};
 }
 

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -66,7 +66,7 @@ void writeDescriptorTag(uint8_t* buffer, uint16_t tag, uint32_t tagLocation)
 std::string toIsoSeparator(const std::string& path)
 {
     std::string result = path;
-    for (int i = 0; i < result.size(); ++i)
+    for (size_t i = 0; i < result.size(); ++i)
     {
         if (result[i] == '\\')
             result[i] = '/';
@@ -136,7 +136,7 @@ std::vector<std::uint8_t> serializeDString(const std::string& str, int fieldLen)
     auto& utf8Str = str;
 #endif
     using namespace convertUTF;
-    const auto maxHeaderAndContentLength = fieldLen - 1;
+    const unsigned maxHeaderAndContentLength = fieldLen - 1;
     rv.reserve(fieldLen);
     if (canUse8BitUnicode(utf8Str))
     {
@@ -333,8 +333,8 @@ bool FileEntryInfo::isFile() const { return m_fileType == FileType_File || m_fil
 FileEntryInfo::~FileEntryInfo()
 {
     delete[] m_sectorBuffer;
-    for (int i = 0; i < m_files.size(); ++i) delete m_files[i];
-    for (int i = 0; i < m_subDirs.size(); ++i) delete m_subDirs[i];
+    for (size_t i = 0; i < m_files.size(); ++i) delete m_files[i];
+    for (size_t i = 0; i < m_subDirs.size(); ++i) delete m_subDirs[i];
 }
 
 bool FileEntryInfo::setName(const std::string& name)
@@ -422,8 +422,8 @@ void FileEntryInfo::serializeDir()
     writer.closeDescriptorTag();
 
     // ------------ 2 (entries) ---------------
-    for (int i = 0; i < m_files.size(); ++i) writeEntity(writer, m_files[i]);
-    for (int i = 0; i < m_subDirs.size(); ++i) writeEntity(writer, m_subDirs[i]);
+    for (size_t i = 0; i < m_files.size(); ++i) writeEntity(writer, m_files[i]);
+    for (size_t i = 0; i < m_subDirs.size(); ++i) writeEntity(writer, m_subDirs[i]);
     assert(writer.size() < SECTOR_SIZE);  // not supported
 
     m_owner->writeExtentFileDescriptor(m_fileType, writer.size(), m_sectorNum + 1, m_subDirs.size() + 1);
@@ -518,7 +518,7 @@ void FileEntryInfo::setSubMode(bool value) { m_subMode = value; }
 
 FileEntryInfo* FileEntryInfo::subDirByName(const std::string& name) const
 {
-    for (int i = 0; i < m_subDirs.size(); ++i)
+    for (size_t i = 0; i < m_subDirs.size(); ++i)
     {
         if (m_subDirs[i]->m_name == name)
             return m_subDirs[i];
@@ -528,7 +528,7 @@ FileEntryInfo* FileEntryInfo::subDirByName(const std::string& name) const
 
 FileEntryInfo* FileEntryInfo::fileByName(const std::string& name) const
 {
-    for (int i = 0; i < m_files.size(); ++i)
+    for (size_t i = 0; i < m_files.size(); ++i)
     {
         if (m_files[i]->m_name == name)
             return m_files[i];
@@ -727,7 +727,7 @@ bool IsoWriter::createInterleavedFile(const std::string& inFile1, const std::str
         return false;
 
     assert(inEntry1->m_extents.size() == inEntry2->m_extents.size());
-    for (int i = 0; i < inEntry1->m_extents.size(); ++i)
+    for (size_t i = 0; i < inEntry1->m_extents.size(); ++i)
     {
         assert(inEntry1->m_extents[i].size % SECTOR_SIZE == 0);
         assert(inEntry2->m_extents[i].size % SECTOR_SIZE == 0);
@@ -932,8 +932,8 @@ void IsoWriter::sectorSeek(Partition partition, int pos)
 void IsoWriter::writeEntity(FileEntryInfo* dir)
 {
     dir->serialize();
-    for (int i = 0; i < dir->m_files.size(); ++i) writeEntity(dir->m_files[i]);
-    for (int i = 0; i < dir->m_subDirs.size(); ++i) writeEntity(dir->m_subDirs[i]);
+    for (size_t i = 0; i < dir->m_files.size(); ++i) writeEntity(dir->m_files[i]);
+    for (size_t i = 0; i < dir->m_subDirs.size(); ++i) writeEntity(dir->m_subDirs[i]);
 }
 
 int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
@@ -947,19 +947,19 @@ int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
     if (entity->m_objectId)
         m_mappingEntries[entity->m_objectId] = MappingEntry(entity->m_parent->m_sectorNum, entity->m_sectorNum);
 
-    for (int i = 0; i < entity->m_files.size(); ++i) sectorNum = allocateEntity(entity->m_files[i], sectorNum);
-    for (int i = 0; i < entity->m_subDirs.size(); ++i) sectorNum = allocateEntity(entity->m_subDirs[i], sectorNum);
+    for (size_t i = 0; i < entity->m_files.size(); ++i) sectorNum = allocateEntity(entity->m_files[i], sectorNum);
+    for (size_t i = 0; i < entity->m_subDirs.size(); ++i) sectorNum = allocateEntity(entity->m_subDirs[i], sectorNum);
     return sectorNum;
 }
 
-void IsoWriter::writeAllocationExtentDescriptor(ExtentList* extents, int start, int indexEnd)
+void IsoWriter::writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd)
 {
     uint32_t* buff32 = (uint32_t*)m_buffer;
     memset(m_buffer, 0, sizeof(m_buffer));
     writeDescriptorTag(m_buffer, DESC_TYPE_AllocationExtent, absoluteSectorNum());
 
     uint8_t* curPos = m_buffer + 24;
-    for (int i = start; i < indexEnd; ++i)
+    for (size_t i = start; i < indexEnd; ++i)
     {
         writeLongAD(curPos, extents->at(i).size, extents->at(i).lbnPos, 0, 0);
         curPos += 16;
@@ -1052,12 +1052,12 @@ int IsoWriter::writeExtentFileDescriptor(uint8_t fileType, uint64_t len, uint32_
     }
     else
     {
-        int indexEnd = FFMIN(MAX_EXTENTS_IN_EXTFILE, extents->size());
+        size_t indexEnd = FFMIN(MAX_EXTENTS_IN_EXTFILE, extents->size());
         if (extents->size() - indexEnd == 1)
             indexEnd++;  // continue record may be replaced by payload data
         buff32[212 / 4] = 0x10 * indexEnd;
         uint8_t* curPos = m_buffer + 216;
-        for (int i = 0; i < indexEnd; ++i)
+        for (size_t i = 0; i < indexEnd; ++i)
         {
             writeLongAD(curPos, extents->at(i).size, extents->at(i).lbnPos, 0, 0);
             curPos += 16;
@@ -1072,7 +1072,7 @@ int IsoWriter::writeExtentFileDescriptor(uint8_t fileType, uint64_t len, uint32_
         m_file.write(m_buffer, SECTOR_SIZE);
         sectorsWrited++;
 
-        int indexStart = indexEnd;
+        size_t indexStart = indexEnd;
         while (indexStart < extents->size())
         {
             indexEnd = FFMIN(indexStart + MAX_EXTENTS_IN_EXTCONT, extents->size());

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -333,8 +333,8 @@ bool FileEntryInfo::isFile() const { return m_fileType == FileType_File || m_fil
 FileEntryInfo::~FileEntryInfo()
 {
     delete[] m_sectorBuffer;
-    std::vector<FileEntryInfo*>().swap(m_files);
-    std::vector<FileEntryInfo*>().swap(m_subDirs);
+    for (int i = 0; i < m_files.size(); ++i) delete m_files[i];
+    for (int i = 0; i < m_subDirs.size(); ++i) delete m_subDirs[i];
 }
 
 bool FileEntryInfo::setName(const std::string& name)

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -66,10 +66,10 @@ void writeDescriptorTag(uint8_t* buffer, uint16_t tag, uint32_t tagLocation)
 std::string toIsoSeparator(const std::string& path)
 {
     std::string result = path;
-    for (size_t i = 0; i < result.size(); ++i)
+    for (auto &i : result)
     {
-        if (result[i] == '\\')
-            result[i] = '/';
+        if (i == '\\')
+            i = '/';
     }
     return result;
 }
@@ -333,8 +333,8 @@ bool FileEntryInfo::isFile() const { return m_fileType == FileType_File || m_fil
 FileEntryInfo::~FileEntryInfo()
 {
     delete[] m_sectorBuffer;
-    for (size_t i = 0; i < m_files.size(); ++i) delete m_files[i];
-    for (size_t i = 0; i < m_subDirs.size(); ++i) delete m_subDirs[i];
+    m_files.clear();
+    m_subDirs.clear();
 }
 
 bool FileEntryInfo::setName(const std::string& name)
@@ -422,8 +422,8 @@ void FileEntryInfo::serializeDir()
     writer.closeDescriptorTag();
 
     // ------------ 2 (entries) ---------------
-    for (size_t i = 0; i < m_files.size(); ++i) writeEntity(writer, m_files[i]);
-    for (size_t i = 0; i < m_subDirs.size(); ++i) writeEntity(writer, m_subDirs[i]);
+    for (auto &i : m_files) writeEntity(writer, i);
+    for (auto &i : m_subDirs) writeEntity(writer, i);
     assert(writer.size() < SECTOR_SIZE);  // not supported
 
     m_owner->writeExtentFileDescriptor(m_fileType, writer.size(), m_sectorNum + 1, m_subDirs.size() + 1);
@@ -518,20 +518,20 @@ void FileEntryInfo::setSubMode(bool value) { m_subMode = value; }
 
 FileEntryInfo* FileEntryInfo::subDirByName(const std::string& name) const
 {
-    for (size_t i = 0; i < m_subDirs.size(); ++i)
+    for (auto &i : m_subDirs)
     {
-        if (m_subDirs[i]->m_name == name)
-            return m_subDirs[i];
+        if (i->m_name == name)
+            return i;
     }
     return 0;
 }
 
 FileEntryInfo* FileEntryInfo::fileByName(const std::string& name) const
 {
-    for (size_t i = 0; i < m_files.size(); ++i)
+    for (auto &i : m_files)
     {
-        if (m_files[i]->m_name == name)
-            return m_files[i];
+        if (i->m_name == name)
+            return i;
     }
     return 0;
 }
@@ -932,8 +932,8 @@ void IsoWriter::sectorSeek(Partition partition, int pos)
 void IsoWriter::writeEntity(FileEntryInfo* dir)
 {
     dir->serialize();
-    for (size_t i = 0; i < dir->m_files.size(); ++i) writeEntity(dir->m_files[i]);
-    for (size_t i = 0; i < dir->m_subDirs.size(); ++i) writeEntity(dir->m_subDirs[i]);
+    for (auto &i : dir->m_files) writeEntity(i);
+    for (auto &i : dir->m_subDirs) writeEntity(i);
 }
 
 int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
@@ -947,8 +947,8 @@ int IsoWriter::allocateEntity(FileEntryInfo* entity, int sectorNum)
     if (entity->m_objectId)
         m_mappingEntries[entity->m_objectId] = MappingEntry(entity->m_parent->m_sectorNum, entity->m_sectorNum);
 
-    for (size_t i = 0; i < entity->m_files.size(); ++i) sectorNum = allocateEntity(entity->m_files[i], sectorNum);
-    for (size_t i = 0; i < entity->m_subDirs.size(); ++i) sectorNum = allocateEntity(entity->m_subDirs[i], sectorNum);
+    for (auto &i : entity->m_files) sectorNum = allocateEntity(i, sectorNum);
+    for (auto &i : entity->m_subDirs) sectorNum = allocateEntity(i, sectorNum);
     return sectorNum;
 }
 
@@ -1401,7 +1401,7 @@ void IsoWriter::setLayerBreakPoint(int lbn) { m_layerBreakPoint = lbn; }
 
 IsoHeaderData IsoHeaderData::normal()
 {
-    return IsoHeaderData{"*tsMuxeR " TSMUXER_VERSION, std::string("*tsMuxeR ") + int32ToHex(random32()), time(0),
+    return IsoHeaderData{"*tsMuxeR ", std::string("*tsMuxeR ") + int32ToHex(random32()), time(0),
                          random32()};
 }
 

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -333,8 +333,8 @@ bool FileEntryInfo::isFile() const { return m_fileType == FileType_File || m_fil
 FileEntryInfo::~FileEntryInfo()
 {
     delete[] m_sectorBuffer;
-    m_files.clear();
-    m_subDirs.clear();
+    std::vector<FileEntryInfo*>().swap(m_files);
+    std::vector<FileEntryInfo*>().swap(m_subDirs);
 }
 
 bool FileEntryInfo::setName(const std::string& name)

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -6,17 +6,17 @@
 #include <map>
 #include <string>
 
-static const uint32_t SECTOR_SIZE = 2048;
-static const uint32_t ALLOC_BLOCK_SIZE = 1024 * 64;
-static const uint32_t METADATA_START_ADDR = 1024 * 640 / SECTOR_SIZE;
-static const uint32_t MAX_EXTENT_SIZE = 0x40000000;
+static const int SECTOR_SIZE = 2048;
+static const int ALLOC_BLOCK_SIZE = 1024 * 64;
+static const int METADATA_START_ADDR = 1024 * 640 / SECTOR_SIZE;
+static const int MAX_EXTENT_SIZE = 0x40000000;
 static const uint32_t NEXT_EXTENT = 0xc0000000;
 
 static const int64_t META_BLOCK_PER_DATA = 16 * 1000000000ll;
 
 // it can be allocated inside single sector of a extended file
-static const int MAX_EXTENTS_IN_EXTFILE = (SECTOR_SIZE - 216 - 32) / 16;
-static const int MAX_EXTENTS_IN_EXTCONT = (SECTOR_SIZE - 24 - 32) / 16;
+static const unsigned MAX_EXTENTS_IN_EXTFILE = (SECTOR_SIZE - 216 - 32) / 16;
+static const unsigned MAX_EXTENTS_IN_EXTCONT = (SECTOR_SIZE - 24 - 32) / 16;
 
 static const int MAIN_INTERLEAVE_BLOCKSIZE = 6144 * 3168;
 static const int SUB_INTERLEAVE_BLOCKSIZE = 6144 * 1312;
@@ -216,7 +216,7 @@ class IsoWriter
     void writeLogicalVolumeIntegrityDescriptor();
     int writeExtentFileDescriptor(uint8_t fileType, uint64_t len, uint32_t pos, int linkCount, ExtentList* extents = 0);
     void writeFileSetDescriptor();
-    void writeAllocationExtentDescriptor(ExtentList* extents, int start, int indexEnd);
+    void writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd);
     // void writeFileIdentifierDescriptor();
 
     void writeEntity(FileEntryInfo* dir);

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -359,7 +359,7 @@ uint8_t* LPCMStreamReader::findSubstr(const char* pattern, uint8_t* buff, uint8_
 {
     size_t patternLen = strlen(pattern);
     for (uint8_t* curPos = buff; curPos < end - patternLen; curPos++)
-        for (int j = 0; j < patternLen; j++)
+        for (size_t j = 0; j < patternLen; j++)
             if (curPos[j] != pattern[j])
                 break;
             else if (j == patternLen - 1)
@@ -577,7 +577,7 @@ int LPCMStreamReader::decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, i
         }
         else
         {
-            if (end - buff < m_frameRest + hdrSize)
+            if (end - buff < (int)(m_frameRest + hdrSize))
                 return NOT_ENOUGH_BUFFER;
             int frameLen = m_frameRest;
             m_frameRest = 0;

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -41,7 +41,7 @@ class LPCMStreamReader : public SimplePacketizerReader
     void setHeadersType(LPCMHeaderType value);
 
    protected:
-    unsigned getHeaderLen() override { return 4; }
+    int getHeaderLen() override { return 4; }
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
     uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
     double getFrameDurationNano() override;

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -206,7 +206,7 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
         LTRACE(LT_INFO, 2, "");
     if (streamInfo.fileDurationNano)
         LTRACE(LT_INFO, 2, "Duration: " << floatToTime(streamInfo.fileDurationNano / 1e9));
-    for (int j = 0; j < chapters.size(); j++)
+    for (size_t j = 0; j < chapters.size(); j++)
     {
         uint64_t time = chapters[j].start;
         if (j % 5 == 0)
@@ -642,9 +642,9 @@ int main(int argc, char** argv)
                     detectStreamReader(itemName.c_str(), &mplsParser, false);
                 }
 
-                int markIndex = 0;
+                size_t markIndex = 0;
                 int64_t prevFileOffset = 0;
-                for (int i = 0; i < mplsParser.m_playItems.size(); i++)
+                for (size_t i = 0; i < mplsParser.m_playItems.size(); i++)
                 {
                     MPLSPlayItem& item = mplsParser.m_playItems[i];
 
@@ -771,7 +771,7 @@ int main(int argc, char** argv)
                     IsoWriter* IsoWriter = blurayHelper.isoWriter();
                     if (IsoWriter)
                     {
-                        for (int i = 0; i < mainMuxer->splitFileCnt(); ++i)
+                        for (size_t i = 0; i < mainMuxer->splitFileCnt(); ++i)
                         {
                             string file1 = mainMuxer->getFileNameByIdx(i);
                             string file2 = subMuxer->getFileNameByIdx(i);
@@ -782,7 +782,7 @@ int main(int argc, char** argv)
                     }
                 }
 
-                for (int i = 0; i < customChapterList.size(); ++i)
+                for (size_t i = 0; i < customChapterList.size(); ++i)
                     customChapterList[i] -= (double)muxerManager.getCutStart() / 1e9;
                 // createMPLSFile(dstDir, mainMuxer->getPidList(), *(mainMuxer->getFirstPts().begin()),
                 // *(mainMuxer->getLastPts().rbegin()),

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -782,8 +782,7 @@ int main(int argc, char** argv)
                     }
                 }
 
-                for (auto& i : customChapterList)
-                    i -= (double)muxerManager.getCutStart() / 1e9;
+                for (auto& i : customChapterList) i -= (double)muxerManager.getCutStart() / 1e9;
                 // createMPLSFile(dstDir, mainMuxer->getPidList(), *(mainMuxer->getFirstPts().begin()),
                 // *(mainMuxer->getLastPts().rbegin()),
                 //    autoChapterLen, customChapterList, dt, firstMplsOffset, firstM2tsOffset);

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -782,8 +782,8 @@ int main(int argc, char** argv)
                     }
                 }
 
-                for (size_t i = 0; i < customChapterList.size(); ++i)
-                    customChapterList[i] -= (double)muxerManager.getCutStart() / 1e9;
+                for (auto &i : customChapterList)
+                    i -= (double)muxerManager.getCutStart() / 1e9;
                 // createMPLSFile(dstDir, mainMuxer->getPidList(), *(mainMuxer->getFirstPts().begin()),
                 // *(mainMuxer->getLastPts().rbegin()),
                 //    autoChapterLen, customChapterList, dt, firstMplsOffset, firstM2tsOffset);

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -782,7 +782,7 @@ int main(int argc, char** argv)
                     }
                 }
 
-                for (auto &i : customChapterList)
+                for (auto& i : customChapterList)
                     i -= (double)muxerManager.getCutStart() / 1e9;
                 // createMPLSFile(dstDir, mainMuxer->getPidList(), *(mainMuxer->getFirstPts().begin()),
                 // *(mainMuxer->getLastPts().rbegin()),

--- a/tsMuxer/matroskaDemuxer.cpp
+++ b/tsMuxer/matroskaDemuxer.cpp
@@ -402,8 +402,8 @@ int MatroskaDemuxer::matroska_find_track_by_num(int num)
 
 int MatroskaDemuxer::matroska_ebmlnum_uint(uint8_t *data, uint32_t size, uint64_t *num)
 {
-    int len_mask = 0x80, read = 1, n = 1, num_ffs = 0;
-    uint64_t total;
+    unsigned read = 1, n = 1, num_ffs = 0;
+    uint64_t total, len_mask = 0x80;
 
     if (size <= 0)
         return AVERROR_INVALIDDATA;

--- a/tsMuxer/matroskaParser.cpp
+++ b/tsMuxer/matroskaParser.cpp
@@ -69,18 +69,18 @@ void ParsedH264TrackData::writeNalHeader(uint8_t*& dst)
 int ParsedH264TrackData::getSPSPPSLen()
 {
     int rez = 0;
-    for (size_t i = 0; i < m_spsPpsList.size(); i++) rez += m_spsPpsList[i].size() + 4;
+    for (auto &i : m_spsPpsList) rez += i.size() + 4;
     return rez;
 }
 
 int ParsedH264TrackData::writeSPSPPS(uint8_t* dst)
 {
     uint8_t* start = dst;
-    for (size_t i = 0; i < m_spsPpsList.size(); i++)
+    for (auto &i : m_spsPpsList)
     {
         writeNalHeader(dst);
-        memcpy(dst, &m_spsPpsList[i][0], m_spsPpsList[i].size());
-        dst += m_spsPpsList[i].size();
+        memcpy(dst, &i[0], i.size());
+        dst += i.size();
     }
     return dst - start;
 }

--- a/tsMuxer/matroskaParser.cpp
+++ b/tsMuxer/matroskaParser.cpp
@@ -69,14 +69,14 @@ void ParsedH264TrackData::writeNalHeader(uint8_t*& dst)
 int ParsedH264TrackData::getSPSPPSLen()
 {
     int rez = 0;
-    for (auto &i : m_spsPpsList) rez += i.size() + 4;
+    for (auto& i : m_spsPpsList) rez += i.size() + 4;
     return rez;
 }
 
 int ParsedH264TrackData::writeSPSPPS(uint8_t* dst)
 {
     uint8_t* start = dst;
-    for (auto &i : m_spsPpsList)
+    for (auto& i : m_spsPpsList)
     {
         writeNalHeader(dst);
         memcpy(dst, &i[0], i.size());

--- a/tsMuxer/matroskaParser.cpp
+++ b/tsMuxer/matroskaParser.cpp
@@ -69,14 +69,14 @@ void ParsedH264TrackData::writeNalHeader(uint8_t*& dst)
 int ParsedH264TrackData::getSPSPPSLen()
 {
     int rez = 0;
-    for (int i = 0; i < m_spsPpsList.size(); i++) rez += m_spsPpsList[i].size() + 4;
+    for (size_t i = 0; i < m_spsPpsList.size(); i++) rez += m_spsPpsList[i].size() + 4;
     return rez;
 }
 
 int ParsedH264TrackData::writeSPSPPS(uint8_t* dst)
 {
     uint8_t* start = dst;
-    for (int i = 0; i < m_spsPpsList.size(); i++)
+    for (size_t i = 0; i < m_spsPpsList.size(); i++)
     {
         writeNalHeader(dst);
         memcpy(dst, &m_spsPpsList[i][0], m_spsPpsList[i].size());
@@ -173,7 +173,7 @@ void ParsedH264TrackData::extractData(AVPacket* pkt, uint8_t* buff, int size)
             THROW(ERR_COMMON, "Unsupported nal unit size " << elSize);
         writeNalHeader(dst);
         assert((curPos[m_nalSize] & 0x80) == 0);
-        memcpy(dst, curPos + m_nalSize, FFMIN(elSize, end - curPos));
+        memcpy(dst, curPos + m_nalSize, FFMIN(elSize, (uint32_t)(end - curPos)));
         curPos += elSize + m_nalSize;
         dst += elSize;
     }

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -207,9 +207,9 @@ void METADemuxer::openFile(const string& streamName)
     }
 
     H264StreamReader::SeiMethod primarySEI = H264StreamReader::SEI_NotDefined;
-    for (size_t i = 0; i < m_codecInfo.size(); ++i)
+    for (auto &i : m_codecInfo)
     {
-        H264StreamReader* reader = dynamic_cast<H264StreamReader*>(m_codecInfo[i].m_streamReader);
+        H264StreamReader* reader = dynamic_cast<H264StreamReader*>(i.m_streamReader);
         if (reader && !reader->isSubStream())
         {
             primarySEI = reader->getInsertSEI();
@@ -220,9 +220,9 @@ void METADemuxer::openFile(const string& streamName)
     bool warned = false;
     if (primarySEI != H264StreamReader::SEI_NotDefined)
     {
-        for (size_t i = 0; i < m_codecInfo.size(); ++i)
+        for (auto &i : m_codecInfo)
         {
-            H264StreamReader* reader = dynamic_cast<H264StreamReader*>(m_codecInfo[i].m_streamReader);
+            H264StreamReader* reader = dynamic_cast<H264StreamReader*>(i.m_streamReader);
             if (reader && reader->isSubStream())
             {
                 if (!warned && (int)reader->getInsertSEI() != primarySEI)
@@ -287,13 +287,10 @@ int METADemuxer::addPGSubStream(const string& codec, const string& _codecStreamN
 std::vector<MPLSPlayItem> METADemuxer::mergePlayItems(const std::vector<MPLSParser>& mplsInfoList)
 {
     std::vector<MPLSPlayItem> result;
-    for (size_t i = 0; i < mplsInfoList.size(); ++i)
+    for (auto &i : mplsInfoList)
     {
-        const MPLSParser& mplsInfo = mplsInfoList[i];
-        for (size_t j = 0; j < mplsInfo.m_playItems.size(); ++j)
-        {
-            result.push_back(mplsInfo.m_playItems[j]);
-        }
+        const MPLSParser& mplsInfo = i;
+        for (auto &j : mplsInfo.m_playItems) result.push_back(j);
     }
     return result;
 }
@@ -561,7 +558,7 @@ int METADemuxer::addStream(const string codec, const string& codecStreamName, co
 
 void METADemuxer::readClose()
 {
-    for (auto& codecInfo : m_codecInfo)
+    for (auto &codecInfo : m_codecInfo)
     {
         codecInfo.m_dataReader->deleteReader(codecInfo.m_readerID);
         delete codecInfo.m_streamReader;
@@ -1129,18 +1126,18 @@ const std::vector<MPLSParser> METADemuxer::getMplsInfo(const string& mplsFileNam
     std::vector<MPLSParser> result;
 
     std::vector<std::string> mplsFiles = splitQuotedStr(mplsFileName.c_str(), '+');
-    for (size_t i = 0; i < mplsFiles.size(); ++i)
+    for (auto &i : mplsFiles)
     {
-        MPLSCache::iterator itr = m_mplsStreamMap.find(mplsFiles[i]);
+        MPLSCache::iterator itr = m_mplsStreamMap.find(i);
         if (itr != m_mplsStreamMap.end())
             result.push_back(itr->second);
         else
         {
             MPLSParser parser;
-            if (!parser.parse(unquoteStr(mplsFiles[i]).c_str()))
-                THROW(ERR_COMMON, "Can't parse play list file " << mplsFiles[i]);
-            pair<MPLSCache::iterator, bool> insRez = m_mplsStreamMap.insert(make_pair(mplsFiles[i], parser));
-            m_mplsStreamMap.insert(make_pair(mplsFiles[i], insRez.first->second));
+            if (!parser.parse(unquoteStr(i).c_str()))
+                THROW(ERR_COMMON, "Can't parse play list file " << i);
+            pair<MPLSCache::iterator, bool> insRez = m_mplsStreamMap.insert(make_pair(i, parser));
+            m_mplsStreamMap.insert(make_pair(i, insRez.first->second));
             result.push_back(insRez.first->second);
         }
     }

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -207,7 +207,7 @@ void METADemuxer::openFile(const string& streamName)
     }
 
     H264StreamReader::SeiMethod primarySEI = H264StreamReader::SEI_NotDefined;
-    for (int i = 0; i < m_codecInfo.size(); ++i)
+    for (size_t i = 0; i < m_codecInfo.size(); ++i)
     {
         H264StreamReader* reader = dynamic_cast<H264StreamReader*>(m_codecInfo[i].m_streamReader);
         if (reader && !reader->isSubStream())
@@ -220,7 +220,7 @@ void METADemuxer::openFile(const string& streamName)
     bool warned = false;
     if (primarySEI != H264StreamReader::SEI_NotDefined)
     {
-        for (int i = 0; i < m_codecInfo.size(); ++i)
+        for (size_t i = 0; i < m_codecInfo.size(); ++i)
         {
             H264StreamReader* reader = dynamic_cast<H264StreamReader*>(m_codecInfo[i].m_streamReader);
             if (reader && reader->isSubStream())
@@ -287,10 +287,10 @@ int METADemuxer::addPGSubStream(const string& codec, const string& _codecStreamN
 std::vector<MPLSPlayItem> METADemuxer::mergePlayItems(const std::vector<MPLSParser>& mplsInfoList)
 {
     std::vector<MPLSPlayItem> result;
-    for (int i = 0; i < mplsInfoList.size(); ++i)
+    for (size_t i = 0; i < mplsInfoList.size(); ++i)
     {
         const MPLSParser& mplsInfo = mplsInfoList[i];
-        for (int j = 0; j < mplsInfo.m_playItems.size(); ++j)
+        for (size_t j = 0; j < mplsInfo.m_playItems.size(); ++j)
         {
             result.push_back(mplsInfo.m_playItems[j]);
         }
@@ -326,11 +326,11 @@ int METADemuxer::addStream(const string codec, const string& codecStreamName, co
     {
         mplsInfoList = getMplsInfo(codecStreamName);
         vector<string> mplsNames = splitQuotedStr(codecStreamName.c_str(), '+');
-        for (int k = 0; k < mplsInfoList.size(); ++k)
+        for (size_t k = 0; k < mplsInfoList.size(); ++k)
         {
             MPLSParser& mplsInfo = mplsInfoList[k];
             string unquotedStreamName = unquoteStr(mplsNames[k]);
-            for (int i = 0; i < mplsInfo.m_playItems.size(); ++i)
+            for (size_t i = 0; i < mplsInfo.m_playItems.size(); ++i)
             {
                 string playItemName;
                 if (isSubStream)
@@ -1129,7 +1129,7 @@ const std::vector<MPLSParser> METADemuxer::getMplsInfo(const string& mplsFileNam
     std::vector<MPLSParser> result;
 
     std::vector<std::string> mplsFiles = splitQuotedStr(mplsFileName.c_str(), '+');
-    for (int i = 0; i < mplsFiles.size(); ++i)
+    for (size_t i = 0; i < mplsFiles.size(); ++i)
     {
         MPLSCache::iterator itr = m_mplsStreamMap.find(mplsFiles[i]);
         if (itr != m_mplsStreamMap.end())

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -289,8 +289,7 @@ std::vector<MPLSPlayItem> METADemuxer::mergePlayItems(const std::vector<MPLSPars
     std::vector<MPLSPlayItem> result;
     for (auto& i : mplsInfoList)
     {
-        const MPLSParser& mplsInfo = i;
-        for (auto& j : mplsInfo.m_playItems) result.push_back(j);
+        for (auto& j : i.m_playItems) result.push_back(j);
     }
     return result;
 }

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -207,7 +207,7 @@ void METADemuxer::openFile(const string& streamName)
     }
 
     H264StreamReader::SeiMethod primarySEI = H264StreamReader::SEI_NotDefined;
-    for (auto &i : m_codecInfo)
+    for (auto& i : m_codecInfo)
     {
         H264StreamReader* reader = dynamic_cast<H264StreamReader*>(i.m_streamReader);
         if (reader && !reader->isSubStream())
@@ -220,7 +220,7 @@ void METADemuxer::openFile(const string& streamName)
     bool warned = false;
     if (primarySEI != H264StreamReader::SEI_NotDefined)
     {
-        for (auto &i : m_codecInfo)
+        for (auto& i : m_codecInfo)
         {
             H264StreamReader* reader = dynamic_cast<H264StreamReader*>(i.m_streamReader);
             if (reader && reader->isSubStream())
@@ -287,10 +287,10 @@ int METADemuxer::addPGSubStream(const string& codec, const string& _codecStreamN
 std::vector<MPLSPlayItem> METADemuxer::mergePlayItems(const std::vector<MPLSParser>& mplsInfoList)
 {
     std::vector<MPLSPlayItem> result;
-    for (auto &i : mplsInfoList)
+    for (auto& i : mplsInfoList)
     {
         const MPLSParser& mplsInfo = i;
-        for (auto &j : mplsInfo.m_playItems) result.push_back(j);
+        for (auto& j : mplsInfo.m_playItems) result.push_back(j);
     }
     return result;
 }
@@ -558,7 +558,7 @@ int METADemuxer::addStream(const string codec, const string& codecStreamName, co
 
 void METADemuxer::readClose()
 {
-    for (auto &codecInfo : m_codecInfo)
+    for (auto& codecInfo : m_codecInfo)
     {
         codecInfo.m_dataReader->deleteReader(codecInfo.m_readerID);
         delete codecInfo.m_streamReader;
@@ -1126,7 +1126,7 @@ const std::vector<MPLSParser> METADemuxer::getMplsInfo(const string& mplsFileNam
     std::vector<MPLSParser> result;
 
     std::vector<std::string> mplsFiles = splitQuotedStr(mplsFileName.c_str(), '+');
-    for (auto &i : mplsFiles)
+    for (auto& i : mplsFiles)
     {
         MPLSCache::iterator itr = m_mplsStreamMap.find(i);
         if (itr != m_mplsStreamMap.end())

--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -305,15 +305,15 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
         uint8_t* dst = pkt->data;
         if (!spsPpsList.empty())
         {
-            for (size_t i = 0; i < spsPpsList.size(); ++i)
+            for (auto &i : spsPpsList)
             {
                 *dst++ = 0x0;
                 *dst++ = 0x0;
                 *dst++ = 0x0;
                 *dst++ = 0x1;
 
-                memcpy(dst, &spsPpsList[i][0], spsPpsList[i].size());
-                dst += spsPpsList[i].size();
+                memcpy(dst, &i[0], i.size());
+                dst += i.size();
             }
             spsPpsList.clear();
         }
@@ -350,7 +350,7 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
             ++nalCnt;
         }
         int spsPpsSize = 0;
-        for (size_t i = 0; i < spsPpsList.size(); ++i) spsPpsSize += spsPpsList[i].size() + 4;
+        for (auto &i : spsPpsList) spsPpsSize += i.size() + 4;
 
         return size + spsPpsSize + nalCnt * (4 - nal_length_size);
     }
@@ -618,12 +618,12 @@ void MovDemuxer::buildIndex()
         for (int i = 0; i < num_tracks; ++i)
         {
             MOVStreamContext* st = (MOVStreamContext*)tracks[i];
-            for (size_t j = 0; j < st->chunk_offsets.size(); ++j)
+            for (auto &j : st->chunk_offsets)
             {
                 if (!found_moof)
-                    if (st->chunk_offsets[j] < m_mdat_pos || st->chunk_offsets[j] > m_mdat_pos + m_mdat_size)
-                        THROW(ERR_MOV_PARSE, "Invalid chunk offset " << st->chunk_offsets[j]);
-                chunks.push_back(make_pair(st->chunk_offsets[j] - m_mdat_pos, i));
+                    if (j < m_mdat_pos || j > m_mdat_pos + m_mdat_size)
+                        THROW(ERR_MOV_PARSE, "Invalid chunk offset " << j);
+                chunks.push_back(make_pair(j - m_mdat_pos, i));
             }
         }
         sort(chunks.begin(), chunks.end());
@@ -1063,10 +1063,10 @@ int MovDemuxer::mov_read_tfhd(MOVAtom atom)
     if (!track_id || track_id > num_tracks)
         return -1;
     frag->track_id = track_id;
-    for (size_t i = 0; i < trex_data.size(); i++)
-        if (trex_data[i].track_id == frag->track_id)
+    for (auto &i : trex_data)
+        if (i.track_id == frag->track_id)
         {
-            trex = &trex_data[i];
+            trex = &i;
             break;
         }
     if (!trex)

--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -305,7 +305,7 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
         uint8_t* dst = pkt->data;
         if (!spsPpsList.empty())
         {
-            for (auto &i : spsPpsList)
+            for (auto& i : spsPpsList)
             {
                 *dst++ = 0x0;
                 *dst++ = 0x0;
@@ -350,7 +350,7 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
             ++nalCnt;
         }
         int spsPpsSize = 0;
-        for (auto &i : spsPpsList) spsPpsSize += i.size() + 4;
+        for (auto& i : spsPpsList) spsPpsSize += i.size() + 4;
 
         return size + spsPpsSize + nalCnt * (4 - nal_length_size);
     }
@@ -618,7 +618,7 @@ void MovDemuxer::buildIndex()
         for (int i = 0; i < num_tracks; ++i)
         {
             MOVStreamContext* st = (MOVStreamContext*)tracks[i];
-            for (auto &j : st->chunk_offsets)
+            for (auto& j : st->chunk_offsets)
             {
                 if (!found_moof)
                     if (j < m_mdat_pos || j > m_mdat_pos + m_mdat_size)
@@ -1063,7 +1063,7 @@ int MovDemuxer::mov_read_tfhd(MOVAtom atom)
     if (!track_id || track_id > num_tracks)
         return -1;
     frag->track_id = track_id;
-    for (auto &i : trex_data)
+    for (auto& i : trex_data)
         if (i.track_id == frag->track_id)
         {
             trex = &i;

--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -305,7 +305,7 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
         uint8_t* dst = pkt->data;
         if (!spsPpsList.empty())
         {
-            for (int i = 0; i < spsPpsList.size(); ++i)
+            for (size_t i = 0; i < spsPpsList.size(); ++i)
             {
                 *dst++ = 0x0;
                 *dst++ = 0x0;
@@ -350,7 +350,7 @@ class MovParsedH264TrackData : public ParsedTrackPrivData
             ++nalCnt;
         }
         int spsPpsSize = 0;
-        for (int i = 0; i < spsPpsList.size(); ++i) spsPpsSize += spsPpsList[i].size() + 4;
+        for (size_t i = 0; i < spsPpsList.size(); ++i) spsPpsSize += spsPpsList[i].size() + 4;
 
         return size + spsPpsSize + nalCnt * (4 - nal_length_size);
     }
@@ -477,7 +477,7 @@ class MovParsedSRTTrackData : public ParsedTrackPrivData
     MovDemuxer* m_demuxer;
     MOVStreamContext* m_sc;
     int m_packetCnt;
-    int sttsPos;
+    size_t sttsPos;
     int sttsCnt;
     int64_t m_timeOffset;
 };
@@ -618,7 +618,7 @@ void MovDemuxer::buildIndex()
         for (int i = 0; i < num_tracks; ++i)
         {
             MOVStreamContext* st = (MOVStreamContext*)tracks[i];
-            for (int j = 0; j < st->chunk_offsets.size(); ++j)
+            for (size_t j = 0; j < st->chunk_offsets.size(); ++j)
             {
                 if (!found_moof)
                     if (st->chunk_offsets[j] < m_mdat_pos || st->chunk_offsets[j] > m_mdat_pos + m_mdat_size)
@@ -968,7 +968,7 @@ int MovDemuxer::mov_read_trun(MOVAtom atom)
     int64_t dts;
     int data_offset = 0;
     unsigned entries, first_sample_flags = frag->flags;
-    int flags, distance, i;
+    int flags, distance;
 
     if (!frag->track_id || frag->track_id > num_tracks)
         return -1;
@@ -986,7 +986,7 @@ int MovDemuxer::mov_read_trun(MOVAtom atom)
     offset = frag->base_data_offset + data_offset;
     sc->chunk_offsets.push_back(offset);
     distance = 0;
-    for (i = 0; i < entries; i++)
+    for (size_t i = 0; i < entries; i++)
     {
         unsigned sample_size = frag->size;
         int sample_flags = i ? frag->flags : first_sample_flags;
@@ -1063,7 +1063,7 @@ int MovDemuxer::mov_read_tfhd(MOVAtom atom)
     if (!track_id || track_id > num_tracks)
         return -1;
     frag->track_id = track_id;
-    for (int i = 0; i < trex_data.size(); i++)
+    for (size_t i = 0; i < trex_data.size(); i++)
         if (trex_data[i].track_id == frag->track_id)
         {
             trex = &trex_data[i];
@@ -1137,7 +1137,7 @@ int MovDemuxer::mov_read_stsz(MOVAtom atom)
         return 0;
     if (entries >= UINT_MAX / sizeof(int))
         return -1;
-    for (int i = 0; i < entries; i++) st->m_index.push_back(get_be32());
+    for (size_t i = 0; i < entries; i++) st->m_index.push_back(get_be32());
     return 0;
 }
 
@@ -1152,7 +1152,7 @@ int MovDemuxer::mov_read_stss(MOVAtom atom)
         return 0;
     if (entries >= UINT_MAX / sizeof(int))
         return -1;
-    for (int i = 0; i < entries; i++) st->keyframes.push_back(get_be32());
+    for (size_t i = 0; i < entries; i++) st->keyframes.push_back(get_be32());
     return 0;
 }
 

--- a/tsMuxer/movDemuxer.h
+++ b/tsMuxer/movDemuxer.h
@@ -39,7 +39,7 @@ class MovDemuxer : public IOContextDemuxer
 
     struct MOVFragment
     {
-        unsigned track_id;
+        int track_id;
         uint64_t base_data_offset;
         uint64_t moof_offset;
         unsigned stsd_id;
@@ -71,7 +71,7 @@ class MovDemuxer : public IOContextDemuxer
     int64_t fileDuration;
     int isom;
     std::vector<std::pair<int64_t, uint64_t>> chunks;
-    int m_curChunk;
+    size_t m_curChunk;
     AVPacket m_deliveredPacket;
     std::vector<uint8_t> m_tmpChunkBuffer;
     bool m_firstDemux;

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -15,7 +15,7 @@ class MpegAudioStreamReader : public SimplePacketizerReader, MP3Codec
     int getChannels() override { return 2; }
 
    protected:
-    unsigned getHeaderLen() override { return MPEG_AUDIO_HEADER_SIZE; };
+    int getHeaderLen() override { return MPEG_AUDIO_HEADER_SIZE; };
     virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) override;
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, int& skipBeforeBytes) override;
     double getFrameDurationNano() override;

--- a/tsMuxer/muxerManager.cpp
+++ b/tsMuxer/muxerManager.cpp
@@ -225,7 +225,7 @@ void MuxerManager::doMux(const string& outFileName, FileFactory* fileFactory)
         m_subMuxer->doFlush();
     m_mainMuxer->doFlush();
 
-    for (size_t i = 0; i < m_delayedData.size(); ++i) asyncWriteBlock(m_delayedData[i]);
+    for (auto &i : m_delayedData) asyncWriteBlock(i);
 
     waitForWriting();
 
@@ -274,10 +274,8 @@ void MuxerManager::muxBlockFinished(AbstractMuxer* muxer)
 
     if (m_subBlockFinished && m_mainBlockFinished)
     {
-        for (size_t i = 0; i < m_delayedData.size(); ++i)
-        {
-            asyncWriteBlock(m_delayedData[i]);
-        }
+        for (auto &i : m_delayedData) asyncWriteBlock(i);
+
         m_delayedData.clear();
         m_subBlockFinished = false;
         m_mainBlockFinished = false;
@@ -322,9 +320,9 @@ int MuxerManager::syncWriteBuffer(AbstractMuxer* muxer, uint8_t* buff, int len, 
 void MuxerManager::parseMuxOpt(const string& opts)
 {
     vector<string> params = splitQuotedStr(opts.c_str(), ' ');
-    for (size_t i = 0; i < params.size(); i++)
+    for (auto &i : params)
     {
-        vector<string> paramPair = splitStr(trimStr(params[i]).c_str(), '=');
+        vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)
             continue;
 

--- a/tsMuxer/muxerManager.cpp
+++ b/tsMuxer/muxerManager.cpp
@@ -225,7 +225,7 @@ void MuxerManager::doMux(const string& outFileName, FileFactory* fileFactory)
         m_subMuxer->doFlush();
     m_mainMuxer->doFlush();
 
-    for (int i = 0; i < m_delayedData.size(); ++i) asyncWriteBlock(m_delayedData[i]);
+    for (size_t i = 0; i < m_delayedData.size(); ++i) asyncWriteBlock(m_delayedData[i]);
 
     waitForWriting();
 
@@ -274,7 +274,7 @@ void MuxerManager::muxBlockFinished(AbstractMuxer* muxer)
 
     if (m_subBlockFinished && m_mainBlockFinished)
     {
-        for (int i = 0; i < m_delayedData.size(); ++i)
+        for (size_t i = 0; i < m_delayedData.size(); ++i)
         {
             asyncWriteBlock(m_delayedData[i]);
         }

--- a/tsMuxer/muxerManager.cpp
+++ b/tsMuxer/muxerManager.cpp
@@ -225,7 +225,7 @@ void MuxerManager::doMux(const string& outFileName, FileFactory* fileFactory)
         m_subMuxer->doFlush();
     m_mainMuxer->doFlush();
 
-    for (auto &i : m_delayedData) asyncWriteBlock(i);
+    for (auto& i : m_delayedData) asyncWriteBlock(i);
 
     waitForWriting();
 
@@ -274,7 +274,7 @@ void MuxerManager::muxBlockFinished(AbstractMuxer* muxer)
 
     if (m_subBlockFinished && m_mainBlockFinished)
     {
-        for (auto &i : m_delayedData) asyncWriteBlock(i);
+        for (auto& i : m_delayedData) asyncWriteBlock(i);
 
         m_delayedData.clear();
         m_subBlockFinished = false;
@@ -320,7 +320,7 @@ int MuxerManager::syncWriteBuffer(AbstractMuxer* muxer, uint8_t* buff, int len, 
 void MuxerManager::parseMuxOpt(const string& opts)
 {
     vector<string> params = splitQuotedStr(opts.c_str(), ' ');
-    for (auto &i : params)
+    for (auto& i : params)
     {
         vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)

--- a/tsMuxer/nalUnits.cpp
+++ b/tsMuxer/nalUnits.cpp
@@ -118,14 +118,14 @@ int NALUnit::encodeNAL(uint8_t* srcBuffer, uint8_t* srcEnd, uint8_t* dstBuffer, 
             dstBufferSize -= srcBuffer - srcStart + 2;
             *dstBuffer++ = 3;
             *dstBuffer++ = *srcBuffer++;
-            for (int k = 0; k < 1; k++)
-                if (srcBuffer < srcEnd)
-                {
-                    if (dstBufferSize < 1)
-                        return -1;
-                    *dstBuffer++ = *srcBuffer++;
-                    dstBufferSize--;
-                }
+
+            if (srcBuffer < srcEnd)
+            {
+                if (dstBufferSize < 1)
+                    return -1;
+                *dstBuffer++ = *srcBuffer++;
+                dstBufferSize--;
+            }
             srcStart = srcBuffer;
         }
         else

--- a/tsMuxer/programStreamDemuxer.cpp
+++ b/tsMuxer/programStreamDemuxer.cpp
@@ -341,8 +341,8 @@ int ProgramStreamDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSe
                 }
 
                 uint8_t* payloadData = curBuf + pesPacket->getHeaderLength() + afterPesHeader;
-                uint32_t pesPayloadLen = pesPacket->getPacketLength() - pesPacket->getHeaderLength() - afterPesHeader;
-                uint32_t copyLen = FFMIN(pesPayloadLen, end - payloadData);
+                int pesPayloadLen = pesPacket->getPacketLength() - pesPacket->getHeaderLength() - afterPesHeader;
+                int copyLen = FFMIN(pesPayloadLen, end - payloadData);
                 vect.append(payloadData, copyLen);
                 m_dataProcessed += copyLen;
                 discardSize += payloadData - curBuf;
@@ -356,7 +356,7 @@ int ProgramStreamDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSe
             }
             else
             {
-                uint32_t tmpLen = pesPacket->getPacketLength();
+                int tmpLen = pesPacket->getPacketLength();
                 if (tmpLen > end - curBuf)
                 {
                     discardSize += end - curBuf;

--- a/tsMuxer/programStreamDemuxer.h
+++ b/tsMuxer/programStreamDemuxer.h
@@ -37,7 +37,7 @@ class ProgramStreamDemuxer : public AbstractDemuxer
    private:
     uint32_t m_tmpBufferLen;
     uint8_t m_tmpBuffer[MAX_PES_HEADER_SIZE];  // TS_FRAME_SIZE
-    int m_lastPesLen;
+    uint32_t m_lastPesLen;
     uint32_t m_lastPID;
     const BufferedReaderManager& m_readManager;
     int m_readCnt;

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -736,7 +736,7 @@ int PGSStreamReader::flushPacket(AVPacket& avPacket) { return 0; }
 
 void PGSStreamReader::setBuffer(uint8_t* data, int dataLen, bool lastBlock)
 {
-    if (m_tmpBufferLen + dataLen > m_tmpBuffer.size())
+    if ((size_t)(m_tmpBufferLen + dataLen) > m_tmpBuffer.size())
         m_tmpBuffer.resize(m_tmpBufferLen + dataLen);
 
     if (m_tmpBuffer.size() > 0)

--- a/tsMuxer/simplePacketizerReader.cpp
+++ b/tsMuxer/simplePacketizerReader.cpp
@@ -46,7 +46,7 @@ void SimplePacketizerReader::doMplsCorrection()
 
 void SimplePacketizerReader::setBuffer(uint8_t* data, int dataLen, bool lastBlock)
 {
-    if (m_tmpBufferLen + dataLen > m_tmpBuffer.size())
+    if ((size_t)(m_tmpBufferLen + dataLen) > m_tmpBuffer.size())
         m_tmpBuffer.resize(m_tmpBufferLen + dataLen);
 
     if (m_tmpBuffer.size() > 0)

--- a/tsMuxer/simplePacketizerReader.h
+++ b/tsMuxer/simplePacketizerReader.h
@@ -41,7 +41,7 @@ class SimplePacketizerReader : public AbstractStreamReader
     virtual bool isIFrame(AVPacket* packet) { return true; }
 
    protected:
-    virtual unsigned getHeaderLen() = 0;  // return fixed frame header size at bytes
+    virtual int getHeaderLen() = 0;  // return fixed frame header size at bytes
     virtual int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes,
                             int& skipBeforeBytes) = 0;  // decode frame parameters. bitrate, channels for audio e.t.c
     virtual uint8_t* findFrame(uint8_t* buff, uint8_t* end) = 0;  // find forawrd nearest frame
@@ -55,7 +55,7 @@ class SimplePacketizerReader : public AbstractStreamReader
 
    protected:
     // uint8_t* m_tmpBuffer;
-    int m_curMplsIndex;
+    unsigned m_curMplsIndex;
     double m_stretch;
     std::vector<uint8_t> m_tmpBuffer;
     uint64_t m_processedBytes;

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -313,9 +313,9 @@ bool SingleFileMuxer::close()
 void SingleFileMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (size_t i = 0; i < params.size(); i++)
+    for (auto &i : params)
     {
-        vector<string> paramPair = splitStr(trimStr(params[i]).c_str(), '=');
+        vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)
             continue;
         if (paramPair[0] == "--split-duration")

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -313,7 +313,7 @@ bool SingleFileMuxer::close()
 void SingleFileMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (auto &i : params)
+    for (auto& i : params)
     {
         vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -313,7 +313,7 @@ bool SingleFileMuxer::close()
 void SingleFileMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (int i = 0; i < params.size(); i++)
+    for (size_t i = 0; i < params.size(); i++)
     {
         vector<string> paramPair = splitStr(trimStr(params[i]).c_str(), '=');
         if (paramPair.size() == 0)

--- a/tsMuxer/srtStreamReader.cpp
+++ b/tsMuxer/srtStreamReader.cpp
@@ -192,7 +192,7 @@ uint8_t* SRTStreamReader::renderNextMessage(uint32_t& renderedLen)
         m_state = PARSE_TIME;
         bool isNUmber = true;
         {
-            for (auto c : m_sourceText.front())
+            for (auto &c : m_sourceText.front())
                 if (!(c >= '0' && c <= '9') && c != ' ')
                 {
                     isNUmber = false;

--- a/tsMuxer/srtStreamReader.cpp
+++ b/tsMuxer/srtStreamReader.cpp
@@ -254,16 +254,16 @@ uint8_t* SRTStreamReader::renderNextMessage(uint32_t& renderedLen)
 
 bool SRTStreamReader::parseTime(const string& text)
 {
-    for (int i = 0; i < text.length() - 2; i++)
+    for (size_t i = 0; i < text.length() - 2; i++)
     {
         if (text[i] == '-' && text[i + 1] == '-' && text[i + 2] == '>')
         {
             string first = trimStr(text.substr(0, i));
             string second = trimStr(text.substr(i + 3, text.length() - i - 3));
-            for (int j = 0; j < first.length(); j++)
+            for (size_t j = 0; j < first.length(); j++)
                 if (first[j] == ',')
                     first[j] = '.';
-            for (int j = 0; j < second.length(); j++)
+            for (size_t j = 0; j < second.length(); j++)
                 if (second[j] == ',')
                     second[j] = '.';
             m_inTime = timeToFloat(first);

--- a/tsMuxer/srtStreamReader.cpp
+++ b/tsMuxer/srtStreamReader.cpp
@@ -192,7 +192,7 @@ uint8_t* SRTStreamReader::renderNextMessage(uint32_t& renderedLen)
         m_state = PARSE_TIME;
         bool isNUmber = true;
         {
-            for (auto &c : m_sourceText.front())
+            for (auto& c : m_sourceText.front())
                 if (!(c >= '0' && c <= '9') && c != ' ')
                 {
                     isNUmber = false;

--- a/tsMuxer/textSubtitles.h
+++ b/tsMuxer/textSubtitles.h
@@ -60,7 +60,7 @@ class TextToPGSConverter  //: public TextSubtitlesRenderWin32
     void setImageBuffer(uint8_t* value) { m_imageBuffer = value; }
 
    public:
-    uint32_t m_rleLen;
+    int m_rleLen;
     int m_bottomOffset;
     int m_composition_number;
     int m_videoWidth;

--- a/tsMuxer/textSubtitlesRender.cpp
+++ b/tsMuxer/textSubtitlesRender.cpp
@@ -262,7 +262,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
             bool endTag = false;
             string tagStr = trimStr(line.substr(bStartPos + 1, i - bStartPos - 1));
             string ltagStr = tagStr;
-            for (auto &j : ltagStr) j = towlower(j);
+            for (auto& j : ltagStr) j = towlower(j);
             if (ltagStr == "i" || ltagStr == "italic")
             {
                 curFont.m_opts |= Font::ITALIC;
@@ -374,7 +374,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
     if (line.size() > (unsigned)prevTextPos)
         rez.push_back(make_pair(curFont, line.substr(prevTextPos, line.size() - prevTextPos)));
     double rSize = m_initFont.m_size;
-    for (auto &i : rez) i.first.m_size = browserSizeToRealSize(i.first.m_size, rSize);
+    for (auto& i : rez) i.first.m_size = browserSizeToRealSize(i.first.m_size, rSize);
     return rez;
 }
 
@@ -386,10 +386,10 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
     vector<string> lines = splitStr(text.c_str(), '\n');
     int curY = 0;
     m_initFont = m_font;
-    for (auto &i : lines)
+    for (auto& i : lines)
     {
         vector<pair<Font, string>> txtParts = processTxtLine(i, fontStack);
-        for (auto &j : txtParts)
+        for (auto& j : txtParts)
         {
             if (j.first.m_opts & Font::FORCED)
                 forced = true;
@@ -400,7 +400,7 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
         int maxHeight = 0;
         int maxBaseLine = 0;
         vector<int> xSize;
-        for (auto &j : txtParts)
+        for (auto& j : txtParts)
         {
             setFont(j.first);
             SIZE mSize;

--- a/tsMuxer/textSubtitlesRender.cpp
+++ b/tsMuxer/textSubtitlesRender.cpp
@@ -262,7 +262,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
             bool endTag = false;
             string tagStr = trimStr(line.substr(bStartPos + 1, i - bStartPos - 1));
             string ltagStr = tagStr;
-            for (size_t j = 0; j < ltagStr.size(); j++) ltagStr[j] = towlower(ltagStr[j]);
+            for (auto &j : ltagStr) j = towlower(j);
             if (ltagStr == "i" || ltagStr == "italic")
             {
                 curFont.m_opts |= Font::ITALIC;
@@ -374,7 +374,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
     if (line.size() > (unsigned)prevTextPos)
         rez.push_back(make_pair(curFont, line.substr(prevTextPos, line.size() - prevTextPos)));
     double rSize = m_initFont.m_size;
-    for (size_t i = 0; i < rez.size(); i++) rez[i].first.m_size = browserSizeToRealSize(rez[i].first.m_size, rSize);
+    for (auto &i : rez) i.first.m_size = browserSizeToRealSize(i.first.m_size, rSize);
     return rez;
 }
 
@@ -386,12 +386,12 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
     vector<string> lines = splitStr(text.c_str(), '\n');
     int curY = 0;
     m_initFont = m_font;
-    for (size_t i = 0; i < lines.size(); ++i)
+    for (auto &i : lines)
     {
-        vector<pair<Font, string>> txtParts = processTxtLine(lines[i], fontStack);
-        for (size_t i = 0; i < txtParts.size(); ++i)
+        vector<pair<Font, string>> txtParts = processTxtLine(i, fontStack);
+        for (auto &j : txtParts)
         {
-            if (txtParts[i].first.m_opts & Font::FORCED)
+            if (j.first.m_opts & Font::FORCED)
                 forced = true;
         }
 
@@ -400,11 +400,11 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
         int maxHeight = 0;
         int maxBaseLine = 0;
         vector<int> xSize;
-        for (size_t j = 0; j < txtParts.size(); j++)
+        for (auto &j : txtParts)
         {
-            setFont(txtParts[j].first);
+            setFont(j.first);
             SIZE mSize;
-            getTextSize(txtParts[j].second, &mSize);
+            getTextSize(j.second, &mSize);
             ySize = FFMAX(ySize, mSize.cy);
             maxHeight = FFMAX(maxHeight, getLineSpacing());
             maxBaseLine = FFMAX(maxBaseLine, getBaseline());

--- a/tsMuxer/textSubtitlesRender.cpp
+++ b/tsMuxer/textSubtitlesRender.cpp
@@ -161,14 +161,14 @@ size_t findUnquotedStr(const string& str, const string& substr)
     if (substr.size() == 0)
         return string::npos;
     bool quote = false;
-    for (int i = 0; i < str.size(); i++)
+    for (size_t i = 0; i < str.size(); i++)
     {
         if (str[i] == '\"' || str[i] == '\'')
             quote = !quote;
         else if (!quote && str[i] == substr[0])
         {
             bool found = true;
-            for (int j = 1; j < substr.size(); j++)
+            for (size_t j = 1; j < substr.size(); j++)
             {
                 if (i + j >= str.size() || str[i + j] != substr[j])
                 {
@@ -201,7 +201,7 @@ string findFontArg(const string& text, int pos)
 {
     bool delFound = false;
     int firstPos = -1;
-    for (int i = pos; i < text.size(); i++)
+    for (size_t i = pos; i < text.size(); i++)
     {
         if (text[i] == '=')
             delFound = true;
@@ -252,7 +252,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
     vector<pair<Font, string>> rez;
     int prevTextPos = 0;
     int bStartPos = -1;
-    for (int i = 0; i < line.size(); i++)
+    for (size_t i = 0; i < line.size(); i++)
     {
         if (line[i] == '<')
             bStartPos = i;
@@ -262,7 +262,7 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
             bool endTag = false;
             string tagStr = trimStr(line.substr(bStartPos + 1, i - bStartPos - 1));
             string ltagStr = tagStr;
-            for (int j = 0; j < ltagStr.size(); j++) ltagStr[j] = towlower(ltagStr[j]);
+            for (size_t j = 0; j < ltagStr.size(); j++) ltagStr[j] = towlower(ltagStr[j]);
             if (ltagStr == "i" || ltagStr == "italic")
             {
                 curFont.m_opts |= Font::ITALIC;
@@ -371,10 +371,10 @@ vector<pair<Font, string>> TextSubtitlesRender::processTxtLine(const std::string
             bStartPos = -1;
         }
     }
-    if (line.size() > prevTextPos)
+    if (line.size() > (unsigned)prevTextPos)
         rez.push_back(make_pair(curFont, line.substr(prevTextPos, line.size() - prevTextPos)));
     double rSize = m_initFont.m_size;
-    for (int i = 0; i < rez.size(); i++) rez[i].first.m_size = browserSizeToRealSize(rez[i].first.m_size, rSize);
+    for (size_t i = 0; i < rez.size(); i++) rez[i].first.m_size = browserSizeToRealSize(rez[i].first.m_size, rSize);
     return rez;
 }
 
@@ -386,10 +386,10 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
     vector<string> lines = splitStr(text.c_str(), '\n');
     int curY = 0;
     m_initFont = m_font;
-    for (int i = 0; i < lines.size(); ++i)
+    for (size_t i = 0; i < lines.size(); ++i)
     {
         vector<pair<Font, string>> txtParts = processTxtLine(lines[i], fontStack);
-        for (int i = 0; i < txtParts.size(); ++i)
+        for (size_t i = 0; i < txtParts.size(); ++i)
         {
             if (txtParts[i].first.m_opts & Font::FORCED)
                 forced = true;
@@ -400,7 +400,7 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
         int maxHeight = 0;
         int maxBaseLine = 0;
         vector<int> xSize;
-        for (int j = 0; j < txtParts.size(); j++)
+        for (size_t j = 0; j < txtParts.size(); j++)
         {
             setFont(txtParts[j].first);
             SIZE mSize;
@@ -413,7 +413,7 @@ bool TextSubtitlesRender::rasterText(const std::string& text)
         }
         int xOffs = (m_width - tWidth) / 2;
         int curX = 0;
-        for (int j = 0; j < txtParts.size(); j++)
+        for (size_t j = 0; j < txtParts.size(); j++)
         {
             Font font(txtParts[j].first);
             setFont(font);

--- a/tsMuxer/tsDemuxer.h
+++ b/tsMuxer/tsDemuxer.h
@@ -70,7 +70,7 @@ class TSDemuxer : public AbstractDemuxer
     int64_t m_firstPTS;
     int64_t m_lastPTS;
     int64_t m_prevFileLen;
-    int m_curFileNum;
+    uint32_t m_curFileNum;
     int64_t m_firstVideoPTS;
     int64_t m_lastVideoPTS;
     int64_t m_lastVideoDTS;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -420,7 +420,7 @@ bool TSMuxer::doFlush()
         newPCR = (m_endStreamDTS - m_minDts) / INT_FREQ_TO_TS_FREQ + 0.5 + m_fixed_pcr_offset;
         if (m_cbrBitrate != -1 && m_lastPCR != -1)
         {
-            int64_t cbrPCR = m_lastPCR + m_pcrBits * 90000.0 / m_cbrBitrate + 0.5;
+            uint64_t cbrPCR = m_lastPCR + m_pcrBits * 90000.0 / m_cbrBitrate + 0.5;
             newPCR = FFMAX(newPCR, cbrPCR);
         }
     }
@@ -507,7 +507,7 @@ bool TSMuxer::close()
 int TSMuxer::calcM2tsFrameCnt()
 {
     uint32_t byteCnt = 0;
-    for (int i = 0; i < m_m2tsDelayBlocks.size(); i++) byteCnt += m_m2tsDelayBlocks[i].second;
+    for (size_t i = 0; i < m_m2tsDelayBlocks.size(); i++) byteCnt += m_m2tsDelayBlocks[i].second;
     byteCnt -= m_prevM2TSPCROffset;
     byteCnt += m_outBufLen;
     assert(byteCnt % 192 == 0);
@@ -526,7 +526,7 @@ void TSMuxer::processM2TSPCR(int64_t pcrVal, int64_t pcrGAP)
     if (m_m2tsDelayBlocks.size() > 0)
     {
         int offset = m_prevM2TSPCROffset;
-        for (int i = 0; i < m_m2tsDelayBlocks.size(); i++)
+        for (size_t i = 0; i < m_m2tsDelayBlocks.size(); i++)
         {
             curPos = m_m2tsDelayBlocks[i].first + offset;
             int j = offset;
@@ -645,7 +645,7 @@ void TSMuxer::buildPesHeader(int pesStreamID, AVPacket& avPacket, int pid)
     int bufLen = pesPacket->getHeaderLength() + additionDataSize;
     m_pesData.resize(bufLen);
     memcpy(m_pesData.data(), tmpBuffer, bufLen);
-    for (int i = 0; i < tmpPriorityData.size(); ++i)
+    for (size_t i = 0; i < tmpPriorityData.size(); ++i)
         m_priorityData.push_back(
             std::pair<int, int>(tmpPriorityData[i].first + pesPacket->getHeaderLength(), tmpPriorityData[i].second));
 }
@@ -858,7 +858,7 @@ void TSMuxer::writePESPacket()
         uint8_t* curPtr = m_pesData.data();
         uint8_t* dataEnd = curPtr + m_pesData.size();
         bool payloadStart = true;
-        for (int i = 0; i < m_priorityData.size(); ++i)
+        for (size_t i = 0; i < m_priorityData.size(); ++i)
         {
             uint8_t* blockPtr = m_pesData.data() + m_priorityData[i].first;
             if (blockPtr > curPtr)
@@ -1369,7 +1369,7 @@ void TSMuxer::writeOutBuffer()
 void TSMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (int i = 0; i < params.size(); i++)
+    for (size_t i = 0; i < params.size(); i++)
     {
         vector<string> paramPair = splitStr(trimStr(params[i]).c_str(), '=');
         if (paramPair.size() == 0)
@@ -1470,7 +1470,7 @@ void TSMuxer::openDstFile()
 vector<int64_t> TSMuxer::getFirstPts()
 {
     std::vector<int64_t> rez;
-    for (int i = 0; i < m_firstPts.size(); i++) rez.push_back(nanoClockToPts(m_firstPts[i]) + m_timeOffset);
+    for (size_t i = 0; i < m_firstPts.size(); i++) rez.push_back(nanoClockToPts(m_firstPts[i]) + m_timeOffset);
     return rez;
 }
 
@@ -1487,7 +1487,7 @@ void TSMuxer::alignPTS(TSMuxer* otherMuxer)
 vector<int64_t> TSMuxer::getLastPts()
 {
     std::vector<int64_t> rez;
-    for (int i = 0; i < m_lastPts.size(); i++) rez.push_back(nanoClockToPts(m_lastPts[i]) + m_timeOffset);
+    for (size_t i = 0; i < m_lastPts.size(); i++) rez.push_back(nanoClockToPts(m_lastPts[i]) + m_timeOffset);
     // if (!rez.empty())
     //    *rez.rbegin() += m_mainStreamFrameDuration;
     return rez;
@@ -1505,7 +1505,7 @@ void TSMuxer::setFileName(const std::string& fileName, FileFactory* fileFactory)
     m_fileNames.push_back(m_outFileName);
 }
 
-std::string TSMuxer::getFileNameByIdx(int idx)
+std::string TSMuxer::getFileNameByIdx(size_t idx)
 {
     if (idx < m_fileNames.size())
         return m_fileNames[idx];

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -507,7 +507,7 @@ bool TSMuxer::close()
 int TSMuxer::calcM2tsFrameCnt()
 {
     uint32_t byteCnt = 0;
-    for (auto &i : m_m2tsDelayBlocks) byteCnt += i.second;
+    for (auto& i : m_m2tsDelayBlocks) byteCnt += i.second;
     byteCnt -= m_prevM2TSPCROffset;
     byteCnt += m_outBufLen;
     assert(byteCnt % 192 == 0);
@@ -526,7 +526,7 @@ void TSMuxer::processM2TSPCR(int64_t pcrVal, int64_t pcrGAP)
     if (m_m2tsDelayBlocks.size() > 0)
     {
         int offset = m_prevM2TSPCROffset;
-        for (auto &i : m_m2tsDelayBlocks)
+        for (auto& i : m_m2tsDelayBlocks)
         {
             curPos = i.first + offset;
             int j = offset;
@@ -645,7 +645,7 @@ void TSMuxer::buildPesHeader(int pesStreamID, AVPacket& avPacket, int pid)
     int bufLen = pesPacket->getHeaderLength() + additionDataSize;
     m_pesData.resize(bufLen);
     memcpy(m_pesData.data(), tmpBuffer, bufLen);
-    for (auto &i : tmpPriorityData)
+    for (auto& i : tmpPriorityData)
         m_priorityData.push_back(
             std::pair<int, int>(i.first + pesPacket->getHeaderLength(), i.second));
 }
@@ -858,7 +858,7 @@ void TSMuxer::writePESPacket()
         uint8_t* curPtr = m_pesData.data();
         uint8_t* dataEnd = curPtr + m_pesData.size();
         bool payloadStart = true;
-        for (auto &i : m_priorityData)
+        for (auto& i : m_priorityData)
         {
             uint8_t* blockPtr = m_pesData.data() + i.first;
             if (blockPtr > curPtr)
@@ -1369,7 +1369,7 @@ void TSMuxer::writeOutBuffer()
 void TSMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (auto &i : params)
+    for (auto& i : params)
     {
         vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)
@@ -1400,7 +1400,7 @@ void TSMuxer::parseMuxOpt(const std::string& opts)
         {
             uint64_t coeff = 1;
             string postfix;
-            for (auto &j : paramPair[1])
+            for (auto& j : paramPair[1])
                 if (!(j >= '0' && j <= '9' || j == '.'))
                     postfix += j;
             postfix = strToUpperCase(postfix);
@@ -1470,7 +1470,7 @@ void TSMuxer::openDstFile()
 vector<int64_t> TSMuxer::getFirstPts()
 {
     std::vector<int64_t> rez;
-    for (auto &i : m_firstPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
+    for (auto& i : m_firstPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
     return rez;
 }
 
@@ -1487,7 +1487,7 @@ void TSMuxer::alignPTS(TSMuxer* otherMuxer)
 vector<int64_t> TSMuxer::getLastPts()
 {
     std::vector<int64_t> rez;
-    for (auto &i : m_lastPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
+    for (auto& i : m_lastPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
     // if (!rez.empty())
     //    *rez.rbegin() += m_mainStreamFrameDuration;
     return rez;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -507,7 +507,7 @@ bool TSMuxer::close()
 int TSMuxer::calcM2tsFrameCnt()
 {
     uint32_t byteCnt = 0;
-    for (size_t i = 0; i < m_m2tsDelayBlocks.size(); i++) byteCnt += m_m2tsDelayBlocks[i].second;
+    for (auto &i : m_m2tsDelayBlocks) byteCnt += i.second;
     byteCnt -= m_prevM2TSPCROffset;
     byteCnt += m_outBufLen;
     assert(byteCnt % 192 == 0);
@@ -526,24 +526,24 @@ void TSMuxer::processM2TSPCR(int64_t pcrVal, int64_t pcrGAP)
     if (m_m2tsDelayBlocks.size() > 0)
     {
         int offset = m_prevM2TSPCROffset;
-        for (size_t i = 0; i < m_m2tsDelayBlocks.size(); i++)
+        for (auto &i : m_m2tsDelayBlocks)
         {
-            curPos = m_m2tsDelayBlocks[i].first + offset;
+            curPos = i.first + offset;
             int j = offset;
-            for (; j < m_m2tsDelayBlocks[i].second; j += 192)
+            for (; j < i.second; j += 192)
             {
                 curM2TSPCR += pcrIncPerFrame;
                 writeM2TSHeader(curPos, (uint64_t)curM2TSPCR);
                 curPos += 192;
             }
             if (m_owner->isAsyncMode())
-                m_owner->asyncWriteBuffer(this, m_m2tsDelayBlocks[i].first, m_m2tsDelayBlocks[i].second, m_muxFile);
+                m_owner->asyncWriteBuffer(this, i.first, i.second, m_muxFile);
             else
             {
-                m_owner->syncWriteBuffer(this, m_m2tsDelayBlocks[i].first, m_m2tsDelayBlocks[i].second, m_muxFile);
-                delete[] m_m2tsDelayBlocks[i].first;
+                m_owner->syncWriteBuffer(this, i.first, i.second, m_muxFile);
+                delete[] i.first;
             }
-            offset = j - m_m2tsDelayBlocks[i].second;
+            offset = j - i.second;
         }
         m_prevM2TSPCROffset = offset;
         m_m2tsDelayBlocks.clear();
@@ -645,9 +645,9 @@ void TSMuxer::buildPesHeader(int pesStreamID, AVPacket& avPacket, int pid)
     int bufLen = pesPacket->getHeaderLength() + additionDataSize;
     m_pesData.resize(bufLen);
     memcpy(m_pesData.data(), tmpBuffer, bufLen);
-    for (size_t i = 0; i < tmpPriorityData.size(); ++i)
+    for (auto &i : tmpPriorityData)
         m_priorityData.push_back(
-            std::pair<int, int>(tmpPriorityData[i].first + pesPacket->getHeaderLength(), tmpPriorityData[i].second));
+            std::pair<int, int>(i.first + pesPacket->getHeaderLength(), i.second));
 }
 
 void TSMuxer::addData(int pesStreamID, int pid, AVPacket& avPacket)
@@ -858,16 +858,16 @@ void TSMuxer::writePESPacket()
         uint8_t* curPtr = m_pesData.data();
         uint8_t* dataEnd = curPtr + m_pesData.size();
         bool payloadStart = true;
-        for (size_t i = 0; i < m_priorityData.size(); ++i)
+        for (auto &i : m_priorityData)
         {
-            uint8_t* blockPtr = m_pesData.data() + m_priorityData[i].first;
+            uint8_t* blockPtr = m_pesData.data() + i.first;
             if (blockPtr > curPtr)
             {
                 tsPackets += writeTSFrames(m_pesPID, curPtr, blockPtr - curPtr, false, payloadStart);
                 payloadStart = false;
             }
-            tsPackets += writeTSFrames(m_pesPID, blockPtr, m_priorityData[i].second, true, payloadStart);
-            curPtr = blockPtr + m_priorityData[i].second;
+            tsPackets += writeTSFrames(m_pesPID, blockPtr, i.second, true, payloadStart);
+            curPtr = blockPtr + i.second;
         }
         tsPackets += writeTSFrames(m_pesPID, curPtr, dataEnd - curPtr, false, payloadStart);
 
@@ -1369,9 +1369,9 @@ void TSMuxer::writeOutBuffer()
 void TSMuxer::parseMuxOpt(const std::string& opts)
 {
     vector<string> params = splitStr(opts.c_str(), ' ');
-    for (size_t i = 0; i < params.size(); i++)
+    for (auto &i : params)
     {
-        vector<string> paramPair = splitStr(trimStr(params[i]).c_str(), '=');
+        vector<string> paramPair = splitStr(trimStr(i).c_str(), '=');
         if (paramPair.size() == 0)
             continue;
         if (paramPair[0] == "--pcr-on-video-pid")
@@ -1400,9 +1400,9 @@ void TSMuxer::parseMuxOpt(const std::string& opts)
         {
             uint64_t coeff = 1;
             string postfix;
-            for (int i = paramPair[1].size() - 1; i >= 0; i--)
-                if (!(paramPair[1][i] >= '0' && paramPair[1][i] <= '9' || paramPair[1][i] == '.'))
-                    postfix = paramPair[1][i] + postfix;
+            for (auto &j : paramPair[1])
+                if (!(j >= '0' && j <= '9' || j == '.'))
+                    postfix += j;
             postfix = strToUpperCase(postfix);
             if (postfix == "GB")
                 coeff = 1000000000ull;
@@ -1470,7 +1470,7 @@ void TSMuxer::openDstFile()
 vector<int64_t> TSMuxer::getFirstPts()
 {
     std::vector<int64_t> rez;
-    for (size_t i = 0; i < m_firstPts.size(); i++) rez.push_back(nanoClockToPts(m_firstPts[i]) + m_timeOffset);
+    for (auto &i : m_firstPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
     return rez;
 }
 
@@ -1487,7 +1487,7 @@ void TSMuxer::alignPTS(TSMuxer* otherMuxer)
 vector<int64_t> TSMuxer::getLastPts()
 {
     std::vector<int64_t> rez;
-    for (size_t i = 0; i < m_lastPts.size(); i++) rez.push_back(nanoClockToPts(m_lastPts[i]) + m_timeOffset);
+    for (auto &i : m_lastPts) rez.push_back(nanoClockToPts(i) + m_timeOffset);
     // if (!rez.empty())
     //    *rez.rbegin() += m_mainStreamFrameDuration;
     return rez;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -646,8 +646,7 @@ void TSMuxer::buildPesHeader(int pesStreamID, AVPacket& avPacket, int pid)
     m_pesData.resize(bufLen);
     memcpy(m_pesData.data(), tmpBuffer, bufLen);
     for (auto& i : tmpPriorityData)
-        m_priorityData.push_back(
-            std::pair<int, int>(i.first + pesPacket->getHeaderLength(), i.second));
+        m_priorityData.push_back(std::pair<int, int>(i.first + pesPacket->getHeaderLength(), i.second));
 }
 
 void TSMuxer::addData(int pesStreamID, int pid, AVPacket& avPacket)

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -55,14 +55,14 @@ class TSMuxer : public AbstractMuxer
     std::vector<int64_t> getFirstPts();
     void alignPTS(TSMuxer* otherMuxer);
     std::vector<int64_t> getLastPts();
-    const std::vector<int64_t>& getMuxedPacketCnt() { return m_muxedPacketCnt; }
-    int splitFileCnt() const { return m_fileNames.size(); }
+    const std::vector<uint64_t>& getMuxedPacketCnt() { return m_muxedPacketCnt; }
+    size_t splitFileCnt() const { return m_fileNames.size(); }
     void setSplitDuration(uint64_t value) { m_splitDuration = value; }
     void setSplitSize(uint64_t value) { m_splitSize = value; }
     void parseMuxOpt(const std::string& opts) override;
 
     void setFileName(const std::string& fileName, FileFactory* fileFactory) override;
-    std::string getFileNameByIdx(int idx);
+    std::string getFileNameByIdx(size_t idx);
     int getFirstFileNum() const;
     bool isInterleaveMode() const;
     std::vector<int32_t> getInterleaveInfo(int idx) const;
@@ -194,7 +194,7 @@ class TSMuxer : public AbstractMuxer
     int64_t m_lastMuxedDts;
     MemoryBlock m_pesData;
     int m_pesPID;
-    std::vector<int64_t> m_muxedPacketCnt;
+    std::vector<uint64_t> m_muxedPacketCnt;
     bool m_pesIFrame;
     bool m_pesSpsPps;
     bool m_computeMuxStats;
@@ -204,7 +204,7 @@ class TSMuxer : public AbstractMuxer
     int m_mainStreamIndex;
 
     std::string m_outFileName;
-    int m_writeBlockSize;
+    unsigned m_writeBlockSize;
     int m_frameSize;
     int64_t m_processedBlockSize;
     TSMuxer* m_sublingMuxer;

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -908,7 +908,7 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     for (auto& i : processStream)
     {
         writer.putBits(16, i.streamPID);  // stream_PID[k] 16 bslbf
-        writer.putBits(10, 0);                           // reserved_for_word_align 10 bslbf
+        writer.putBits(10, 0);            // reserved_for_word_align 10 bslbf
         writer.putBits(4, EP_stream_type);
         std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(i);
         writer.putBits(16, coarseInfo.size());  // number_of_EP_coarse_entries[k] 16 uimsbf

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -905,7 +905,7 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     writer.putBits(8, processStream.size());  // number_of_stream_PID_entries 8 uimsbf
     std::vector<uint32_t*> epStartAddrPos;
 
-    for (auto &i : processStream)
+    for (auto& i : processStream)
     {
         writer.putBits(16, i.streamPID);  // stream_PID[k] 16 bslbf
         writer.putBits(10, 0);                           // reserved_for_word_align 10 bslbf
@@ -961,7 +961,7 @@ void CLPIParser::composeEP_map_for_one_stream_PID(BitStreamWriter& writer, M2TSS
     uint32_t beforePos = writer.getBitsCount() / 8;
     writer.putBits(32, 0);  // EP_fine_table_start_address 32 uimsbf
     std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(streamInfo);
-    for (auto &i : coarseInfo)
+    for (auto& i : coarseInfo)
     {
         writer.putBits(18, i.m_fineRefID);  // ref_to_EP_fine_id[i] 18 uimsbf
         writer.putBits(14, i.m_coarsePts);  // PTS_EP_coarse[i] 14 uimsbf
@@ -1091,7 +1091,7 @@ void CLPIParser::composeExtentStartPoint(BitStreamWriter& writer)
     writer.putBits(16, interleaveInfo.size());
 
     uint32_t sum = 0;
-    for (auto &i : interleaveInfo)
+    for (auto& i : interleaveInfo)
     {
         sum += i;
         writer.putBits(32, sum);
@@ -1471,7 +1471,7 @@ int MPLSParser::composeUHD_metadata(uint8_t* buffer, int bufferSize)
 
 int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 {
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -1668,13 +1668,13 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
 
 MPLSStreamInfo& MPLSParser::getMainStream()
 {
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int coding_type = i.stream_coding_type;
         if (isVideoStreamType(coding_type))
             return i;
     }
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int coding_type = i.stream_coding_type;
         if (isAudioStreamType(coding_type))
@@ -1699,7 +1699,7 @@ int MPLSParser::pgIndexToFullIndex(int value)
 
 MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 {
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         if (i.streamPID == pid)
             return i;
@@ -1710,7 +1710,7 @@ MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 std::vector<MPLSStreamInfo> MPLSParser::getPgStreams() const
 {
     std::vector<MPLSStreamInfo> pgStreams;
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int coding_type = i.stream_coding_type;
         if (coding_type == 0x90)
@@ -1721,7 +1721,7 @@ std::vector<MPLSStreamInfo> MPLSParser::getPgStreams() const
 
 MPLSStreamInfo& MPLSParser::getMVCDependStream()
 {
-    for (auto &i : m_streamInfoMVC)
+    for (auto& i : m_streamInfoMVC)
     {
         int coding_type = i.stream_coding_type;
         if (coding_type == 0x20)
@@ -1849,7 +1849,7 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
     vector<MPLSStreamInfo> pipStreams;
     int mainVSize = 0;
     int mainHSize = 0;
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -2144,7 +2144,7 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
         for (size_t i = 0; i < extDataBlockInfo.size(); ++i)
         {
             *(extDataStartAddrPos[i]) = my_htonl(writer.getBitsCount() / 8 - initPos + 4);
-            for (auto &j : extDataBlockInfo[i].data) writer.putBits(8, j);
+            for (auto& j : extDataBlockInfo[i].data) writer.putBits(8, j);
         }
     }
 
@@ -2291,7 +2291,7 @@ void MPLSParser::composePlayListMark(BitStreamWriter& writer)
         }
     }
     writer.putBits(16, m_marks.size());  // 16 uimsbf
-    for (auto &i : m_marks)
+    for (auto& i : m_marks)
     {
         writer.putBits(8, 0);  // reserved_for_future_use 8 bslbf
         writer.putBits(8, 1);  // mark_type 0x01 = Chapter search
@@ -2346,7 +2346,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     std::vector<MPLSStreamInfo>& streamInfo = isSSEx ? m_streamInfoMVC : m_streamInfo;
 
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -2388,7 +2388,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     // if (number_of_SubPaths == 0)
 
     // video
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type) && !i.isSecondary && i.HDR != 4)
@@ -2404,7 +2404,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // primary audio
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isAudioStreamType(stream_coding_type) && !i.isSecondary)
@@ -2415,7 +2415,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // PG
-    for (auto &i : m_streamInfo)
+    for (auto& i : m_streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (stream_coding_type == 0x90)
@@ -2433,7 +2433,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // secondary audio
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isAudioStreamType(stream_coding_type) && i.isSecondary)
@@ -2446,7 +2446,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
                                                                             // allowed to join with this stream
                 writer.putBits(8, 0);                                       // word align
                 uint8_t primaryAudioNum = 0;
-                for (auto &j : streamInfo)
+                for (auto& j : streamInfo)
                 {
                     int stream_coding_type = j.stream_coding_type;
                     if (isAudioStreamType(stream_coding_type) && !j.isSecondary)
@@ -2464,7 +2464,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     // secondary video
     int secondaryVNum = 0;
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (i.isSecondary && isVideoStreamType(stream_coding_type))
@@ -2492,7 +2492,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // DV video
-    for (auto &i : streamInfo)
+    for (auto& i : streamInfo)
     {
         int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type) && i.HDR == 4)

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -115,7 +115,7 @@ bool TS_program_association_section::deserialize(uint8_t* buffer, int buf_size)
         bitReader.skipBits(2);  // reserved
 
         unsigned section_length = bitReader.getBits(12);
-        int crcBit = bitReader.getBitsCount() + (section_length - 4) * 8;
+        unsigned crcBit = bitReader.getBitsCount() + (section_length - 4) * 8;
 
         transport_stream_id = bitReader.getBits(16);
         bitReader.skipBits(2);  // reserved
@@ -905,7 +905,7 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     writer.putBits(8, processStream.size());  // number_of_stream_PID_entries 8 uimsbf
     std::vector<uint32_t*> epStartAddrPos;
 
-    for (int i = 0; i < processStream.size(); i++)
+    for (size_t i = 0; i < processStream.size(); i++)
     {
         writer.putBits(16, processStream[i].streamPID);  // stream_PID[k] 16 bslbf
         writer.putBits(10, 0);                           // reserved_for_word_align 10 bslbf
@@ -921,7 +921,7 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     }
     while (writer.getBitsCount() % 16 != 0) writer.putBits(8, 0);  // padding_word 16 bslbf
 
-    for (int i = 0; i < processStream.size(); i++)
+    for (size_t i = 0; i < processStream.size(); i++)
     {
         *epStartAddrPos[i] = my_htonl(writer.getBitsCount() / 8 - beforeCount);
         composeEP_map_for_one_stream_PID(writer, processStream[i]);
@@ -961,7 +961,7 @@ void CLPIParser::composeEP_map_for_one_stream_PID(BitStreamWriter& writer, M2TSS
     uint32_t beforePos = writer.getBitsCount() / 8;
     writer.putBits(32, 0);  // EP_fine_table_start_address 32 uimsbf
     std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(streamInfo);
-    for (int i = 0; i < coarseInfo.size(); i++)
+    for (size_t i = 0; i < coarseInfo.size(); i++)
     {
         writer.putBits(18, coarseInfo[i].m_fineRefID);  // ref_to_EP_fine_id[i] 18 uimsbf
         writer.putBits(14, coarseInfo[i].m_coarsePts);  // PTS_EP_coarse[i] 14 uimsbf
@@ -1091,7 +1091,7 @@ void CLPIParser::composeExtentStartPoint(BitStreamWriter& writer)
     writer.putBits(16, interleaveInfo.size());
 
     uint32_t sum = 0;
-    for (int i = 0; i < interleaveInfo.size(); ++i)
+    for (size_t i = 0; i < interleaveInfo.size(); ++i)
     {
         sum += interleaveInfo[i];
         writer.putBits(32, sum);
@@ -1190,7 +1190,7 @@ void CLPIParser::parseExtensionData(uint8_t* buffer, uint8_t* end)
         uint32_t dataAddress = reader.getBits(32);
         uint32_t dataLength = reader.getBits(32);
 
-        if (dataAddress + dataLength > end - buffer)
+        if (dataAddress + dataLength > (uint32_t)(end - buffer))
         {
             LTRACE(LT_WARN, 2, "Invalid extended clip info entry skipped.");
             continue;
@@ -1397,7 +1397,7 @@ void MPLSParser::SubPath_extension(BitStreamWriter& writer)
 
     std::vector<PMTIndex> pmtIndexList = getMVCDependStream().m_index;
     writer.putBits(8, pmtIndexList.size());  // number_of_SubPlayItems
-    for (int i = 0; i < pmtIndexList.size(); i++) composeSubPlayItem(writer, i, 0, pmtIndexList);
+    for (size_t i = 0; i < pmtIndexList.size(); i++) composeSubPlayItem(writer, i, 0, pmtIndexList);
 
     *lengthPos = my_htonl(writer.getBitsCount() / 8 - beforeCount);
 }
@@ -1436,7 +1436,7 @@ int MPLSParser::composeSTN_tableSS(uint8_t* buffer, int bufferSize)
     try
     {
         MPLSStreamInfo streamInfoMVC = getMVCDependStream();
-        for (int PlayItem_id = 0; PlayItem_id < streamInfoMVC.m_index.size(); PlayItem_id++)
+        for (size_t PlayItem_id = 0; PlayItem_id < streamInfoMVC.m_index.size(); PlayItem_id++)
         {
             composeSTN_table(writer, PlayItem_id, true);
             // connection_condition = 6;
@@ -1471,7 +1471,7 @@ int MPLSParser::composeUHD_metadata(uint8_t* buffer, int bufferSize)
 
 int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 {
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int stream_coding_type = m_streamInfo[i].stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -1668,13 +1668,13 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
 
 MPLSStreamInfo& MPLSParser::getMainStream()
 {
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int coding_type = m_streamInfo[i].stream_coding_type;
         if (isVideoStreamType(coding_type))
             return m_streamInfo[i];
     }
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int coding_type = m_streamInfo[i].stream_coding_type;
         if (isAudioStreamType(coding_type))
@@ -1688,7 +1688,7 @@ MPLSStreamInfo& MPLSParser::getMainStream()
 int MPLSParser::pgIndexToFullIndex(int value)
 {
     int cnt = 0;
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         if (m_streamInfo[i].stream_coding_type == 0x90)
         {
@@ -1701,7 +1701,7 @@ int MPLSParser::pgIndexToFullIndex(int value)
 
 MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 {
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         if (m_streamInfo[i].streamPID == pid)
             return m_streamInfo[i];
@@ -1712,7 +1712,7 @@ MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 std::vector<MPLSStreamInfo> MPLSParser::getPgStreams() const
 {
     std::vector<MPLSStreamInfo> pgStreams;
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int coding_type = m_streamInfo[i].stream_coding_type;
         if (coding_type == 0x90)
@@ -1723,7 +1723,7 @@ std::vector<MPLSStreamInfo> MPLSParser::getPgStreams() const
 
 MPLSStreamInfo& MPLSParser::getMVCDependStream()
 {
-    for (int i = 0; i < m_streamInfoMVC.size(); i++)
+    for (size_t i = 0; i < m_streamInfoMVC.size(); i++)
     {
         int coding_type = m_streamInfoMVC[i].stream_coding_type;
         if (coding_type == 0x20)
@@ -1743,7 +1743,7 @@ void MPLSParser::composePlayList(BitStreamWriter& writer)
     writer.putBits(16, mainStreamInfo.m_index.size());  // 16 uimsbf number_of_PlayItems
     writer.putBits(16, number_of_SubPaths);             // number_of_SubPaths
     // connection_condition = 1;
-    for (int PlayItem_id = 0; PlayItem_id < mainStreamInfo.m_index.size(); PlayItem_id++)
+    for (size_t PlayItem_id = 0; PlayItem_id < mainStreamInfo.m_index.size(); PlayItem_id++)
     {
         composePlayItem(writer, PlayItem_id, mainStreamInfo.m_index);
         // connection_condition = 6;
@@ -1751,7 +1751,7 @@ void MPLSParser::composePlayList(BitStreamWriter& writer)
 
     MPLSStreamInfo& dependStreamInfo = mainStreamInfo;
 
-    for (int SubPath_id = 0; SubPath_id < number_of_SubPaths * dependStreamInfo.m_index.size(); SubPath_id++)
+    for (size_t SubPath_id = 0; SubPath_id < number_of_SubPaths * dependStreamInfo.m_index.size(); SubPath_id++)
     {
         composeSubPath(writer, SubPath_id, dependStreamInfo.m_index, subPath_type);  // pip
     }
@@ -1782,7 +1782,7 @@ void MPLSParser::composeSubPath(BitStreamWriter& writer, int subPathNum, std::ve
     }
     */
     writer.putBits(8, pmtIndexList.size());  // number_of_SubPlayItems
-    for (int i = 0; i < pmtIndexList.size(); i++)
+    for (size_t i = 0; i < pmtIndexList.size(); i++)
     {
         composeSubPlayItem(writer, i, subPathNum, pmtIndexList);
     }
@@ -1851,7 +1851,7 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
     vector<MPLSStreamInfo> pipStreams;
     int mainVSize = 0;
     int mainHSize = 0;
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int stream_coding_type = m_streamInfo[i].stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -1870,9 +1870,9 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
 
     writer.putBits(16, pipStreams.size() * pmtIndexList.size());
     vector<uint32_t*> blockDataAddressPos;
-    for (int i = 0; i < pmtIndexList.size(); ++i)
+    for (size_t i = 0; i < pmtIndexList.size(); ++i)
     {
-        for (int k = 0; k < pipStreams.size(); k++)
+        for (size_t k = 0; k < pipStreams.size(); k++)
         {
             PIPParams pipParams = pipStreams[k].pipParams;
             // metadata_block_header[k]() {
@@ -1899,9 +1899,9 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
         }
     }
     while (writer.getBitsCount() % 16 != 0) writer.putBit(0);
-    for (int i = 0; i < pmtIndexList.size(); ++i)
+    for (size_t i = 0; i < pmtIndexList.size(); ++i)
     {
-        for (int k = 0; k < pipStreams.size(); k++)
+        for (size_t k = 0; k < pipStreams.size(); k++)
         {
             PIPParams pipParams = pipStreams[k].pipParams;
 
@@ -2093,13 +2093,13 @@ void MPLSParser::parseExtensionData(uint8_t* data, uint8_t* dataEnd)
             uint32_t dataAddress = reader.getBits(32);
             uint32_t dataLength = reader.getBits(32);
 
-            if (dataAddress + dataLength > dataEnd - data)
+            if (dataAddress + dataLength > (uint32_t)(dataEnd - data))
             {
                 LTRACE(LT_WARN, 2, "Invalid playlist extension entry skipped.");
                 continue;
             }
 
-            if (dataAddress + dataLength > dataEnd - data)
+            if (dataAddress + dataLength > (uint32_t)(dataEnd - data))
                 continue;  // invalid entry
 
             switch (dataID)
@@ -2133,7 +2133,7 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
         writer.putBits(32, 0);  // data_block_start_address
         writer.putBits(24, 0);  // reserved_for_word_align
         writer.putBits(8, extDataBlockInfo.size());
-        for (int i = 0; i < extDataBlockInfo.size(); i++)
+        for (size_t i = 0; i < extDataBlockInfo.size(); i++)
         {
             writer.putBits(16, extDataBlockInfo[i].id1);
             writer.putBits(16, extDataBlockInfo[i].id2);
@@ -2143,10 +2143,10 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
         }
         while ((writer.getBitsCount() / 8 - initPos) % 4 != 0) writer.putBits(16, 0);
         *(lengthPos + 1) = my_htonl(writer.getBitsCount() / 8 - initPos + 4);  // data_block_start_address
-        for (int i = 0; i < extDataBlockInfo.size(); i++)
+        for (size_t i = 0; i < extDataBlockInfo.size(); i++)
         {
             *(extDataStartAddrPos[i]) = my_htonl(writer.getBitsCount() / 8 - initPos + 4);
-            for (int j = 0; j < extDataBlockInfo[i].data.size(); ++j) writer.putBits(8, extDataBlockInfo[i].data[j]);
+            for (size_t j = 0; j < extDataBlockInfo[i].data.size(); ++j) writer.putBits(8, extDataBlockInfo[i].data[j]);
         }
     }
 
@@ -2266,7 +2266,7 @@ void MPLSParser::parsePlayListMark(uint8_t* buffer, int len)
 
 int MPLSParser::calcPlayItemID(MPLSStreamInfo& streamInfo, uint32_t pts)
 {
-    for (int i = 0; i < streamInfo.m_index.size(); i++)
+    for (size_t i = 0; i < streamInfo.m_index.size(); i++)
     {
         if (streamInfo.m_index[i].size() > 0)
         {
@@ -2289,11 +2289,11 @@ void MPLSParser::composePlayListMark(BitStreamWriter& writer)
             m_marks.push_back(PlayListMark(-1, IN_time));
         else
         {
-            for (int i = IN_time; i < OUT_time; i += m_chapterLen * 45000) m_marks.push_back(PlayListMark(-1, i));
+            for (size_t i = IN_time; i < OUT_time; i += m_chapterLen * 45000) m_marks.push_back(PlayListMark(-1, i));
         }
     }
     writer.putBits(16, m_marks.size());  // 16 uimsbf
-    for (int i = 0; i < m_marks.size(); i++)
+    for (size_t i = 0; i < m_marks.size(); i++)
     {
         writer.putBits(8, 0);  // reserved_for_future_use 8 bslbf
         writer.putBits(8, 1);  // mark_type 0x01 = Chapter search
@@ -2348,7 +2348,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     std::vector<MPLSStreamInfo>& streamInfo = isSSEx ? m_streamInfoMVC : m_streamInfo;
 
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
@@ -2390,7 +2390,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     // if (number_of_SubPaths == 0)
 
     // video
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (isVideoStreamType(stream_coding_type) && !streamInfo[i].isSecondary && streamInfo[i].HDR != 4)
@@ -2406,7 +2406,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // primary audio
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (isAudioStreamType(stream_coding_type) && !streamInfo[i].isSecondary)
@@ -2417,7 +2417,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // PG
-    for (int i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); i++)
     {
         int stream_coding_type = m_streamInfo[i].stream_coding_type;
         if (stream_coding_type == 0x90)
@@ -2435,7 +2435,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // secondary audio
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (isAudioStreamType(stream_coding_type) && streamInfo[i].isSecondary)
@@ -2448,7 +2448,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
                                                                             // allowed to join with this stream
                 writer.putBits(8, 0);                                       // word align
                 uint8_t primaryAudioNum = 0;
-                for (int j = 0; j < streamInfo.size(); j++)
+                for (size_t j = 0; j < streamInfo.size(); j++)
                 {
                     int stream_coding_type = streamInfo[j].stream_coding_type;
                     if (isAudioStreamType(stream_coding_type) && !streamInfo[j].isSecondary)
@@ -2466,7 +2466,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     // secondary video
     int secondaryVNum = 0;
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (streamInfo[i].isSecondary && isVideoStreamType(stream_coding_type))
@@ -2494,7 +2494,7 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // DV video
-    for (int i = 0; i < streamInfo.size(); i++)
+    for (size_t i = 0; i < streamInfo.size(); i++)
     {
         int stream_coding_type = streamInfo[i].stream_coding_type;
         if (isVideoStreamType(stream_coding_type) && streamInfo[i].HDR == 4)

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -905,15 +905,15 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     writer.putBits(8, processStream.size());  // number_of_stream_PID_entries 8 uimsbf
     std::vector<uint32_t*> epStartAddrPos;
 
-    for (size_t i = 0; i < processStream.size(); i++)
+    for (auto &i : processStream)
     {
-        writer.putBits(16, processStream[i].streamPID);  // stream_PID[k] 16 bslbf
+        writer.putBits(16, i.streamPID);  // stream_PID[k] 16 bslbf
         writer.putBits(10, 0);                           // reserved_for_word_align 10 bslbf
         writer.putBits(4, EP_stream_type);
-        std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(processStream[i]);
+        std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(i);
         writer.putBits(16, coarseInfo.size());  // number_of_EP_coarse_entries[k] 16 uimsbf
-        if (processStream[i].m_index.size() > 0)
-            writer.putBits(18, processStream[i].m_index[m_clpiNum].size());  // number_of_EP_fine_entries[k] 18 uimsbf
+        if (i.m_index.size() > 0)
+            writer.putBits(18, i.m_index[m_clpiNum].size());  // number_of_EP_fine_entries[k] 18 uimsbf
         else
             writer.putBits(18, 0);
         epStartAddrPos.push_back((uint32_t*)(writer.getBuffer() + writer.getBitsCount() / 8));
@@ -921,7 +921,7 @@ void CLPIParser::composeEP_map(BitStreamWriter& writer, bool isSSExt)
     }
     while (writer.getBitsCount() % 16 != 0) writer.putBits(8, 0);  // padding_word 16 bslbf
 
-    for (size_t i = 0; i < processStream.size(); i++)
+    for (size_t i = 0; i < processStream.size(); ++i)
     {
         *epStartAddrPos[i] = my_htonl(writer.getBitsCount() / 8 - beforeCount);
         composeEP_map_for_one_stream_PID(writer, processStream[i]);
@@ -961,11 +961,11 @@ void CLPIParser::composeEP_map_for_one_stream_PID(BitStreamWriter& writer, M2TSS
     uint32_t beforePos = writer.getBitsCount() / 8;
     writer.putBits(32, 0);  // EP_fine_table_start_address 32 uimsbf
     std::vector<BluRayCoarseInfo> coarseInfo = buildCoarseInfo(streamInfo);
-    for (size_t i = 0; i < coarseInfo.size(); i++)
+    for (auto &i : coarseInfo)
     {
-        writer.putBits(18, coarseInfo[i].m_fineRefID);  // ref_to_EP_fine_id[i] 18 uimsbf
-        writer.putBits(14, coarseInfo[i].m_coarsePts);  // PTS_EP_coarse[i] 14 uimsbf
-        writer.putBits(32, coarseInfo[i].m_pktCnt);     // SPN_EP_coarse[i] 32 uimsbf
+        writer.putBits(18, i.m_fineRefID);  // ref_to_EP_fine_id[i] 18 uimsbf
+        writer.putBits(14, i.m_coarsePts);  // PTS_EP_coarse[i] 14 uimsbf
+        writer.putBits(32, i.m_pktCnt);     // SPN_EP_coarse[i] 32 uimsbf
     }
     while (writer.getBitsCount() % 16 != 0) writer.putBits(8, 0);  // padding_word 16 bslbf
     *epFineStartAddr = my_htonl(writer.getBitsCount() / 8 - beforePos);
@@ -1091,9 +1091,9 @@ void CLPIParser::composeExtentStartPoint(BitStreamWriter& writer)
     writer.putBits(16, interleaveInfo.size());
 
     uint32_t sum = 0;
-    for (size_t i = 0; i < interleaveInfo.size(); ++i)
+    for (auto &i : interleaveInfo)
     {
-        sum += interleaveInfo[i];
+        sum += i;
         writer.putBits(32, sum);
     }
 
@@ -1397,7 +1397,7 @@ void MPLSParser::SubPath_extension(BitStreamWriter& writer)
 
     std::vector<PMTIndex> pmtIndexList = getMVCDependStream().m_index;
     writer.putBits(8, pmtIndexList.size());  // number_of_SubPlayItems
-    for (size_t i = 0; i < pmtIndexList.size(); i++) composeSubPlayItem(writer, i, 0, pmtIndexList);
+    for (size_t i = 0; i < pmtIndexList.size(); ++i) composeSubPlayItem(writer, i, 0, pmtIndexList);
 
     *lengthPos = my_htonl(writer.getBitsCount() / 8 - beforeCount);
 }
@@ -1471,17 +1471,17 @@ int MPLSParser::composeUHD_metadata(uint8_t* buffer, int bufferSize)
 
 int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 {
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int stream_coding_type = m_streamInfo[i].stream_coding_type;
+        int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
         {
-            if (m_streamInfo[i].isSecondary)
+            if (i.isSecondary)
             {
                 number_of_SubPaths++;
                 subPath_type = 7;  // PIP not fully implemented yet
             }
-            else if (m_streamInfo[i].HDR & 4)
+            else if (i.HDR & 4)
             {
                 number_of_SubPaths++;
                 subPath_type = 10;
@@ -1668,19 +1668,17 @@ void MPLSParser::parsePlayList(uint8_t* buffer, int len)
 
 MPLSStreamInfo& MPLSParser::getMainStream()
 {
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int coding_type = m_streamInfo[i].stream_coding_type;
+        int coding_type = i.stream_coding_type;
         if (isVideoStreamType(coding_type))
-            return m_streamInfo[i];
+            return i;
     }
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int coding_type = m_streamInfo[i].stream_coding_type;
+        int coding_type = i.stream_coding_type;
         if (isAudioStreamType(coding_type))
-        {
-            return m_streamInfo[i];
-        }
+            return i;
     }
     THROW(ERR_COMMON, "Can't find stream index. One audio or video stream is needed.");
 }
@@ -1688,7 +1686,7 @@ MPLSStreamInfo& MPLSParser::getMainStream()
 int MPLSParser::pgIndexToFullIndex(int value)
 {
     int cnt = 0;
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (size_t i = 0; i < m_streamInfo.size(); ++i)
     {
         if (m_streamInfo[i].stream_coding_type == 0x90)
         {
@@ -1701,10 +1699,10 @@ int MPLSParser::pgIndexToFullIndex(int value)
 
 MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 {
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        if (m_streamInfo[i].streamPID == pid)
-            return m_streamInfo[i];
+        if (i.streamPID == pid)
+            return i;
     }
     return MPLSStreamInfo();
 }
@@ -1712,22 +1710,22 @@ MPLSStreamInfo MPLSParser::getStreamByPID(int pid) const
 std::vector<MPLSStreamInfo> MPLSParser::getPgStreams() const
 {
     std::vector<MPLSStreamInfo> pgStreams;
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int coding_type = m_streamInfo[i].stream_coding_type;
+        int coding_type = i.stream_coding_type;
         if (coding_type == 0x90)
-            pgStreams.push_back(m_streamInfo[i]);
+            pgStreams.push_back(i);
     }
     return pgStreams;
 }
 
 MPLSStreamInfo& MPLSParser::getMVCDependStream()
 {
-    for (size_t i = 0; i < m_streamInfoMVC.size(); i++)
+    for (auto &i : m_streamInfoMVC)
     {
-        int coding_type = m_streamInfoMVC[i].stream_coding_type;
+        int coding_type = i.stream_coding_type;
         if (coding_type == 0x20)
-            return m_streamInfoMVC[i];
+            return i;
     }
     THROW(ERR_COMMON, "Can't find stream index. One audio or video stream is needed.");
 }
@@ -1851,19 +1849,19 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
     vector<MPLSStreamInfo> pipStreams;
     int mainVSize = 0;
     int mainHSize = 0;
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int stream_coding_type = m_streamInfo[i].stream_coding_type;
+        int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
         {
-            if (m_streamInfo[i].isSecondary)
+            if (i.isSecondary)
             {
-                pipStreams.push_back(m_streamInfo[i]);
+                pipStreams.push_back(i);
             }
             else
             {
-                mainHSize = m_streamInfo[i].width;
-                mainVSize = m_streamInfo[i].height;
+                mainHSize = i.width;
+                mainVSize = i.height;
             }
         }
     }
@@ -1901,7 +1899,7 @@ int MPLSParser::composePip_metadata(uint8_t* buffer, int bufferSize, std::vector
     while (writer.getBitsCount() % 16 != 0) writer.putBit(0);
     for (size_t i = 0; i < pmtIndexList.size(); ++i)
     {
-        for (size_t k = 0; k < pipStreams.size(); k++)
+        for (size_t k = 0; k < pipStreams.size(); ++k)
         {
             PIPParams pipParams = pipStreams[k].pipParams;
 
@@ -2133,7 +2131,7 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
         writer.putBits(32, 0);  // data_block_start_address
         writer.putBits(24, 0);  // reserved_for_word_align
         writer.putBits(8, extDataBlockInfo.size());
-        for (size_t i = 0; i < extDataBlockInfo.size(); i++)
+        for (size_t i = 0; i < extDataBlockInfo.size(); ++i)
         {
             writer.putBits(16, extDataBlockInfo[i].id1);
             writer.putBits(16, extDataBlockInfo[i].id2);
@@ -2143,10 +2141,10 @@ void MPLSParser::composeExtensionData(BitStreamWriter& writer, vector<ExtDataBlo
         }
         while ((writer.getBitsCount() / 8 - initPos) % 4 != 0) writer.putBits(16, 0);
         *(lengthPos + 1) = my_htonl(writer.getBitsCount() / 8 - initPos + 4);  // data_block_start_address
-        for (size_t i = 0; i < extDataBlockInfo.size(); i++)
+        for (size_t i = 0; i < extDataBlockInfo.size(); ++i)
         {
             *(extDataStartAddrPos[i]) = my_htonl(writer.getBitsCount() / 8 - initPos + 4);
-            for (size_t j = 0; j < extDataBlockInfo[i].data.size(); ++j) writer.putBits(8, extDataBlockInfo[i].data[j]);
+            for (auto &j : extDataBlockInfo[i].data) writer.putBits(8, j);
         }
     }
 
@@ -2293,15 +2291,15 @@ void MPLSParser::composePlayListMark(BitStreamWriter& writer)
         }
     }
     writer.putBits(16, m_marks.size());  // 16 uimsbf
-    for (size_t i = 0; i < m_marks.size(); i++)
+    for (auto &i : m_marks)
     {
         writer.putBits(8, 0);  // reserved_for_future_use 8 bslbf
         writer.putBits(8, 1);  // mark_type 0x01 = Chapter search
-        if (m_marks[i].m_playItemID >= 0)
-            writer.putBits(16, m_marks[i].m_playItemID);  // play item ID
+        if (i.m_playItemID >= 0)
+            writer.putBits(16, i.m_playItemID);  // play item ID
         else
-            writer.putBits(16, calcPlayItemID(streamInfo, m_marks[i].m_markTime * 2));  // play item ID
-        writer.putBits(32, m_marks[i].m_markTime);                                      // 32 uimsbf
+            writer.putBits(16, calcPlayItemID(streamInfo, i.m_markTime * 2));  // play item ID
+        writer.putBits(32, i.m_markTime);                                      // 32 uimsbf
         writer.putBits(16, 0xffff);  // entry_ES_PID always 0xffff for mark_type 1
         writer.putBits(32, 0);       // duration always 0 for mark_type 1
     }
@@ -2348,21 +2346,21 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     std::vector<MPLSStreamInfo>& streamInfo = isSSEx ? m_streamInfoMVC : m_streamInfo;
 
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
+        int stream_coding_type = i.stream_coding_type;
         if (isVideoStreamType(stream_coding_type))
         {
-            if (streamInfo[i].isSecondary)
+            if (i.isSecondary)
                 number_of_secondary_video_stream_entries++;
-            else if (streamInfo[i].HDR == 4)
+            else if (i.HDR == 4)
                 number_of_DolbyVision_video_stream_entries++;
             else
                 number_of_primary_video_stream_entries++;
         }
         else if (isAudioStreamType(stream_coding_type))
         {
-            if (!streamInfo[i].isSecondary)
+            if (!i.isSecondary)
                 number_of_primary_audio_stream_entries++;
             else
                 number_of_secondary_audio_stream_entries++;
@@ -2390,68 +2388,68 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     // if (number_of_SubPaths == 0)
 
     // video
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
-        if (isVideoStreamType(stream_coding_type) && !streamInfo[i].isSecondary && streamInfo[i].HDR != 4)
+        int stream_coding_type = i.stream_coding_type;
+        if (isVideoStreamType(stream_coding_type) && !i.isSecondary && i.HDR != 4)
         {
-            streamInfo[i].composeStreamEntry(writer, PlayItem_id);
-            streamInfo[i].composeStreamAttributes(writer);
+            i.composeStreamEntry(writer, PlayItem_id);
+            i.composeStreamAttributes(writer);
             if (stream_coding_type == 0x20)  // MVC
             {
                 writer.putBits(10, 0);  // reserved_for_future_use
-                writer.putBits(6, FFMAX(1, streamInfo[i].number_of_offset_sequences));
+                writer.putBits(6, FFMAX(1, i.number_of_offset_sequences));
             }
         }
     }
 
     // primary audio
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
-        if (isAudioStreamType(stream_coding_type) && !streamInfo[i].isSecondary)
+        int stream_coding_type = i.stream_coding_type;
+        if (isAudioStreamType(stream_coding_type) && !i.isSecondary)
         {
-            streamInfo[i].composeStreamEntry(writer, PlayItem_id);
-            streamInfo[i].composeStreamAttributes(writer);
+            i.composeStreamEntry(writer, PlayItem_id);
+            i.composeStreamAttributes(writer);
         }
     }
 
     // PG
-    for (size_t i = 0; i < m_streamInfo.size(); i++)
+    for (auto &i : m_streamInfo)
     {
-        int stream_coding_type = m_streamInfo[i].stream_coding_type;
+        int stream_coding_type = i.stream_coding_type;
         if (stream_coding_type == 0x90)
         {
             if (isSSEx)
             {
-                m_streamInfo[i].composePGS_SS_StreamEntry(writer, PlayItem_id);
+                i.composePGS_SS_StreamEntry(writer, PlayItem_id);
             }
             else
             {
-                m_streamInfo[i].composeStreamEntry(writer, PlayItem_id);
-                m_streamInfo[i].composeStreamAttributes(writer);
+                i.composeStreamEntry(writer, PlayItem_id);
+                i.composeStreamAttributes(writer);
             }
         }
     }
 
     // secondary audio
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
-        if (isAudioStreamType(stream_coding_type) && streamInfo[i].isSecondary)
+        int stream_coding_type = i.stream_coding_type;
+        if (isAudioStreamType(stream_coding_type) && i.isSecondary)
         {
-            streamInfo[i].composeStreamEntry(writer, PlayItem_id);
-            streamInfo[i].composeStreamAttributes(writer);
+            i.composeStreamEntry(writer, PlayItem_id);
+            i.composeStreamAttributes(writer);
             if (number_of_secondary_video_stream_entries == 0)
             {
                 writer.putBits(8, number_of_primary_audio_stream_entries);  // number_of_primary_audio_ref_entries
                                                                             // allowed to join with this stream
                 writer.putBits(8, 0);                                       // word align
                 uint8_t primaryAudioNum = 0;
-                for (size_t j = 0; j < streamInfo.size(); j++)
+                for (auto &j : streamInfo)
                 {
-                    int stream_coding_type = streamInfo[j].stream_coding_type;
-                    if (isAudioStreamType(stream_coding_type) && !streamInfo[j].isSecondary)
+                    int stream_coding_type = j.stream_coding_type;
+                    if (isAudioStreamType(stream_coding_type) && !j.isSecondary)
                         writer.putBits(8, primaryAudioNum++);
                 }
                 if (number_of_primary_audio_stream_entries % 2 == 1)
@@ -2466,14 +2464,14 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
 
     // secondary video
     int secondaryVNum = 0;
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
-        if (streamInfo[i].isSecondary && isVideoStreamType(stream_coding_type))
+        int stream_coding_type = i.stream_coding_type;
+        if (i.isSecondary && isVideoStreamType(stream_coding_type))
         {
-            streamInfo[i].type = 3;
-            streamInfo[i].composeStreamEntry(writer, PlayItem_id, secondaryVNum);
-            streamInfo[i].composeStreamAttributes(writer);
+            i.type = 3;
+            i.composeStreamEntry(writer, PlayItem_id, secondaryVNum);
+            i.composeStreamAttributes(writer);
             // comb_info_Secondary_video_Secondary_audio() {
             int useSecondaryAudio = number_of_secondary_audio_stream_entries > secondaryVNum ? 1 : 0;
             writer.putBits(8, useSecondaryAudio);
@@ -2494,14 +2492,14 @@ void MPLSParser::composeSTN_table(BitStreamWriter& writer, int PlayItem_id, bool
     }
 
     // DV video
-    for (size_t i = 0; i < streamInfo.size(); i++)
+    for (auto &i : streamInfo)
     {
-        int stream_coding_type = streamInfo[i].stream_coding_type;
-        if (isVideoStreamType(stream_coding_type) && streamInfo[i].HDR == 4)
+        int stream_coding_type = i.stream_coding_type;
+        if (isVideoStreamType(stream_coding_type) && i.HDR == 4)
         {
-            streamInfo[i].type = 4;
-            streamInfo[i].composeStreamEntry(writer, PlayItem_id);
-            streamInfo[i].composeStreamAttributes(writer);
+            i.type = 4;
+            i.composeStreamEntry(writer, PlayItem_id);
+            i.composeStreamAttributes(writer);
         }
     }
 

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -196,7 +196,7 @@ struct PMTIndexData
     PMTIndexData(uint32_t pktCnt, uint32_t frameLen) : m_pktCnt(pktCnt), m_frameLen(frameLen) {}
 };
 
-typedef std::map<int64_t, PMTIndexData> PMTIndex;
+typedef std::map<uint64_t, PMTIndexData> PMTIndex;
 
 struct PMTStreamInfo
 {
@@ -483,7 +483,7 @@ struct MPLSPlayItem
 
 struct PlayListMark
 {
-    int m_playItemID;
+    unsigned m_playItemID;
     uint32_t m_markTime;
     PlayListMark(int playItemID, uint32_t markTime) : m_playItemID(playItemID), m_markTime(markTime) {}
 };

--- a/tsMuxer/vc1StreamReader.cpp
+++ b/tsMuxer/vc1StreamReader.cpp
@@ -34,14 +34,14 @@ int VC1StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
         m_firstFileFrame = false;
         if (m_seqBuffer.size() > 0)
         {
-            if (dstEnd - curPtr < m_seqBuffer.size())
+            if (dstEnd - curPtr < (int)m_seqBuffer.size())
                 THROW(ERR_COMMON, "VC1 stream error: Not enough buffer for write headers");
             memcpy(curPtr, &m_seqBuffer[0], m_seqBuffer.size());
             curPtr += m_seqBuffer.size();
         }
         if (m_entryPointBuffer.size() > 0)
         {
-            if (dstEnd - curPtr < m_entryPointBuffer.size())
+            if (dstEnd - curPtr < (int)m_entryPointBuffer.size())
                 THROW(ERR_COMMON, "VC1 stream error: Not enough buffer for write headers");
             memcpy(curPtr, &m_entryPointBuffer[0], m_entryPointBuffer.size());
             curPtr += m_entryPointBuffer.size();

--- a/tsMuxer/vod_common.cpp
+++ b/tsMuxer/vod_common.cpp
@@ -15,7 +15,7 @@ bool sLastMsg = false;
 std::string toNativeSeparators(const std::string& dirName)
 {
     std::string rez = dirName;
-    for (int i = 0; i < rez.length(); ++i)
+    for (size_t i = 0; i < rez.length(); ++i)
         if (rez[i] == '\\' || rez[i] == '/')
             rez[i] = getDirSeparator();
     return rez;
@@ -47,7 +47,7 @@ std::vector<std::string> extractFileList(const std::string& val)
     std::vector<std::string> rez;
     bool quoted = false;
     size_t lastStartPos = 0;
-    for (int i = 0; i < val.size(); i++)
+    for (size_t i = 0; i < val.size(); i++)
     {
         if (val[i] == '"')
             quoted = !quoted;


### PR DESCRIPTION
Fix all signed/unsigned mismatch in `<` `>` comparisons.