### PR TITLE
Remove default font settings from UI XML

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -333,9 +333,9 @@ TsMuxerWindow::TsMuxerWindow()
     ui->listViewFont->horizontalHeader()->resizeSection(1, 185);
     for (int i = 0; i < ui->listViewFont->rowCount(); ++i)
     {
-        ui->listViewFont->setRowHeight(i, 16);
+        ui->listViewFont->setRowHeight(i, 20);
         ui->listViewFont->item(i, 0)->setFlags(ui->listViewFont->item(i, 0)->flags() & (~Qt::ItemIsEditable));
-        ui->listViewFont->item(i, 1)->setFlags(ui->listViewFont->item(i, 0)->flags() & (~Qt::ItemIsEditable));
+        ui->listViewFont->item(i, 1)->setFlags(ui->listViewFont->item(i, 1)->flags() & (~Qt::ItemIsEditable));
     }
     void (QSpinBox::*spinBoxValueChanged)(int) = &QSpinBox::valueChanged;
     void (QDoubleSpinBox::*doubleSpinBoxValueChanged)(double) = &QDoubleSpinBox::valueChanged;

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1677,26 +1677,23 @@ void TsMuxerWindow::setRendererAnimationTime(double value)
 
 QString TsMuxerWindow::getSrtParams()
 {
-    QString rez;
-    if (ui->listViewFont->rowCount() < 5)
-        return rez;
-    rez = QString(",font-name=\"") + ui->listViewFont->item(0, 1)->text();
-    rez += QString("\",font-size=") + ui->listViewFont->item(1, 1)->text();
-    rez += QString(",font-color=") + ui->listViewFont->item(2, 1)->text();
-    int charsetCode = getCharsetCode(ui->listViewFont->item(3, 1)->text());
-    if (charsetCode)
-        rez += QString(",font-charset=") + QString::number(charsetCode);
+    auto rez = QString(",font-name=\"%1\",font-size=%2,font-color=%3")
+                   .arg(ui->listViewFont->item(0, 1)->text(), ui->listViewFont->item(1, 1)->text(),
+                        ui->listViewFont->item(2, 1)->text());
+
     if (ui->lineSpacing->value() != 1.0)
         rez += ",line-spacing=" + QString::number(ui->lineSpacing->value());
 
-    if (ui->listViewFont->item(4, 1)->text().indexOf("Italic") >= 0)
+    const auto fontOptions = ui->listViewFont->item(3, 1)->text();
+    if (fontOptions.contains("Italic"))
         rez += ",font-italic";
-    if (ui->listViewFont->item(4, 1)->text().indexOf("Bold") >= 0)
+    if (fontOptions.contains("Bold"))
         rez += ",font-bold";
-    if (ui->listViewFont->item(4, 1)->text().indexOf("Underline") >= 0)
+    if (fontOptions.contains("Underline"))
         rez += ",font-underline";
-    if (ui->listViewFont->item(4, 1)->text().indexOf("Strikeout") >= 0)
+    if (fontOptions.contains("Strikeout"))
         rez += ",font-strikeout";
+
     rez += QString(",bottom-offset=") + QString::number(ui->spinEditOffset->value()) +
            ",font-border=" + QString::number(ui->spinEditBorder->value());
     if (ui->rbhLeft->isChecked())
@@ -1880,13 +1877,16 @@ void TsMuxerWindow::onLanguageComboBoxIndexChanged(int idx)
 
 void TsMuxerWindow::provideDefaultFontSettings()
 {
-    if (ui->listViewFont->item(0, 1)->text().isEmpty()) {
+    if (ui->listViewFont->item(0, 1)->text().isEmpty())
+    {
         ui->listViewFont->item(0, 1)->setText("Arial");
     }
-    if (ui->listViewFont->item(1, 1)->text().isEmpty()) {
+    if (ui->listViewFont->item(1, 1)->text().isEmpty())
+    {
         ui->listViewFont->item(1, 1)->setText("65");
     }
-    if (ui->listViewFont->item(2, 1)->text().isEmpty()) {
+    if (ui->listViewFont->item(2, 1)->text().isEmpty())
+    {
         quint32 color = ~0;
         setTextItemColor(QString::number(color, 16));
     }
@@ -1984,10 +1984,13 @@ void TsMuxerWindow::onFontBtnClicked()
     QFont font;
     font.setFamily(ui->listViewFont->item(0, 1)->text());
     font.setPointSize((ui->listViewFont->item(1, 1)->text()).toInt());
-    font.setItalic(ui->listViewFont->item(4, 1)->text().indexOf("Italic") >= 0);
-    font.setBold(ui->listViewFont->item(4, 1)->text().indexOf("Bold") >= 0);
-    font.setUnderline(ui->listViewFont->item(4, 1)->text().indexOf("Underline") >= 0);
-    font.setStrikeOut(ui->listViewFont->item(4, 1)->text().indexOf("Strikeout") >= 0);
+    {
+        auto fontOptions = ui->listViewFont->item(3, 1)->text();
+        font.setItalic(fontOptions.contains("Italic"));
+        font.setBold(fontOptions.contains("Bold"));
+        font.setUnderline(fontOptions.contains("Underline"));
+        font.setStrikeOut(fontOptions.contains("Strikeout"));
+    }
     font = QFontDialog::getFont(&ok, font, this);
     if (ok)
     {
@@ -2015,7 +2018,7 @@ void TsMuxerWindow::onFontBtnClicked()
                 optStr += ',';
             optStr += "Strikeout";
         }
-        ui->listViewFont->item(4, 1)->setText(optStr);
+        ui->listViewFont->item(3, 1)->setText(optStr);
         writeSettings();
         updateMetaLines();
     }
@@ -2738,7 +2741,7 @@ void TsMuxerWindow::writeSettings()
     settings->setValue("family", ui->listViewFont->item(0, 1)->text());
     settings->setValue("size", ui->listViewFont->item(1, 1)->text().toUInt());
     settings->setValue("color", ui->listViewFont->item(2, 1)->text().mid(2).toUInt(0, 16));
-    settings->setValue("options", ui->listViewFont->item(4, 1)->text());
+    settings->setValue("options", ui->listViewFont->item(3, 1)->text());
     settings->endGroup();
 
     settings->beginGroup("pip");
@@ -2787,7 +2790,7 @@ bool TsMuxerWindow::readSettings()
         quint32 color = settings->value("color").toUInt();
         setTextItemColor(QString::number(color, 16));
     }
-    ui->listViewFont->item(4, 1)->setText(settings->value("options").toString());
+    ui->listViewFont->item(3, 1)->setText(settings->value("options").toString());
     settings->endGroup();
 
     settings->beginGroup("pip");

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -309,6 +309,7 @@ TsMuxerWindow::TsMuxerWindow()
     }
 
     ui->outFileName->setText(getDefaultOutputFileName());
+    provideDefaultFontSettings();
 
     m_header = new QnCheckBoxedHeaderView(this);
     ui->trackLV->setHorizontalHeader(m_header);
@@ -1875,6 +1876,20 @@ void TsMuxerWindow::onLanguageComboBoxIndexChanged(int idx)
         ui->textEdit->clear();
     }
     writeSettings();
+}
+
+void TsMuxerWindow::provideDefaultFontSettings()
+{
+    if (ui->listViewFont->item(0, 1)->text().isEmpty()) {
+        ui->listViewFont->item(0, 1)->setText("Arial");
+    }
+    if (ui->listViewFont->item(1, 1)->text().isEmpty()) {
+        ui->listViewFont->item(1, 1)->setText("65");
+    }
+    if (ui->listViewFont->item(2, 1)->text().isEmpty()) {
+        quint32 color = ~0;
+        setTextItemColor(QString::number(color, 16));
+    }
 }
 
 void TsMuxerWindow::updateMetaLines()

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1635,12 +1635,6 @@ QString TsMuxerWindow::getMuxOpts()
     return rez;
 }
 
