### PR TITLE
[Bug] Incorrect values of VC-1 framerate

### DIFF
--- a/tsMuxer/vc1Parser.cpp
+++ b/tsMuxer/vc1Parser.cpp
@@ -273,7 +273,7 @@ if(psf) { //PsF, 6.1.13
                 m_fpsFieldBitVal = bitReader.getBitsCount();
                 nr = bitReader.getBits(8);
                 dr = bitReader.getBits(4);
-                if (nr && nr < 8 && dr && dr < 3)
+                if (nr > 0 && nr < 8 && dr > 0 && dr < 3)
                 {
                     time_base_num = ff_vc1_fps_dr[dr - 1];
                     time_base_den = ff_vc1_fps_nr[nr - 1] * 1000;

--- a/tsMuxer/vc1Parser.h
+++ b/tsMuxer/vc1Parser.h
@@ -36,7 +36,7 @@ enum Profile
 };
 //@}
 
-const int ff_vc1_fps_nr[5] = {24, 25, 30, 50, 60};
+const int ff_vc1_fps_nr[7] = {24, 25, 30, 50, 60, 48, 72};
 const int ff_vc1_fps_dr[2] = {1000, 1001};
 
 /*


### PR DESCRIPTION
As per https://ffmpeg.org/doxygen/2.7/vc1data_8c_source.html#l00087
and https://ffmpeg.org/doxygen/2.7/vc1_8c_source.html#l00479.

Fixes issue #426 .