### PR TITLE
Hopefully fix commit.txt not being updated on Bintray

### DIFF
--- a/bintray_nightly_check.sh
+++ b/bintray_nightly_check.sh
@@ -11,30 +11,38 @@
 
 # BINTRAY_USER and BINTRAY_API_KEY must be present in the environment.
 
+version_date=$(date +%Y-%m-%d)
+
+create_version() {
+  local package_name=$1
+
+  # create a new version with the timestamp
+  version_data='{ "name": "'
+  version_data+=$version_date
+  version_data+='", "desc": "tsMuxer CLI and GUI binaries built on '
+  version_data+=$version_date
+  version_data+='"}'
+  echo "$version_data"
+
+  version_created=$(curl -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --write-out %{http_code} --silent --output /dev/null --request POST --data "$version_data" https://api.bintray.com/packages/$BINTRAY_USER/$BINTRAY_REPO/${package_name}/versions)
+  if [[ $version_created -eq 201 ]]; then
+    echo "version $version_date has been created!"
+  else
+    echo "error creating version $version_date : server returned $version_created"
+  fi
+}
+
 BINTRAY_REPO=tsMuxer
 PCK_NAME=tsMuxerGUI-Nightly
 repo_commit=$(curl -s https://dl.bintray.com/$BINTRAY_USER/$BINTRAY_REPO/commit.txt)
 local_commit=$(git rev-parse HEAD)
-version_date=$(date +%Y-%m-%d)
 
 if [[ $repo_commit == $local_commit ]]; then
   echo "latest nightly build already in bintray!"
   exit 1
 fi
 
-# create a new version with the timestamp
-version_data='{ "name": "'
-version_data+=$version_date
-version_data+='", "desc": "tsMuxer CLI and GUI binaries built on '
-version_data+=$version_date
-version_data+='"}'
-echo "$version_data"
-
-version_created=$(curl -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --write-out %{http_code} --silent --output /dev/null --request POST --data "$version_data" https://api.bintray.com/packages/$BINTRAY_USER/$BINTRAY_REPO/$PCK_NAME/versions)
-if [[ $version_created -eq 201 ]]; then
-  echo "version $version_date has been created!"
-else
-  echo "error creating version $version_date : server returned $version_created"
-fi
+create_version "$PCK_NAME"
+create_version "commit"
 
 exit 0 # don't return an error in case the version already exists

--- a/bintray_nightly_upload.sh
+++ b/bintray_nightly_upload.sh
@@ -32,7 +32,12 @@ echo "files uploaded!"
 
 # update the latest commit on bintray
 echo "updating commit record on bintray..."
-git rev-parse HEAD | curl -T - "-u$BINTRAY_USER:$BINTRAY_API_KEY" -H "X-Bintray-Package:commit" -H "X-Bintray-Version:latest"  -H "X-Bintray-Publish:1"  -H "X-Bintray-Override:1" "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/commit.txt"0
+git rev-parse HEAD | curl -T - "-u$BINTRAY_USER:$BINTRAY_API_KEY" \
+  -H "X-Bintray-Package:commit" \
+  -H "X-Bintray-Version:$version_date" \
+  -H "X-Bintray-Publish:1" \
+  -H "X-Bintray-Override:1" \
+  "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO/commit.txt"
 echo "commit record updated!"
 
 # try to trigger a new build in OBS


### PR DESCRIPTION
Bintray builds have been created every night since the 5th of December. Not only is this caused by a runaway "0" at the end of the line responsible for updating the commit.txt file (oh, those long lines!), but Bintray has been returning the 200 OK code when attempting an update of the file despite also returning an error and the file not actually being updated :

```
{"message":"Version 'latest' has been published for more than 365 days. Files can only be uploaded to a version within 365 days from its publish date."}
```

Hopefully, creating a version in the "commit" package with the same version as the nightlies will solve this problem.