-int getCharsetCode(const QString &name)
-{
-    Q_UNUSED(name);
-    return 0;  // todo: refactor this function
-}
-
 double TsMuxerWindow::getRendererAnimationTime() const
 {
     switch (ui->comboBoxAnimation->currentIndex())

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -91,6 +91,7 @@ class TsMuxerWindow : public QWidget
     void updateMuxTime1();
     void updateMuxTime2();
     void onLanguageComboBoxIndexChanged(int);
+    void provideDefaultFontSettings();
     template <typename OnCodecListReadyFn, typename PostActionSignal, typename PostActionFn>
     void processAddFileList(OnCodecListReadyFn onCodecListReady, PostActionSignal postActionSignal,
                             PostActionFn postActionFn);

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -2016,7 +2016,7 @@
                </item>
                <item row="0" column="1">
                 <property name="text">
-                 <string notr="true">Arial</string>
+                 <string/>
                 </property>
                </item>
                <item row="1" column="0">
@@ -2026,7 +2026,7 @@
                </item>
                <item row="1" column="1">
                 <property name="text">
-                 <string>65</string>
+                 <string/>
                 </property>
                </item>
                <item row="2" column="0">
@@ -2036,7 +2036,7 @@
                </item>
                <item row="2" column="1">
                 <property name="text">
-                 <string>0xffffffff</string>
+                 <string/>
                 </property>
                </item>
                <item row="3" column="0">
@@ -2046,7 +2046,7 @@
                </item>
                <item row="3" column="1">
                 <property name="text">
-                 <string>Default</string>
+                 <string/>
                 </property>
                </item>
                <item row="4" column="0">

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -1994,11 +1994,6 @@
                  <string>New Row</string>
                 </property>
                </row>
-               <row>
-                <property name="text">
-                 <string>New Row</string>
-                </property>
-               </row>
                <column>
                 <property name="text">
                  <string>New Column</string>
@@ -2041,20 +2036,10 @@
                </item>
                <item row="3" column="0">
                 <property name="text">
-                 <string>Charset:</string>
-                </property>
-               </item>
-               <item row="3" column="1">
-                <property name="text">
-                 <string/>
-                </property>
-               </item>
-               <item row="4" column="0">
-                <property name="text">
                  <string>Options:</string>
                 </property>
                </item>
-               <item row="4" column="1">
+               <item row="3" column="1">
                 <property name="text">
                  <string/>
                 </property>


### PR DESCRIPTION
This causes these strings to be set when `retranslateUi` is called, possibly overwriting the proper ones loaded from the settings.

Fixes #482 .