### PR TITLE
[Bug] infinite loop when blockSize = 0

### DIFF
--- a/tsMuxer/matroskaParser.cpp
+++ b/tsMuxer/matroskaParser.cpp
@@ -364,10 +364,12 @@ void ParsedPGTrackData::extractData(AVPacket* pkt, uint8_t* buff, int size)
     while (curPtr <= end - 3)
     {
         uint16_t blockSize = AV_RB16(curPtr + 1) + 3;
+        if (blockSize == 0)
+            break;
         curPtr += blockSize;
         blocks++;
     }
-    assert(curPtr == end);
+    // assert(curPtr == end);
     if (curPtr != end)
     {
         pkt->size = 0;


### PR DESCRIPTION
A situation can occur where tsMuxer tries to extract data from a block which is not a PG track, and blocksize = 0 results in an infinite loop.

Fixes issue #440.