### PR TITLE
Qt6 Readiness

### DIFF
--- a/.github/workflows/qt6_test.sh
+++ b/.github/workflows/qt6_test.sh
@@ -1,6 +1,15 @@
 cd tsMuxerGUI
+
 rm -fR build
 mkdir build
 cd build
 qmake ..
 make -j$(nproc --all)
+
+cd ..
+
+rm -fR build
+mkdir build
+cd build
+cmake -DTSMUXER_GUI=TRUE -DQT_VERSION=6 -GNinja ..
+ninja tsMuxerGUI

--- a/.github/workflows/qt6_test.sh
+++ b/.github/workflows/qt6_test.sh
@@ -11,5 +11,5 @@ cd ..
 rm -fR build
 mkdir build
 cd build
-cmake -DTSMUXER_GUI=TRUE -DQT_VERSION=6 -GNinja ..
-ninja tsMuxerGUI
+cmake -DTSMUXER_GUI=TRUE -DQT_VERSION=6 ..
+make -j$(nproc --all) tsMuxerGUI

--- a/.github/workflows/qt6_test.sh
+++ b/.github/workflows/qt6_test.sh
@@ -1,15 +1,13 @@
 cd tsMuxerGUI
 
-rm -fR build
-mkdir build
-cd build
+mkdir qmake_build
+cd qmake_build
 qmake ..
 make -j$(nproc --all)
 
-cd ..
+cd ../..
 
-rm -fR build
-mkdir build
-cd build
+mkdir cmake_build
+cd cmake_build
 cmake -DTSMUXER_GUI=TRUE -DQT_VERSION=6 ..
 make -j$(nproc --all) tsMuxerGUI

--- a/.github/workflows/qt6_test.sh
+++ b/.github/workflows/qt6_test.sh
@@ -1,0 +1,5 @@
+cd tsMuxerGUI
+rm -fR build
+mkdir build
+qmake ..
+make -j$(nproc --all)

--- a/.github/workflows/qt6_test.sh
+++ b/.github/workflows/qt6_test.sh
@@ -1,5 +1,6 @@
 cd tsMuxerGUI
 rm -fR build
 mkdir build
+cd build
 qmake ..
 make -j$(nproc --all)

--- a/.github/workflows/qt6_test.yml
+++ b/.github/workflows/qt6_test.yml
@@ -21,7 +21,8 @@ jobs:
       
     - name: Install Qt
       uses: jurplel/install-qt-action@master
-      version: 6.2.0
+      with:
+        version: '6.2.0'
       
     - run: ./.github/workflows/qt6_test.sh
       name: build-qt6-linux

--- a/.github/workflows/qt6_test.yml
+++ b/.github/workflows/qt6_test.yml
@@ -1,0 +1,27 @@
+name: Qt6 test build
+
+on:
+  push:
+    branches: [master]
+    paths:
+    - 'tsMuxerGUI/**'
+  pull_request:
+    branches: [master]
+    paths:
+    - 'tsMuxerGUI/**'
+
+jobs:
+  build-mac-native:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@master
+      name: checkout
+      
+    - name: Install Qt
+      uses: jurplel/install-qt-action@master
+      version: 6.2.0
+      
+    - run: ./.github/workflows/qt6_test.sh
+      name: build-qt6-linux

--- a/.github/workflows/qt6_test.yml
+++ b/.github/workflows/qt6_test.yml
@@ -20,7 +20,7 @@ jobs:
       name: checkout
       
     - name: Install Qt
-      uses: jurplel/install-qt-action@master
+      uses: jurplel/install-qt-action@v2
       with:
         version: '6.2.0'
       

--- a/.github/workflows/qt6_test.yml
+++ b/.github/workflows/qt6_test.yml
@@ -11,7 +11,7 @@ on:
     - 'tsMuxerGUI/**'
 
 jobs:
