### PR TITLE
Gitignore for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,16 @@
 *.exe
 *.out
 *.app
+
+#Visual Studio
+.vs
+*.sln
+*.json
+**/Debug
+**/Release
+*.vcxproj*
+
+#CMakeFiles
+**/CMakeFiles
+*.cmake
+CMakeCache.txt


### PR DESCRIPTION
Git ignore the files produced by the cmake generator for Visual Studio, and by Visual Studio on Windows.