### PR TITLE
[Bug] Buffer overflow with non-hevc stream

### DIFF
--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -50,7 +50,8 @@ int HevcUnit::deserialize()
         nal_unit_type = m_reader.getBits(6);
         nuh_layer_id = m_reader.getBits(6);
         nuh_temporal_id_plus1 = m_reader.getBits(3);
-        if (nuh_temporal_id_plus1 == 0)
+        if (nuh_temporal_id_plus1 == 0 || (nuh_temporal_id_plus1 != 1 && (nal_unit_type == 32 || nal_unit_type == 33 ||
+                                                                          nal_unit_type == 36 || nal_unit_type == 37)))
             return 1;
         return 0;
     }


### PR DESCRIPTION
As per T-REC-H265 standard sub-clause 7.4.2.2., when `nal_unit_type `== `VPS_NUT `or `SPS_NUT `or `EOS_NUT `or `EOB_NUT`, `nuh_temporal_id `shall be equal to 0.

This patch allows early return when this condition is not fulfilled therefore the stream is obviously not an hevc stream (or is not compliant).

Fixes issues #418, #419, #420, #424, #436 and #437.