-  build-mac-native:
+  build-qt6-test:
 
     runs-on: ubuntu-latest
     

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -9,7 +9,13 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 COMPONENTS Widgets Multimedia LinguistTools REQUIRED)
+find_package(Qt5 COMPONENTS Widgets LinguistTools REQUIRED)
+set(tsmuxer_gui_libs Qt5::Widgets)
+
+find_package(Qt5 COMPONENTS Multimedia)
+if(${Qt5Multimedia_FOUND})
+  list(APPEND tsmuxer_gui_libs Qt5::Multimedia)
+endif()
 
 set(lang_qrc "translations.qrc")
 configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
@@ -40,7 +46,7 @@ elseif(APPLE)
 endif()
 
 add_executable(tsMuxerGUI ${GUI_OPTIONS} ${tsmuxer_gui_sources})
-target_link_libraries(tsMuxerGUI Qt5::Widgets Qt5::Multimedia)
+target_link_libraries(tsMuxerGUI ${tsmuxer_gui_libs})
 
 if(NOT MSVC)
   install(TARGETS tsMuxerGUI DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -15,8 +15,8 @@ set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
 set(qt_ver_pfx "Qt${QT_VERSION}")
 
 find_package(${qt_ver_pfx}
-    REQUIRED COMPONENTS Widgets LinguistTools
-    OPTIONAL_COMPONENTS Multimedia)
+  REQUIRED COMPONENTS Widgets LinguistTools
+  OPTIONAL_COMPONENTS Multimedia)
 set(tsmuxer_gui_libs ${qt_ver_pfx}::Widgets)
 
 if(${${qt_ver_pfx}Multimedia_FOUND})
@@ -75,7 +75,7 @@ if(NOT MSVC)
   install(FILES tsMuxerGUI.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
   install(FILES images/icon.png
           DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps/
-		  RENAME tsMuxerGUI.png)
+          RENAME tsMuxerGUI.png)
 endif(NOT MSVC)
 
 if (WIN32)

--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -9,18 +9,40 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 COMPONENTS Widgets LinguistTools REQUIRED)
-set(tsmuxer_gui_libs Qt5::Widgets)
+set(QT_VERSION 5 CACHE STRING "Qt version to use")
+set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
 
-find_package(Qt5 COMPONENTS Multimedia)
-if(${Qt5Multimedia_FOUND})
-  list(APPEND tsmuxer_gui_libs Qt5::Multimedia)
+set(qt_ver_pfx "Qt${QT_VERSION}")
+
+find_package(${qt_ver_pfx}
+    REQUIRED COMPONENTS Widgets LinguistTools
+    OPTIONAL_COMPONENTS Multimedia)
+set(tsmuxer_gui_libs ${qt_ver_pfx}::Widgets)
+
+if(${${qt_ver_pfx}Multimedia_FOUND})
+  list(APPEND tsmuxer_gui_libs ${qt_ver_pfx}::Multimedia)
 endif()
+
+set(tsmuxer_ts_files
+  translations/tsmuxergui_en.ts
+  translations/tsmuxergui_ru.ts
+  translations/tsmuxergui_fr.ts
+  translations/tsmuxergui_zh.ts
+)
 
 set(lang_qrc "translations.qrc")
 configure_file(${lang_qrc} ${lang_qrc} COPYONLY)
