### PR TITLE
Upgrade to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1)
 project (tsmuxer_main CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS FALSE)
 

--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -474,6 +474,7 @@ uint32_t random32()
 }
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 namespace


### PR DESCRIPTION
Add #define WIN32_LEAN_AND_MEAN to avoid conflict between new c++17 std::byte and windows.h byte type.