### PR TITLE
[Bug] Correct stream_id

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -260,9 +260,13 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
         {
             m_pesType[tsStreamIndex] = PES_VC1_ID;
         }
+        else if (codecName == "V_MPEGH/ISO/HEVC")
+        {
+            m_pesType[tsStreamIndex] = PES_HEVC_ID;
+        }
         else
         {
-            m_pesType[tsStreamIndex] = (m_m2tsMode ? PES_VIDEO_ID : PES_VIDEO_ID - 1);  // m_videoCnt++;
+            m_pesType[tsStreamIndex] = PES_VIDEO_ID;  // m_videoCnt++;
         }
     }
 

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -29,7 +29,8 @@ static const uint8_t PES_PRIVATE_DATA2 = 0xbf;
 static const uint8_t PROGRAM_STREAM_DIRECTORY = 0xff;
 
 static const uint8_t PES_AUDIO_ID = 0xc0;
-static const uint8_t PES_VIDEO_ID = 0xe1;
+static const uint8_t PES_VIDEO_ID = 0xe0;
+static const uint8_t PES_HEVC_ID = 0xe1;
 static const uint8_t PES_VC1_ID = 0xfd;
 
 static const uint8_t DVB_SUBT_DESCID = 0x59;


### PR DESCRIPTION
PES stream_id should be 0xE1 for HEVC, and 0xE0 for AVC / MPEG-2.