-# create_translation is not used due to QTBUG-41736
-qt5_add_translation(QM_FILES translations/tsmuxergui_en.ts translations/tsmuxergui_ru.ts translations/tsmuxergui_fr.ts translations/tsmuxergui_zh.ts)
+
+if(${QT_VERSION} EQUAL 5)
+  # create_translation is not used due to QTBUG-41736
+  qt5_add_translation(QM_FILES ${tsmuxer_ts_files})
+elseif(${QT_VERSION} EQUAL 6)
+  # should use qt6_add_translations once Qt6 is the only supported version.
+  # this will also make ${lang_qrc} and all QM_FILES shenanigans unnecessary as
+  # that command turns the compiled qrcs into resources automatically, and adds
+  # them to the target's sources so they're embedded in the final binary.
+  qt6_add_translation(QM_FILES ${tsmuxer_ts_files})
+endif()
 
 set(tsmuxer_gui_sources
   main.cpp

--- a/tsMuxerGUI/tsMuxerGUI.pro
+++ b/tsMuxerGUI/tsMuxerGUI.pro
@@ -6,7 +6,10 @@
 
 TEMPLATE = app
 TARGET = tsMuxerGUI
-QT = core gui widgets multimedia
+QT = core gui widgets
+qtHaveModule(multimedia) {
+  QT += multimedia
+}
 CONFIG += c++17 strict_c++ lrelease embed_translations
 
 HEADERS += tsmuxerwindow.h lang_codes.h muxForm.h checkboxedheaderview.h \

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -14,7 +14,6 @@
 #include <QStandardPaths>
 #include <QTemporaryFile>
 #include <QTime>
-
 #include <unordered_set>
 #include <vector>
 

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -14,8 +14,6 @@
 #include <QStandardPaths>
 #include <QTemporaryFile>
 #include <QTime>
-#include <unordered_set>
-#include <vector>
 
 #include "checkboxedheaderview.h"
 #include "codecinfo.h"
@@ -1280,7 +1278,7 @@ void TsMuxerWindow::continueAddFile()
 
 void TsMuxerWindow::updateCustomChapters()
 {
-    std::unordered_set<qint64> chaptersSet;
+    QSet<qint64> chaptersSet;
     double prevDuration = 0.0;
     double offset = 0.0;
     for (int i = 0; i < ui->inputFilesLV->count(); ++i)
@@ -1295,12 +1293,12 @@ void TsMuxerWindow::updateCustomChapters()
 
         ChapterList chapters = item->data(ChaptersRole).value<ChapterList>();
         foreach (double chapter, chapters)
-            chaptersSet.insert(qint64((chapter + offset) * 1000000));
+            chaptersSet << qint64((chapter + offset) * 1000000);
         prevDuration = item->data(FileDurationRole).toDouble();
     }
 
     ui->memoChapters->clear();
-    std::vector<qint64> mergedChapterList(std::begin(chaptersSet), std::end(chaptersSet));
+    QList<qint64> mergedChapterList = chaptersSet.values();
     std::sort(std::begin(mergedChapterList), std::end(mergedChapterList));
     for (auto chapter : mergedChapterList)
         ui->memoChapters->insertPlainText(floatToTime(chapter / 1000000.0) + QString('\n'));

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1377,8 +1377,12 @@ void TsMuxerWindow::readFromStderr()
 
 void TsMuxerWindow::myPlaySound(const QString &fileName)
 {
+#if QT_MULTIMEDIA_LIB
     sound.setSource(QUrl(QString("qrc%1").arg(fileName)));
     sound.play();
+#else
+    QApplication::beep();
+#endif
 }
 
 void TsMuxerWindow::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -3,10 +3,13 @@
 
 #include <QHeaderView>
 #include <QProcess>
-#include <QSoundEffect>
 #include <QTimer>
 #include <QTranslator>
 #include <QWidget>
+
+#if QT_MULTIMEDIA_LIB
+#include <QSoundEffect>
+#endif
 
 #include "codecinfo.h"
 
@@ -194,7 +197,9 @@ class TsMuxerWindow : public QWidget
     void dragMoveEvent(QDragMoveEvent* event) override;
     void dragLeaveEvent(QDragLeaveEvent* event) override;
 
+#if QT_MULTIMEDIA_LIB
     QSoundEffect sound;
+#endif
     void myPlaySound(const QString& fileName);
     bool isVideoCropped();
 

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1233,7 +1233,7 @@
              <property name="tabChangesFocus">
               <bool>true</bool>
              </property>
-             <property name="tabStopWidth">
+             <property name="tabStopDistance">
               <number>20</number>
              </property>
             </widget>


### PR DESCRIPTION
This PR is to work on Qt6 readiness. Currently there is only Qt 6.1.3 available and it does not include QtMultimedia but 6.2.0 should be released soon and that will include it.

To be ready I have updated some GUI code to work in Qt6 - it should be backwards-compatible - and added the possibility to not use QtMultimedia, just in case it is useful.