### PR TITLE
Fix max value of log2_max_mv_length

### DIFF
--- a/tsMuxer/nalUnits.cpp
+++ b/tsMuxer/nalUnits.cpp
@@ -802,10 +802,10 @@ int SPSUnit::deserializeVuiParameters()
         if (max_bits_per_mb_denom > 16)
             return 1;
         unsigned log2_max_mv_length_horizontal = extractUEGolombCode();
-        if (log2_max_mv_length_horizontal >= 16)
+        if (log2_max_mv_length_horizontal > 16)
             return 1;
         unsigned log2_max_mv_length_vertical = extractUEGolombCode();
-        if (log2_max_mv_length_vertical >= 16)
+        if (log2_max_mv_length_vertical > 16)
             return 1;
         unsigned num_reorder_frames = extractUEGolombCode();
         unsigned max_dec_frame_buffering = extractUEGolombCode();


### PR DESCRIPTION
H264 standard states "**log2_max_mv_length_horizontal** and **log2_max_mv_length_vertical** indicate the maximum absolute value of a decoded horizontal and vertical motion vector component, respectively, in ¼ luma sample units, for all pictures in the coded video sequence. [ ] The value of log2_max_mv_length_horizontal shall be in the range of 0 to 15, inclusive. The value of log2_max_mv_length_vertical shall be in the range of 0 to 15, inclusive".

However some hardware decoders seem to produce log2_max_mv_length with values of 16.

Fixes issue #389.