### PR TITLE
Use the model-view approach for handling font settings

### DIFF
--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tsmuxer_gui_sources
   muxForm.ui
   checkboxedheaderview.cpp
   images.qrc
+  fontsettingstablemodel.cpp
   ${QM_FILES}
   ${CMAKE_CURRENT_BINARY_DIR}/${lang_qrc}
 )

--- a/tsMuxerGUI/fontsettingstablemodel.cpp
+++ b/tsMuxerGUI/fontsettingstablemodel.cpp
@@ -127,7 +127,7 @@ QVariant FontSettingsTableModel::data(const QModelIndex &index, int role) const
 
     case Qt::DisplayRole:
     {
-        static const std::array<std::function<QVariant()>, 8> providers = {
+        const std::array<std::function<QVariant()>, 8> providers = {
             // column 0
             []() { return tr("Name:"); }, []() { return tr("Size:"); }, []() { return tr("Color:"); },
             []() { return tr("Options:"); },

--- a/tsMuxerGUI/fontsettingstablemodel.cpp
+++ b/tsMuxerGUI/fontsettingstablemodel.cpp
@@ -3,6 +3,8 @@
 #include <QBrush>
 #include <QColor>
 #include <QSettings>
+#include <array>
+#include <functional>
 
 namespace
 {

--- a/tsMuxerGUI/fontsettingstablemodel.cpp
+++ b/tsMuxerGUI/fontsettingstablemodel.cpp
@@ -1,0 +1,112 @@
+#include "fontsettingstablemodel.h"
+
+#include <QBrush>
+#include <QColor>
+
+namespace
+{
+constexpr int NUM_ROWS = 4;
+constexpr int NUM_COLUMNS = 2;
+
+QString fontOptions(const QFont &font)
+{
+    QString optStr;
+    if (font.italic())
+        optStr += "Italic";
+    if (font.bold())
+    {
+        if (!optStr.isEmpty())
+            optStr += ',';
+        optStr += "Bold";
+    }
+    if (font.underline())
+    {
+        if (!optStr.isEmpty())
+            optStr += ',';
+        optStr += "Underline";
+    }
+    if (font.strikeOut())
+    {
+        if (!optStr.isEmpty())
+            optStr += ',';
+        optStr += "Strikeout";
+    }
+    return optStr;
+}
+
+int colorLight(QColor color) { return (0.257 * color.red()) + (0.504 * color.green()) + (0.098 * color.blue()) + 16; }
+}  // namespace
+
+int FontSettingsTableModel::rowCount(const QModelIndex &) const { return NUM_ROWS; }
+
+int FontSettingsTableModel::columnCount(const QModelIndex &) const { return NUM_COLUMNS; }
+
+QVariant FontSettingsTableModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+    {
+        return QVariant();
+    }
+    switch (role)
+    {
+    case Qt::BackgroundRole:
+        if (index.row() == 2 && index.column() == 1)
+        {
+            return QBrush(m_color);
+        }
+        else
+        {
+            return QVariant();
+        }
+
+    case Qt::ForegroundRole:
+        if (index.row() == 2 && index.column() == 1)
+        {
+            if (colorLight(QColor(m_color)) < 128)
+            {
+                return QBrush(QColor(255, 255, 255, 255));
+            }
+            else
+            {
+                return QBrush(QColor(0, 0, 0, 255));
+            }
+        }
+        else
+        {
+            return QVariant();
+        }
+
+    case Qt::DisplayRole:
+    {
+        static const std::array<std::function<QVariant()>, 8> providers = {
+            // column 0
+            []() { return tr("Name:"); }, []() { return tr("Size:"); }, []() { return tr("Color:"); },
+            []() { return tr("Options:"); },
+            // column 1
+            [this]() { return m_font.family(); }, [this]() { return m_font.pointSize(); },
+            [this]() { return QString("0x%1").arg(m_color, 8, 16, QLatin1Char('0')); },
+            [this]() { return fontOptions(m_font); }};
+        return providers[index.column() * NUM_ROWS + index.row()]();
+    }
+
+    default:
+        return QVariant();
+    }
+}
+
+Qt::ItemFlags FontSettingsTableModel::flags(const QModelIndex &index) const
+{
+    return QAbstractTableModel::flags(index) & (~Qt::ItemIsEditable);
+}
+
+void FontSettingsTableModel::setFont(const QFont &font)
+{
+    m_font = font;
+    emit dataChanged(index(0, 1), index(3, 1));
+}
+
+void FontSettingsTableModel::setColor(quint32 color)
+{
+    m_color = color;
+    emit dataChanged(index(2, 1), index(2, 1));
+}

--- a/tsMuxerGUI/fontsettingstablemodel.cpp
+++ b/tsMuxerGUI/fontsettingstablemodel.cpp
@@ -135,7 +135,8 @@ QVariant FontSettingsTableModel::data(const QModelIndex &index, int role) const
             [this]() { return m_font.family(); }, [this]() { return m_font.pointSize(); },
             [this]() { return QString("0x%1").arg(m_color, 8, 16, QLatin1Char('0')); },
             [this]() { return fontOptions(m_font); }};
-        return providers[index.column() * NUM_ROWS + index.row()]();
+        auto idx = index.column() * NUM_ROWS + index.row();
+        return idx < static_cast<int>(providers.size()) ? providers[idx]() : QVariant();
     }
 
     default:
@@ -159,3 +160,5 @@ void FontSettingsTableModel::setColor(quint32 color)
     m_color = color;
     emit dataChanged(index(2, 1), index(2, 1));
 }
+
+void FontSettingsTableModel::onLanguageChanged() { emit dataChanged(index(0, 0), index(3, 0)); }

--- a/tsMuxerGUI/fontsettingstablemodel.h
+++ b/tsMuxerGUI/fontsettingstablemodel.h
@@ -1,0 +1,26 @@
+#ifndef FONT_SETTINGS_TABLE_MODEL_H
+#define FONT_SETTINGS_TABLE_MODEL_H
+
+#include <QAbstractTableModel>
+#include <QFont>
+
+class FontSettingsTableModel : public QAbstractTableModel
+{
+   public:
+    FontSettingsTableModel(QObject *parent = nullptr) : QAbstractTableModel(parent) {}
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+    quint32 color() const { return m_color; }
+    const QFont &font() const { return m_font; }
+    void setFont(const QFont &font);
+    void setColor(quint32 color);
+
+   private:
+    QFont m_font = QFont{"Arial", 65};
+    quint32 m_color = ~0;
+};
+
+#endif

--- a/tsMuxerGUI/fontsettingstablemodel.h
+++ b/tsMuxerGUI/fontsettingstablemodel.h
@@ -6,6 +6,8 @@
 
 class FontSettingsTableModel : public QAbstractTableModel
 {
+    Q_OBJECT
+
    public:
     FontSettingsTableModel(QObject *parent = nullptr);
     ~FontSettingsTableModel() override;
@@ -18,6 +20,8 @@ class FontSettingsTableModel : public QAbstractTableModel
     const QFont &font() const { return m_font; }
     void setFont(const QFont &font);
     void setColor(quint32 color);
+
+    void onLanguageChanged();
 
    private:
     QFont m_font = QFont{"Arial", 65};

--- a/tsMuxerGUI/fontsettingstablemodel.h
+++ b/tsMuxerGUI/fontsettingstablemodel.h
@@ -7,7 +7,8 @@
 class FontSettingsTableModel : public QAbstractTableModel
 {
    public:
-    FontSettingsTableModel(QObject *parent = nullptr) : QAbstractTableModel(parent) {}
+    FontSettingsTableModel(QObject *parent = nullptr);
+    ~FontSettingsTableModel() override;
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;

--- a/tsMuxerGUI/main.cpp
+++ b/tsMuxerGUI/main.cpp
@@ -6,6 +6,8 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    app.setOrganizationName("Network Optix");
+    app.setApplicationName("tsMuxeR");
     TsMuxerWindow win;
     win.show();
     QList<QUrl> files;

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
 <context>
+    <name>FontSettingsTableModel</name>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <source>Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../muxForm.cpp" line="48"/>
@@ -106,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="52"/>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>General track options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -172,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1010"/>
         <source>Downconvert HD audio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <location filename="../tsmuxerwindow.cpp" line="55"/>
         <source>Demux options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -569,430 +592,375 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1979"/>
-        <location filename="../tsmuxerwindow.ui" line="1984"/>
-        <location filename="../tsmuxerwindow.ui" line="1989"/>
-        <location filename="../tsmuxerwindow.ui" line="1994"/>
-        <location filename="../tsmuxerwindow.ui" line="1999"/>
-        <source>New Row</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2004"/>
-        <location filename="../tsmuxerwindow.ui" line="2009"/>
-        <source>New Column</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2014"/>
-        <source>Name:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2024"/>
-        <source>Size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2029"/>
-        <source>65</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2034"/>
-        <source>Color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2039"/>
-        <source>0xffffffff</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2044"/>
-        <source>Charset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2049"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2054"/>
-        <source>Options:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2075"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2082"/>
+        <location filename="../tsmuxerwindow.ui" line="1997"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2106"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Additional border, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2132"/>
+        <location filename="../tsmuxerwindow.ui" line="2047"/>
         <source>line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2158"/>
+        <location filename="../tsmuxerwindow.ui" line="2073"/>
         <source>Fade in/out animation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2169"/>
+        <location filename="../tsmuxerwindow.ui" line="2084"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2174"/>
+        <location filename="../tsmuxerwindow.ui" line="2089"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2179"/>
+        <location filename="../tsmuxerwindow.ui" line="2094"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2184"/>
+        <location filename="../tsmuxerwindow.ui" line="2099"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2189"/>
+        <location filename="../tsmuxerwindow.ui" line="2104"/>
         <source>Very slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2225"/>
+        <location filename="../tsmuxerwindow.ui" line="2140"/>
         <source> Vertical position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2236"/>
+        <location filename="../tsmuxerwindow.ui" line="2151"/>
         <source>Top of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2270"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>top offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2304"/>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2219"/>
+        <location filename="../tsmuxerwindow.ui" line="2391"/>
         <source>Screen center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2311"/>
+        <location filename="../tsmuxerwindow.ui" line="2226"/>
         <source>Bottom of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2345"/>
+        <location filename="../tsmuxerwindow.ui" line="2260"/>
         <source>bottom offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2397"/>
+        <location filename="../tsmuxerwindow.ui" line="2312"/>
         <source> Horizontal position: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2408"/>
+        <location filename="../tsmuxerwindow.ui" line="2323"/>
         <source>Left of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2442"/>
+        <location filename="../tsmuxerwindow.ui" line="2357"/>
         <source>left offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2489"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Right of screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2526"/>
+        <location filename="../tsmuxerwindow.ui" line="2441"/>
         <source>right offset, pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2591"/>
+        <location filename="../tsmuxerwindow.ui" line="2506"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2643"/>
+        <location filename="../tsmuxerwindow.ui" line="2558"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2657"/>
+        <location filename="../tsmuxerwindow.ui" line="2572"/>
         <source>TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2673"/>
+        <location filename="../tsmuxerwindow.ui" line="2588"/>
         <source>M2TS muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2595"/>
         <source>Blu-ray ISO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2608"/>
         <source>Blu-ray folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.ui" line="2615"/>
         <source>AVCHD folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2713"/>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.ui" line="2628"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Demux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2737"/>
+        <location filename="../tsmuxerwindow.ui" line="2652"/>
         <source>Disk label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2747"/>
-        <location filename="../tsmuxerwindow.cpp" line="2334"/>
+        <location filename="../tsmuxerwindow.ui" line="2662"/>
+        <location filename="../tsmuxerwindow.cpp" line="2282"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2773"/>
+        <location filename="../tsmuxerwindow.ui" line="2688"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
+        <location filename="../tsmuxerwindow.ui" line="2712"/>
         <source>Meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2866"/>
-        <location filename="../tsmuxerwindow.cpp" line="2318"/>
+        <location filename="../tsmuxerwindow.ui" line="2781"/>
+        <location filename="../tsmuxerwindow.cpp" line="2266"/>
         <source>Sta&amp;rt muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2891"/>
+        <location filename="../tsmuxerwindow.ui" line="2806"/>
         <source>Save meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="28"/>
+        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <location filename="../tsmuxerwindow.cpp" line="61"/>
         <source>Disk image (*.iso);;all files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="543"/>
+        <location filename="../tsmuxerwindow.cpp" line="551"/>
         <source>Not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="609"/>
-        <location filename="../tsmuxerwindow.cpp" line="1129"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="1135"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="610"/>
+        <location filename="../tsmuxerwindow.cpp" line="618"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="911"/>
         <source>Add media files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="920"/>
+        <location filename="../tsmuxerwindow.cpp" line="926"/>
         <source>File already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="921"/>
+        <location filename="../tsmuxerwindow.cpp" line="927"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="998"/>
+        <location filename="../tsmuxerwindow.cpp" line="1004"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1000"/>
+        <location filename="../tsmuxerwindow.cpp" line="1006"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1002"/>
+        <location filename="../tsmuxerwindow.cpp" line="1008"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="1141"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1145"/>
+        <location filename="../tsmuxerwindow.cpp" line="1151"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Mux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1406"/>
+        <location filename="../tsmuxerwindow.cpp" line="1412"/>
         <source>tsMuxeR error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1410"/>
+        <location filename="../tsmuxerwindow.cpp" line="1416"/>
         <source>tsMuxeR not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1428"/>
+        <location filename="../tsmuxerwindow.cpp" line="1434"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
-        <location filename="../tsmuxerwindow.cpp" line="2195"/>
+        <location filename="../tsmuxerwindow.cpp" line="2142"/>
+        <location filename="../tsmuxerwindow.cpp" line="2143"/>
         <source>No track selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2201"/>
+        <location filename="../tsmuxerwindow.cpp" line="2149"/>
         <source>Append media files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2217"/>
+        <location filename="../tsmuxerwindow.cpp" line="2165"/>
         <source>Invalid file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2218"/>
+        <location filename="../tsmuxerwindow.cpp" line="2166"/>
         <source>Appended file must have same file extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2316"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Sta&amp;rt demuxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2278"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>Select file for muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2442"/>
-        <location filename="../tsmuxerwindow.cpp" line="2458"/>
+        <location filename="../tsmuxerwindow.cpp" line="2386"/>
+        <location filename="../tsmuxerwindow.cpp" line="2402"/>
         <source>Invalid file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2443"/>
+        <location filename="../tsmuxerwindow.cpp" line="2387"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2459"/>
+        <location filename="../tsmuxerwindow.cpp" line="2403"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2475"/>
+        <location filename="../tsmuxerwindow.cpp" line="2419"/>
         <source>Overwrite existing %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2476"/>
+        <location filename="../tsmuxerwindow.cpp" line="2420"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Muxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Demuxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2507"/>
+        <location filename="../tsmuxerwindow.cpp" line="2451"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2522"/>
+        <location filename="../tsmuxerwindow.cpp" line="2466"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2467"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_fr.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_fr.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr">
 <context>
+    <name>FontSettingsTableModel</name>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Name:</source>
+        <translation>Nom :</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Size:</source>
+        <translation>Taille :</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Color:</source>
+        <translation>Couleur :</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <source>Options:</source>
+        <translation>Options :</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../muxForm.cpp" line="48"/>
@@ -106,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="52"/>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>General track options</source>
         <translation>Options générales de la piste</translation>
     </message>
@@ -172,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1010"/>
         <source>Downconvert HD audio</source>
         <translation>Supprimer les données HD de l&apos;audio</translation>
     </message>
@@ -198,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <location filename="../tsmuxerwindow.cpp" line="55"/>
         <source>Demux options</source>
         <translation>Options de démuxage</translation>
     </message>
@@ -569,430 +592,375 @@
         <translation> Police par défaut utilisée pour les sous-titres à base de texte : </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1979"/>
-        <location filename="../tsmuxerwindow.ui" line="1984"/>
-        <location filename="../tsmuxerwindow.ui" line="1989"/>
-        <location filename="../tsmuxerwindow.ui" line="1994"/>
-        <location filename="../tsmuxerwindow.ui" line="1999"/>
-        <source>New Row</source>
-        <translation>Nouvelle ligne</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2004"/>
-        <location filename="../tsmuxerwindow.ui" line="2009"/>
-        <source>New Column</source>
-        <translation>Nouvelle colonne</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2014"/>
-        <source>Name:</source>
-        <translation>Nom :</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2024"/>
-        <source>Size:</source>
-        <translation>Taille :</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2029"/>
-        <source>65</source>
-        <translation>65</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2034"/>
-        <source>Color:</source>
-        <translation>Couleur :</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2039"/>
-        <source>0xffffffff</source>
-        <translation>0xffffffff</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2044"/>
-        <source>Charset:</source>
-        <translation>Codage :</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2049"/>
-        <source>Default</source>
-        <translation>Par défaut</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2054"/>
-        <source>Options:</source>
-        <translation>Options :</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2075"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
         <source>Font</source>
         <translation>Police</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2082"/>
+        <location filename="../tsmuxerwindow.ui" line="1997"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2106"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Additional border, pixels:</source>
         <translation>Bordure aditionnelle, en pixels :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2132"/>
+        <location filename="../tsmuxerwindow.ui" line="2047"/>
         <source>line spacing:</source>
         <translation>Interligne :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2158"/>
+        <location filename="../tsmuxerwindow.ui" line="2073"/>
         <source>Fade in/out animation:</source>
         <translation>Animation de fondu en entrée/sortie :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2169"/>
+        <location filename="../tsmuxerwindow.ui" line="2084"/>
         <source>None</source>
         <translation>Aucune</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2174"/>
+        <location filename="../tsmuxerwindow.ui" line="2089"/>
         <source>Fast</source>
         <translation>Rapide</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2179"/>
+        <location filename="../tsmuxerwindow.ui" line="2094"/>
         <source>Medium</source>
         <translation>Moyenne</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2184"/>
+        <location filename="../tsmuxerwindow.ui" line="2099"/>
         <source>Slow</source>
         <translation>Lente</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2189"/>
+        <location filename="../tsmuxerwindow.ui" line="2104"/>
         <source>Very slow</source>
         <translation>Très lente</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2225"/>
+        <location filename="../tsmuxerwindow.ui" line="2140"/>
         <source> Vertical position: </source>
         <translation> Position verticale : </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2236"/>
+        <location filename="../tsmuxerwindow.ui" line="2151"/>
         <source>Top of screen</source>
         <translation>En haut de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2270"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>top offset, pixels:</source>
         <translation>Nombre de pixels depuis le haut de l&apos;écran :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2304"/>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2219"/>
+        <location filename="../tsmuxerwindow.ui" line="2391"/>
         <source>Screen center</source>
         <translation>Au centre de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2311"/>
+        <location filename="../tsmuxerwindow.ui" line="2226"/>
         <source>Bottom of screen</source>
         <translation>En bas de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2345"/>
+        <location filename="../tsmuxerwindow.ui" line="2260"/>
         <source>bottom offset, pixels:</source>
         <translation>Nombre de pixels depuis le bas de l&apos;écran :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2397"/>
+        <location filename="../tsmuxerwindow.ui" line="2312"/>
         <source> Horizontal position: </source>
         <translation> Position horizontale : </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2408"/>
+        <location filename="../tsmuxerwindow.ui" line="2323"/>
         <source>Left of screen</source>
         <translation>À gauche de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2442"/>
+        <location filename="../tsmuxerwindow.ui" line="2357"/>
         <source>left offset, pixels:</source>
         <translation>Nombre de pixels depuis la gauche de l&apos;écran :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2489"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Right of screen</source>
         <translation>À droite de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2526"/>
+        <location filename="../tsmuxerwindow.ui" line="2441"/>
         <source>right offset, pixels:</source>
         <translation>Nombre de pixels depuis la droite de l&apos;écran :</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2591"/>
+        <location filename="../tsmuxerwindow.ui" line="2506"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2643"/>
+        <location filename="../tsmuxerwindow.ui" line="2558"/>
         <source>Output</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2657"/>
+        <location filename="../tsmuxerwindow.ui" line="2572"/>
         <source>TS muxing</source>
         <translation>Muxage en TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2673"/>
+        <location filename="../tsmuxerwindow.ui" line="2588"/>
         <source>M2TS muxing</source>
         <translation>Muxage en M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2595"/>
         <source>Blu-ray ISO</source>
         <translation>ISO de Blu-Ray</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2608"/>
         <source>Blu-ray folder</source>
         <translation>Dossier de Blu-Ray</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.ui" line="2615"/>
         <source>AVCHD folder</source>
         <translation>Dossier AVCHD</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2713"/>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.ui" line="2628"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Demux</source>
         <translation>Démuxer</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2737"/>
+        <location filename="../tsmuxerwindow.ui" line="2652"/>
         <source>Disk label</source>
         <translation>Titre du disque</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2747"/>
-        <location filename="../tsmuxerwindow.cpp" line="2334"/>
+        <location filename="../tsmuxerwindow.ui" line="2662"/>
+        <location filename="../tsmuxerwindow.cpp" line="2282"/>
         <source>File name</source>
         <translation>Nom du fichier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2773"/>
+        <location filename="../tsmuxerwindow.ui" line="2688"/>
         <source>Browse</source>
         <translation>Parcourir</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
+        <location filename="../tsmuxerwindow.ui" line="2712"/>
         <source>Meta file</source>
         <translation>Fichier Meta</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2866"/>
-        <location filename="../tsmuxerwindow.cpp" line="2318"/>
+        <location filename="../tsmuxerwindow.ui" line="2781"/>
+        <location filename="../tsmuxerwindow.cpp" line="2266"/>
         <source>Sta&amp;rt muxing</source>
         <translation>&amp;Démarrer le muxage</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2891"/>
+        <location filename="../tsmuxerwindow.ui" line="2806"/>
         <source>Save meta file</source>
         <translation>Sauvegarder le fichier Meta</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="28"/>
+        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
         <translation>Tous les fichiers média pris en charge (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 flux élémentaire (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Flux vidéo élémentaire Mpeg (*.mpv *.m1v *.m2v);;Flux audio élémentaire Mpeg (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Fichiers audio/vidéo Matroska (*.mkv *.mka *.mks);;Fichiers audio/vidéo MP4 (*.mp4 *.m4a *.m4v);;Fichiers audio/vidéo QuickTime (*.mov);;Liste de lecture Blu-Ray (*.mpls *.mpl);;Sous-titres PGS de Blu-ray (*.sup);;Sous-titres à base de texte (*.srt);;WAVE - Audio PCM non compressé (*.wav *.w64);;Flux LPCM RAW (*.pcm);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
         <translation>Transport stream (*.ts);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
         <translation>BDAV Transport Stream (*.m2ts);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <location filename="../tsmuxerwindow.cpp" line="61"/>
         <source>Disk image (*.iso);;all files (*.*)</source>
         <translation>Image disque (*.iso);; Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="543"/>
+        <location filename="../tsmuxerwindow.cpp" line="551"/>
         <source>Not supported</source>
         <translation>Non pris en charge</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="609"/>
-        <location filename="../tsmuxerwindow.cpp" line="1129"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="1135"/>
         <source>Unsupported format</source>
         <translation>Format non pris en charge</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="610"/>
+        <location filename="../tsmuxerwindow.cpp" line="618"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Impossible de déterminer le type de flux pour le fichier : &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="911"/>
         <source>Add media files</source>
         <translation>Ajouter un fichiers médias</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="920"/>
+        <location filename="../tsmuxerwindow.cpp" line="926"/>
         <source>File already exists</source>
         <translation>Le fichier existe déjà</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="921"/>
+        <location filename="../tsmuxerwindow.cpp" line="927"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Le fichier &quot;%1&quot; existe déjà</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="998"/>
+        <location filename="../tsmuxerwindow.cpp" line="1004"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>Réduire le DTS-HD en DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1000"/>
+        <location filename="../tsmuxerwindow.cpp" line="1006"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>Réduire le TRUE-HD en AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1002"/>
+        <location filename="../tsmuxerwindow.cpp" line="1008"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>Réduire le E-AC3 en AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="1141"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Format non pris en charge ou aucune piste n&apos;a été reconnue pour le fichier &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1145"/>
+        <location filename="../tsmuxerwindow.cpp" line="1151"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>La piste %1 n&apos;a pas été reconnue et a été ignorée pour le fichier &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Mux</source>
         <translation>Muxer</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1406"/>
+        <location filename="../tsmuxerwindow.cpp" line="1412"/>
         <source>tsMuxeR error</source>
         <translation>Erreur de tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1410"/>
+        <location filename="../tsmuxerwindow.cpp" line="1416"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxer introuvable !</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1428"/>
+        <location filename="../tsmuxerwindow.cpp" line="1434"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Impossible d&apos;exécuter tsMuxer !</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
-        <location filename="../tsmuxerwindow.cpp" line="2195"/>
+        <location filename="../tsmuxerwindow.cpp" line="2142"/>
+        <location filename="../tsmuxerwindow.cpp" line="2143"/>
         <source>No track selected</source>
         <translation>Aucune piste sélectionnée</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2201"/>
+        <location filename="../tsmuxerwindow.cpp" line="2149"/>
         <source>Append media files</source>
         <translation>Concaténer un fichiers médias</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2217"/>
+        <location filename="../tsmuxerwindow.cpp" line="2165"/>
         <source>Invalid file extension</source>
         <translation>Extension de fichier non valide</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2218"/>
+        <location filename="../tsmuxerwindow.cpp" line="2166"/>
         <source>Appended file must have same file extension.</source>
         <translation>Le fichier concaténé doit avoir la même extension de fichier.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2316"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Déma&amp;rrer le démuxage</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2278"/>
         <source>Folder</source>
         <translation>Dossier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>Select file for muxing</source>
         <translation>Sélectionner un fichier pour le muxage</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2442"/>
-        <location filename="../tsmuxerwindow.cpp" line="2458"/>
+        <location filename="../tsmuxerwindow.cpp" line="2386"/>
+        <location filename="../tsmuxerwindow.cpp" line="2402"/>
         <source>Invalid file name</source>
         <translation>Nom de fichier non valide</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2443"/>
+        <location filename="../tsmuxerwindow.cpp" line="2387"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Le fichier de sortie &quot;%1&quot;&apos; n&apos;a pas une extension valide. Veuillez changer l&apos;extension du fichier en &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2459"/>
+        <location filename="../tsmuxerwindow.cpp" line="2403"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Le fichier de sortie &quot;%1&quot;&apos; n&apos;a pas une extension valide. Veuillez changer l&apos;extension du fichier en &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation>fichier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>directory</source>
         <translation>dossier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2475"/>
+        <location filename="../tsmuxerwindow.cpp" line="2419"/>
         <source>Overwrite existing %1?</source>
         <translation>Écraser %1 qui existe déjà ?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2476"/>
+        <location filename="../tsmuxerwindow.cpp" line="2420"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>La sortie %1 &quot;%2&quot; existe déjà. Souhaitez-vous l&apos;écraser ?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Muxing in progress</source>
         <translation>Muxage en cours</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Demuxing in progress</source>
         <translation>Démuxage en cours</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2507"/>
+        <location filename="../tsmuxerwindow.cpp" line="2451"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>Fichier de projet tsMuxeR (*.meta);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2522"/>
+        <location filename="../tsmuxerwindow.cpp" line="2466"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Impossible de créer le fichier Meta temporaire</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2467"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Impossible de créer le fichier Meta temporaire &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>FontSettingsTableModel</name>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Name:</source>
+        <translation>Имя:</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Size:</source>
+        <translation>Размер:</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Color:</source>
+        <translation>Цвет:</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <source>Options:</source>
+        <translation>Параметры:</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../muxForm.cpp" line="48"/>
@@ -106,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="52"/>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>General track options</source>
         <translation>Общие параметры дорожки</translation>
     </message>
@@ -172,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1010"/>
         <source>Downconvert HD audio</source>
         <translation>Упростить HD звук</translation>
     </message>
@@ -198,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <location filename="../tsmuxerwindow.cpp" line="55"/>
         <source>Demux options</source>
         <translation>Параметры записи дорожек</translation>
     </message>
@@ -569,431 +592,376 @@
         <translation> Шрифт текстовых субтитров по умолчанию: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1979"/>
-        <location filename="../tsmuxerwindow.ui" line="1984"/>
-        <location filename="../tsmuxerwindow.ui" line="1989"/>
-        <location filename="../tsmuxerwindow.ui" line="1994"/>
-        <location filename="../tsmuxerwindow.ui" line="1999"/>
-        <source>New Row</source>
-        <translation>Новая Строка</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2004"/>
-        <location filename="../tsmuxerwindow.ui" line="2009"/>
-        <source>New Column</source>
-        <translation>Новый Столбец</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2014"/>
-        <source>Name:</source>
-        <translation>Имя:</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2024"/>
-        <source>Size:</source>
-        <translation>Размер:</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2029"/>
-        <source>65</source>
-        <translation>65</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2034"/>
-        <source>Color:</source>
-        <translation>Цвет:</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2039"/>
-        <source>0xffffffff</source>
-        <translation>0xffffffff</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2044"/>
-        <source>Charset:</source>
-        <translation>Набор символов:</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2049"/>
-        <source>Default</source>
-        <translation>По умолчанию</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2054"/>
-        <source>Options:</source>
-        <translation>Параметры:</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2075"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2082"/>
+        <location filename="../tsmuxerwindow.ui" line="1997"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2106"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Additional border, pixels:</source>
         <translation>Дополнительная рамка, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2132"/>
+        <location filename="../tsmuxerwindow.ui" line="2047"/>
         <source>line spacing:</source>
         <translation>Междустрочное расстояние:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2158"/>
+        <location filename="../tsmuxerwindow.ui" line="2073"/>
         <source>Fade in/out animation:</source>
         <translation>Анимация появления/исчезания:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2169"/>
+        <location filename="../tsmuxerwindow.ui" line="2084"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2174"/>
+        <location filename="../tsmuxerwindow.ui" line="2089"/>
         <source>Fast</source>
         <translation>Быстрое</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2179"/>
+        <location filename="../tsmuxerwindow.ui" line="2094"/>
         <source>Medium</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2184"/>
+        <location filename="../tsmuxerwindow.ui" line="2099"/>
         <source>Slow</source>
         <translation>Медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2189"/>
+        <location filename="../tsmuxerwindow.ui" line="2104"/>
         <source>Very slow</source>
         <translation>Очень медленное</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2225"/>
+        <location filename="../tsmuxerwindow.ui" line="2140"/>
         <source> Vertical position: </source>
         <translation> Позиция по вертикали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2236"/>
+        <location filename="../tsmuxerwindow.ui" line="2151"/>
         <source>Top of screen</source>
         <translation>Верх экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2270"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>top offset, pixels:</source>
         <translation>отступ от верха, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2304"/>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2219"/>
+        <location filename="../tsmuxerwindow.ui" line="2391"/>
         <source>Screen center</source>
         <translation>Центр экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2311"/>
+        <location filename="../tsmuxerwindow.ui" line="2226"/>
         <source>Bottom of screen</source>
         <translation>Низ экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2345"/>
+        <location filename="../tsmuxerwindow.ui" line="2260"/>
         <source>bottom offset, pixels:</source>
         <translation>отступ от низа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2397"/>
+        <location filename="../tsmuxerwindow.ui" line="2312"/>
         <source> Horizontal position: </source>
         <translation> Позиция по горизонтали: </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2408"/>
+        <location filename="../tsmuxerwindow.ui" line="2323"/>
         <source>Left of screen</source>
         <translation>слева экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2442"/>
+        <location filename="../tsmuxerwindow.ui" line="2357"/>
         <source>left offset, pixels:</source>
         <translation>отступ слева, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2489"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Right of screen</source>
         <translation>справа экрана</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2526"/>
+        <location filename="../tsmuxerwindow.ui" line="2441"/>
         <source>right offset, pixels:</source>
         <translation>отступ справа, пикселей:</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2591"/>
+        <location filename="../tsmuxerwindow.ui" line="2506"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2643"/>
+        <location filename="../tsmuxerwindow.ui" line="2558"/>
         <source>Output</source>
         <translation>Результат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2657"/>
+        <location filename="../tsmuxerwindow.ui" line="2572"/>
         <source>TS muxing</source>
         <translation>Запись в TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2673"/>
+        <location filename="../tsmuxerwindow.ui" line="2588"/>
         <source>M2TS muxing</source>
         <translation>Запись в M2TS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2595"/>
         <source>Blu-ray ISO</source>
         <translation>Запись блюрея в файл ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2608"/>
         <source>Blu-ray folder</source>
         <translation>Запись блюрея в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.ui" line="2615"/>
         <source>AVCHD folder</source>
         <translation>Запись AVCHD в папку</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2713"/>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.ui" line="2628"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2737"/>
+        <location filename="../tsmuxerwindow.ui" line="2652"/>
         <source>Disk label</source>
         <translation>Имя диска</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2747"/>
-        <location filename="../tsmuxerwindow.cpp" line="2334"/>
+        <location filename="../tsmuxerwindow.ui" line="2662"/>
+        <location filename="../tsmuxerwindow.cpp" line="2282"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2773"/>
+        <location filename="../tsmuxerwindow.ui" line="2688"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
+        <location filename="../tsmuxerwindow.ui" line="2712"/>
         <source>Meta file</source>
         <translation>Файл проекта tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2866"/>
-        <location filename="../tsmuxerwindow.cpp" line="2318"/>
+        <location filename="../tsmuxerwindow.ui" line="2781"/>
+        <location filename="../tsmuxerwindow.cpp" line="2266"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2891"/>
+        <location filename="../tsmuxerwindow.ui" line="2806"/>
         <source>Save meta file</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="28"/>
+        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
         <translation>Все поддерживаемые медиафайлы (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;Элементарный поток AVC/MVC/H.264 (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Элеменарный поток MPEG видео (*.mpv *.m1v *.m2v);;Элеменарный поток MPEG аудио (*.mpa);;Транспортный поток (*.ts);;Транспортный поток BDAV (*.m2ts *.mts *.ssif);;Программный поток (*.mpg *.mpeg *.vob *.evo);;Аудио/видео файлы матрёшки (*.mkv *.mka *.mks);;Аудио/видео файлы MP4 (*.mp4 *.m4a *.m4v);;Аудио/видео файлы Quick time (*.mov);;Плейлист блюрея (*.mpls *.mpl);;PGS субтитры блюрея (*.sup);;Текстовые субтитры (*.srt);;WAVE - Несжатый звук PCM (*.wav *.w64);;RAW LPCM поток (*.pcm);;Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
         <translation>Транспортный поток (*.ts);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
         <translation>Транспортный поток BDAV (*.m2ts);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <location filename="../tsmuxerwindow.cpp" line="61"/>
         <source>Disk image (*.iso);;all files (*.*)</source>
         <translation>Образ диска (*.iso);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="543"/>
+        <location filename="../tsmuxerwindow.cpp" line="551"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="609"/>
-        <location filename="../tsmuxerwindow.cpp" line="1129"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="1135"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="610"/>
+        <location filename="../tsmuxerwindow.cpp" line="618"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="911"/>
         <source>Add media files</source>
         <translation>Добавить медиафайлы</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="920"/>
+        <location filename="../tsmuxerwindow.cpp" line="926"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="921"/>
+        <location filename="../tsmuxerwindow.cpp" line="927"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="998"/>
+        <location filename="../tsmuxerwindow.cpp" line="1004"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>Преобразовать из DTS-HD в DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1000"/>
+        <location filename="../tsmuxerwindow.cpp" line="1006"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>Преобразовать из TRUE-HD в AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1002"/>
+        <location filename="../tsmuxerwindow.cpp" line="1008"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>Преобразовать из E-AC3 в AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="1141"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1145"/>
+        <location filename="../tsmuxerwindow.cpp" line="1151"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>Дорожка %1 не распознана и проигнорирована. Имя файла: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1406"/>
+        <location filename="../tsmuxerwindow.cpp" line="1412"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1410"/>
+        <location filename="../tsmuxerwindow.cpp" line="1416"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1428"/>
+        <location filename="../tsmuxerwindow.cpp" line="1434"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
-        <location filename="../tsmuxerwindow.cpp" line="2195"/>
+        <location filename="../tsmuxerwindow.cpp" line="2142"/>
+        <location filename="../tsmuxerwindow.cpp" line="2143"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2201"/>
+        <location filename="../tsmuxerwindow.cpp" line="2149"/>
         <source>Append media files</source>
         <translation>Присоединить медиафайлы</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2217"/>
+        <location filename="../tsmuxerwindow.cpp" line="2165"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2218"/>
+        <location filename="../tsmuxerwindow.cpp" line="2166"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2316"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2278"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2442"/>
-        <location filename="../tsmuxerwindow.cpp" line="2458"/>
+        <location filename="../tsmuxerwindow.cpp" line="2386"/>
+        <location filename="../tsmuxerwindow.cpp" line="2402"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2443"/>
+        <location filename="../tsmuxerwindow.cpp" line="2387"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2459"/>
+        <location filename="../tsmuxerwindow.cpp" line="2403"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2475"/>
+        <location filename="../tsmuxerwindow.cpp" line="2419"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2476"/>
+        <location filename="../tsmuxerwindow.cpp" line="2420"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2507"/>
+        <location filename="../tsmuxerwindow.cpp" line="2451"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>Файл проекта tsMuxeR (*.meta);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2522"/>
+        <location filename="../tsmuxerwindow.cpp" line="2466"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2467"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_zh.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_zh.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>FontSettingsTableModel</name>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Name:</source>
+        <translation>名称：</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Size:</source>
+        <translation>尺寸：</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <source>Color:</source>
+        <translation>颜色：</translation>
+    </message>
+    <message>
+        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <source>Options:</source>
+        <translation>选项：</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../muxForm.cpp" line="48"/>
@@ -106,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="52"/>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>General track options</source>
         <translation>常规轨道选项</translation>
     </message>
@@ -172,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1010"/>
         <source>Downconvert HD audio</source>
         <translation>降频高清音频</translation>
     </message>
@@ -198,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="54"/>
+        <location filename="../tsmuxerwindow.cpp" line="55"/>
         <source>Demux options</source>
         <translation>Demux选项</translation>
     </message>
@@ -569,430 +592,375 @@
         <translation> 默认的基于文本的字幕字体： </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="1979"/>
-        <location filename="../tsmuxerwindow.ui" line="1984"/>
-        <location filename="../tsmuxerwindow.ui" line="1989"/>
-        <location filename="../tsmuxerwindow.ui" line="1994"/>
-        <location filename="../tsmuxerwindow.ui" line="1999"/>
-        <source>New Row</source>
-        <translation>新行</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2004"/>
-        <location filename="../tsmuxerwindow.ui" line="2009"/>
-        <source>New Column</source>
-        <translation>新列</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2014"/>
-        <source>Name:</source>
-        <translation>名称：</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2024"/>
-        <source>Size:</source>
-        <translation>尺寸：</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2029"/>
-        <source>65</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2034"/>
-        <source>Color:</source>
-        <translation>颜色：</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2039"/>
-        <source>0xffffffff</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2044"/>
-        <source>Charset:</source>
-        <translation>字符集：</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2049"/>
-        <source>Default</source>
-        <translation>默认</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2054"/>
-        <source>Options:</source>
-        <translation>选项：</translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.ui" line="2075"/>
+        <location filename="../tsmuxerwindow.ui" line="1990"/>
         <source>Font</source>
         <translation>字体</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2082"/>
+        <location filename="../tsmuxerwindow.ui" line="1997"/>
         <source>Color</source>
         <translation>颜色</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2106"/>
+        <location filename="../tsmuxerwindow.ui" line="2021"/>
         <source>Additional border, pixels:</source>
         <translation>额外边框, 像素：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2132"/>
+        <location filename="../tsmuxerwindow.ui" line="2047"/>
         <source>line spacing:</source>
         <translation>行间距：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2158"/>
+        <location filename="../tsmuxerwindow.ui" line="2073"/>
         <source>Fade in/out animation:</source>
         <translation>淡入/淡出 动画：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2169"/>
+        <location filename="../tsmuxerwindow.ui" line="2084"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2174"/>
+        <location filename="../tsmuxerwindow.ui" line="2089"/>
         <source>Fast</source>
         <translation>快速</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2179"/>
+        <location filename="../tsmuxerwindow.ui" line="2094"/>
         <source>Medium</source>
         <translation>中等</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2184"/>
+        <location filename="../tsmuxerwindow.ui" line="2099"/>
         <source>Slow</source>
         <translation>慢</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2189"/>
+        <location filename="../tsmuxerwindow.ui" line="2104"/>
         <source>Very slow</source>
         <translation>非常慢</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2225"/>
+        <location filename="../tsmuxerwindow.ui" line="2140"/>
         <source> Vertical position: </source>
         <translation> 垂直位置： </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2236"/>
+        <location filename="../tsmuxerwindow.ui" line="2151"/>
         <source>Top of screen</source>
         <translation>屏幕上方</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2270"/>
+        <location filename="../tsmuxerwindow.ui" line="2185"/>
         <source>top offset, pixels:</source>
         <translation>顶部偏移,像素：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2304"/>
-        <location filename="../tsmuxerwindow.ui" line="2476"/>
+        <location filename="../tsmuxerwindow.ui" line="2219"/>
+        <location filename="../tsmuxerwindow.ui" line="2391"/>
         <source>Screen center</source>
         <translation>屏幕中心</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2311"/>
+        <location filename="../tsmuxerwindow.ui" line="2226"/>
         <source>Bottom of screen</source>
         <translation>屏幕底部</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2345"/>
+        <location filename="../tsmuxerwindow.ui" line="2260"/>
         <source>bottom offset, pixels:</source>
         <translation>底部偏移, 像素：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2397"/>
+        <location filename="../tsmuxerwindow.ui" line="2312"/>
         <source> Horizontal position: </source>
         <translation> 水平位置： </translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2408"/>
+        <location filename="../tsmuxerwindow.ui" line="2323"/>
         <source>Left of screen</source>
         <translation>屏幕左侧</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2442"/>
+        <location filename="../tsmuxerwindow.ui" line="2357"/>
         <source>left offset, pixels:</source>
         <translation>左偏移, 像素：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2489"/>
+        <location filename="../tsmuxerwindow.ui" line="2404"/>
         <source>Right of screen</source>
         <translation>屏幕右侧</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2526"/>
+        <location filename="../tsmuxerwindow.ui" line="2441"/>
         <source>right offset, pixels:</source>
         <translation>右偏移, 像素：</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2591"/>
+        <location filename="../tsmuxerwindow.ui" line="2506"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2643"/>
+        <location filename="../tsmuxerwindow.ui" line="2558"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2657"/>
+        <location filename="../tsmuxerwindow.ui" line="2572"/>
         <source>TS muxing</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2673"/>
+        <location filename="../tsmuxerwindow.ui" line="2588"/>
         <source>M2TS muxing</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2680"/>
+        <location filename="../tsmuxerwindow.ui" line="2595"/>
         <source>Blu-ray ISO</source>
         <translation>蓝光ISO</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2693"/>
+        <location filename="../tsmuxerwindow.ui" line="2608"/>
         <source>Blu-ray folder</source>
         <translation>蓝光目录</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2700"/>
+        <location filename="../tsmuxerwindow.ui" line="2615"/>
         <source>AVCHD folder</source>
         <translation>AVCHD 目录</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2713"/>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.ui" line="2628"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Demux</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2737"/>
+        <location filename="../tsmuxerwindow.ui" line="2652"/>
         <source>Disk label</source>
         <translation>ISO标签</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2747"/>
-        <location filename="../tsmuxerwindow.cpp" line="2334"/>
+        <location filename="../tsmuxerwindow.ui" line="2662"/>
+        <location filename="../tsmuxerwindow.cpp" line="2282"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2773"/>
+        <location filename="../tsmuxerwindow.ui" line="2688"/>
         <source>Browse</source>
         <translation>浏览</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2797"/>
+        <location filename="../tsmuxerwindow.ui" line="2712"/>
         <source>Meta file</source>
         <translation>项目文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2866"/>
-        <location filename="../tsmuxerwindow.cpp" line="2318"/>
+        <location filename="../tsmuxerwindow.ui" line="2781"/>
+        <location filename="../tsmuxerwindow.cpp" line="2266"/>
         <source>Sta&amp;rt muxing</source>
         <translation>开始muxing</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.ui" line="2891"/>
+        <location filename="../tsmuxerwindow.ui" line="2806"/>
         <source>Save meta file</source>
         <translation>保存项目文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="28"/>
+        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
         <translation>所有支持的媒体文件 (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (高级音频编码)) (*.aac);;AVC/MVC/H.264 基本流 (*.avc *.mvc *.264 *.h264);;HEVC (高效视频编解码器) (*.hevc *.hvc *.265 *.h265);;数字影院系统 (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg视频基本流 (*.mpv *.m1v *.m2v);;MPEG 音频基本流 (*.mpa);;传输流 (*.ts);;BDAV 传输流 (*.m2ts *.mts *.ssif);;节目流 (*.mpg *.mpeg *.vob *.evo);;Matroska 音频/视频 文件 (*.mkv *.mka *.mks);;MP4 音频/视频 文件 (*.mp4 *.m4a *.m4v);;Quick 音频/视频 文件 (*.mov);;蓝光播放列表 (*.mpls *.mpl);;蓝光PGS字幕 (*.sup);;文本字幕 (*.srt);;WAVE-未压缩的PCM音频 (*.wav *.w64);;RAW LPCM流 (*.pcm);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="56"/>
+        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
         <translation>传输流 (*.ts);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="58"/>
+        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
         <translation>BDAV 传输流 (*.m2ts);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <location filename="../tsmuxerwindow.cpp" line="61"/>
         <source>Disk image (*.iso);;all files (*.*)</source>
         <translation>磁盘镜像 (*.iso);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="543"/>
+        <location filename="../tsmuxerwindow.cpp" line="551"/>
         <source>Not supported</source>
         <translation>不支持</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="609"/>
-        <location filename="../tsmuxerwindow.cpp" line="1129"/>
+        <location filename="../tsmuxerwindow.cpp" line="617"/>
+        <location filename="../tsmuxerwindow.cpp" line="1135"/>
         <source>Unsupported format</source>
         <translation>不支持的格式</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="610"/>
+        <location filename="../tsmuxerwindow.cpp" line="618"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>无法检测流类型。 文件名： &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="905"/>
+        <location filename="../tsmuxerwindow.cpp" line="911"/>
         <source>Add media files</source>
         <translation>添加媒体文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="920"/>
+        <location filename="../tsmuxerwindow.cpp" line="926"/>
         <source>File already exists</source>
         <translation>文件已存在</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="921"/>
+        <location filename="../tsmuxerwindow.cpp" line="927"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>文件 &quot;%1&quot; 已存在</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="998"/>
+        <location filename="../tsmuxerwindow.cpp" line="1004"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>降频转换DTS-HD为DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1000"/>
+        <location filename="../tsmuxerwindow.cpp" line="1006"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>降频转换TRUE-HD为AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1002"/>
+        <location filename="../tsmuxerwindow.cpp" line="1008"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>降频转换E-AC3为AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="1141"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>不支持的格式或无法识别所有轨道。文件名： &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1145"/>
+        <location filename="../tsmuxerwindow.cpp" line="1151"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>轨道 %1 无法识别和忽略。文件名： &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1387"/>
+        <location filename="../tsmuxerwindow.cpp" line="1393"/>
         <source>Mux</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1406"/>
+        <location filename="../tsmuxerwindow.cpp" line="1412"/>
         <source>tsMuxeR error</source>
         <translation>tsMuxeR 错误</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1410"/>
+        <location filename="../tsmuxerwindow.cpp" line="1416"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR 未找到！</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1428"/>
+        <location filename="../tsmuxerwindow.cpp" line="1434"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>无法执行tsMuxeR！</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2194"/>
-        <location filename="../tsmuxerwindow.cpp" line="2195"/>
+        <location filename="../tsmuxerwindow.cpp" line="2142"/>
+        <location filename="../tsmuxerwindow.cpp" line="2143"/>
         <source>No track selected</source>
         <translation>未选定轨道</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2201"/>
+        <location filename="../tsmuxerwindow.cpp" line="2149"/>
         <source>Append media files</source>
         <translation>附加媒体文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2217"/>
+        <location filename="../tsmuxerwindow.cpp" line="2165"/>
         <source>Invalid file extension</source>
         <translation>无效的文件扩展名</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2218"/>
+        <location filename="../tsmuxerwindow.cpp" line="2166"/>
         <source>Appended file must have same file extension.</source>
         <translation>附加文件必须具有相同的文件扩展名。</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2316"/>
+        <location filename="../tsmuxerwindow.cpp" line="2264"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>开始demuxing</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2330"/>
+        <location filename="../tsmuxerwindow.cpp" line="2278"/>
         <source>Folder</source>
         <translation>文件夹</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2364"/>
         <source>Select file for muxing</source>
         <translation>选择要muxing的文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2442"/>
-        <location filename="../tsmuxerwindow.cpp" line="2458"/>
+        <location filename="../tsmuxerwindow.cpp" line="2386"/>
+        <location filename="../tsmuxerwindow.cpp" line="2402"/>
         <source>Invalid file name</source>
         <translation>无效的文件名</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2443"/>
+        <location filename="../tsmuxerwindow.cpp" line="2387"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>输出文件 &quot;%1&quot; 具有无效的扩展名。 请将文件扩展名更改为 &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2459"/>
+        <location filename="../tsmuxerwindow.cpp" line="2403"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>输出文件 &quot;%1&quot; 具有无效的扩展名。 请将文件扩展名更改为 &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2473"/>
+        <location filename="../tsmuxerwindow.cpp" line="2417"/>
         <source>directory</source>
         <translation>目录</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2475"/>
+        <location filename="../tsmuxerwindow.cpp" line="2419"/>
         <source>Overwrite existing %1?</source>
         <translation>覆盖现有的 %1？</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2476"/>
+        <location filename="../tsmuxerwindow.cpp" line="2420"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>输出 %1 &quot;%2&quot; 已存在。要覆盖它吗？</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Muxing in progress</source>
         <translation>Muxing正在进行中</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2493"/>
+        <location filename="../tsmuxerwindow.cpp" line="2437"/>
         <source>Demuxing in progress</source>
         <translation>Demuxing正在进行中</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2507"/>
+        <location filename="../tsmuxerwindow.cpp" line="2451"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>tsMuxeR 项目文件 (*.meta);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2522"/>
+        <location filename="../tsmuxerwindow.cpp" line="2466"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>无法创建临时项目文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2523"/>
+        <location filename="../tsmuxerwindow.cpp" line="2467"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>无法创建临时项目文件 &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/tsMuxerGUI.pro
+++ b/tsMuxerGUI/tsMuxerGUI.pro
@@ -7,11 +7,12 @@
 TEMPLATE = app
 TARGET = tsMuxerGUI
 QT = core gui widgets multimedia
-CONFIG += c++14 strict_c++ lrelease embed_translations
+CONFIG += c++17 strict_c++ lrelease embed_translations
 
 HEADERS += tsmuxerwindow.h lang_codes.h muxForm.h checkboxedheaderview.h \
-           codecinfo.h
-SOURCES += main.cpp tsmuxerwindow.cpp muxForm.cpp checkboxedheaderview.cpp
+           codecinfo.h fontsettingstablemodel.h
+SOURCES += main.cpp tsmuxerwindow.cpp muxForm.cpp checkboxedheaderview.cpp \
+           fontsettingstablemodel.cpp
 FORMS += tsmuxerwindow.ui muxForm.ui
 
 RESOURCES += images.qrc

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -329,7 +329,7 @@ TsMuxerWindow::TsMuxerWindow()
         ui->trackLV->horizontalHeader()->resizeSection(i, colWidths[i]);
     ui->trackLV->setWordWrap(false);
 
-    fontSettingsModel = new FontSettingsTableModel();
+    fontSettingsModel = new FontSettingsTableModel(this);
     ui->fontSettingsTableView->setModel(fontSettingsModel);
     ui->fontSettingsTableView->horizontalHeader()->resizeSection(0, 65);
     ui->fontSettingsTableView->horizontalHeader()->resizeSection(1, 185);

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -296,7 +296,7 @@ TsMuxerWindow::TsMuxerWindow()
     QString path = QFileInfo(QApplication::arguments()[0]).absolutePath();
     QString iniName = QDir::toNativeSeparators(path) + QDir::separator() + QString("tsMuxerGUI.ini");
 
-    settings = new QSettings(QSettings::UserScope, "Network Optix", "tsMuxeR");
+    settings = new QSettings();
     readSettings();
 
     if (QFile::exists(iniName))
@@ -2658,12 +2658,6 @@ void TsMuxerWindow::writeSettings()
     settings->setValue("fontLineSpacing", ui->lineSpacing->value());
     settings->setValue("offset", ui->spinEditOffset->value());
     settings->setValue("fadeTime", getRendererAnimationTime());
-#if 0
-    settings->setValue("family", ui->listViewFont->item(0, 1)->text());
-    settings->setValue("size", ui->listViewFont->item(1, 1)->text().toUInt());
-    settings->setValue("color", ui->listViewFont->item(2, 1)->text().mid(2).toUInt(0, 16));
-    settings->setValue("options", ui->listViewFont->item(3, 1)->text());
-#endif
     settings->endGroup();
 
     settings->beginGroup("pip");
@@ -2695,26 +2689,6 @@ bool TsMuxerWindow::readSettings()
     ui->lineSpacing->setValue(settings->value("fontLineSpacing").toDouble());
     setRendererAnimationTime(settings->value("fadeTime").toDouble());
     ui->spinEditOffset->setValue(settings->value("offset").toInt());
-    // keep backward compatibility with versions < 2.6.15 which contain "famaly" key
-    if (settings->contains("famaly"))
-    {
-        settings->setValue("family", settings->value("famaly"));
-        settings->remove("famaly");
-    }
-    QString fontName = settings->value("family").toString();
-#if 0
-    if (!fontName.isEmpty())
-        ui->listViewFont->item(0, 1)->setText(fontName);
-    int fontSize = settings->value("size").toInt();
-    if (fontSize > 0)
-        ui->listViewFont->item(1, 1)->setText(QString::number(fontSize));
-    if (!settings->value("color").isNull())
-    {
-        quint32 color = settings->value("color").toUInt();
-        setTextItemColor(QString::number(color, 16));
-    }
-    ui->listViewFont->item(3, 1)->setText(settings->value("options").toString());
-#endif
     settings->endGroup();
 
     settings->beginGroup("pip");

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -2492,6 +2492,7 @@ void TsMuxerWindow::changeEvent(QEvent *event)
     if (event->type() == QEvent::LanguageChange)
     {
         ui->retranslateUi(this);
+        fontSettingsModel->onLanguageChanged();
     }
     QWidget::changeEvent(event);
 }

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1673,8 +1673,10 @@ void TsMuxerWindow::setRendererAnimationTime(double value)
 QString TsMuxerWindow::getSrtParams()
 {
     auto &font = fontSettingsModel->font();
-    auto rez = QString(",font-name=\"%1\",font-size=%2,font-color=%3")
-                   .arg(font.family(), font.pointSize(), fontSettingsModel->color());
+    auto rez = QString(",font-name=\"%1\",font-size=%2,font-color=0x%3")
+                   .arg(font.family())
+                   .arg(font.pointSize())
+                   .arg(fontSettingsModel->color(), 8, 16, QLatin1Char('0'));
 
     if (ui->lineSpacing->value() != 1.0)
         rez += ",line-spacing=" + QString::number(ui->lineSpacing->value());

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -17,6 +17,7 @@
 
 #include "checkboxedheaderview.h"
 #include "codecinfo.h"
+#include "fontsettingstablemodel.h"
 #include "lang_codes.h"
 #include "muxForm.h"
 #include "ui_tsmuxerwindow.h"
@@ -328,10 +329,11 @@ TsMuxerWindow::TsMuxerWindow()
         ui->trackLV->horizontalHeader()->resizeSection(i, colWidths[i]);
     ui->trackLV->setWordWrap(false);
 
-    ui->fontSettingsTableView->setModel(&fontSettingsModel);
+    fontSettingsModel = new FontSettingsTableModel();
+    ui->fontSettingsTableView->setModel(fontSettingsModel);
     ui->fontSettingsTableView->horizontalHeader()->resizeSection(0, 65);
     ui->fontSettingsTableView->horizontalHeader()->resizeSection(1, 185);
-    for (int i = 0; i < fontSettingsModel.rowCount(QModelIndex()); ++i)
+    for (int i = 0; i < fontSettingsModel->rowCount(QModelIndex()); ++i)
     {
         ui->fontSettingsTableView->setRowHeight(i, 20);
     }
@@ -1670,9 +1672,9 @@ void TsMuxerWindow::setRendererAnimationTime(double value)
 
 QString TsMuxerWindow::getSrtParams()
 {
-    auto &font = fontSettingsModel.font();
+    auto &font = fontSettingsModel->font();
     auto rez = QString(",font-name=\"%1\",font-size=%2,font-color=%3")
-                   .arg(font.family(), font.pointSize(), fontSettingsModel.color());
+                   .arg(font.family(), font.pointSize(), fontSettingsModel->color());
 
     if (ui->lineSpacing->value() != 1.0)
         rez += ",line-spacing=" + QString::number(ui->lineSpacing->value());
@@ -1956,10 +1958,10 @@ void TsMuxerWindow::updateMetaLines()
 void TsMuxerWindow::onFontBtnClicked()
 {
     bool ok;
-    auto font = QFontDialog::getFont(&ok, fontSettingsModel.font(), this);
+    auto font = QFontDialog::getFont(&ok, fontSettingsModel->font(), this);
     if (ok)
     {
-        fontSettingsModel.setFont(font);
+        fontSettingsModel->setFont(font);
         writeSettings();
         updateMetaLines();
     }
@@ -1967,9 +1969,9 @@ void TsMuxerWindow::onFontBtnClicked()
 
 void TsMuxerWindow::onColorBtnClicked()
 {
-    QColor color = fontSettingsModel.color();
+    QColor color = fontSettingsModel->color();
     color = QColorDialog::getColor(color, this);
-    fontSettingsModel.setColor(color.rgba());
+    fontSettingsModel->setColor(color.rgba());
 
     writeSettings();
     updateMetaLines();

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -197,8 +197,8 @@ class TsMuxerWindow : public QWidget
     QSoundEffect sound;
     void myPlaySound(const QString& fileName);
     bool isVideoCropped();
-    
-    FontSettingsTableModel *fontSettingsModel;
+
+    FontSettingsTableModel* fontSettingsModel;
 };
 
 Q_DECLARE_METATYPE(ChapterList);

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -9,7 +9,6 @@
 #include <QWidget>
 
 #include "codecinfo.h"
-#include "fontsettingstablemodel.h"
 
 class QFileDialog;
 class QTableWidgetItem;
@@ -23,6 +22,7 @@ class TsMuxerWindow;
 }
 
 class QnCheckBoxedHeaderView;
+class FontSettingsTableModel;
 
 typedef QList<double> ChapterList;
 
@@ -198,7 +198,7 @@ class TsMuxerWindow : public QWidget
     void myPlaySound(const QString& fileName);
     bool isVideoCropped();
     
-    FontSettingsTableModel fontSettingsModel;
+    FontSettingsTableModel *fontSettingsModel;
 };
 
 Q_DECLARE_METATYPE(ChapterList);

--- a/tsMuxerGUI/tsmuxerwindow.h
+++ b/tsMuxerGUI/tsmuxerwindow.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 
 #include "codecinfo.h"
+#include "fontsettingstablemodel.h"
 
 class QFileDialog;
 class QTableWidgetItem;
@@ -91,7 +92,6 @@ class TsMuxerWindow : public QWidget
     void updateMuxTime1();
     void updateMuxTime2();
     void onLanguageComboBoxIndexChanged(int);
-    void provideDefaultFontSettings();
     template <typename OnCodecListReadyFn, typename PostActionSignal, typename PostActionFn>
     void processAddFileList(OnCodecListReadyFn onCodecListReady, PostActionSignal postActionSignal,
                             PostActionFn postActionFn);
@@ -197,6 +197,8 @@ class TsMuxerWindow : public QWidget
     QSoundEffect sound;
     void myPlaySound(const QString& fileName);
     bool isVideoCropped();
+    
+    FontSettingsTableModel fontSettingsModel;
 };
 
 Q_DECLARE_METATYPE(ChapterList);

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -31,7 +31,7 @@
      </property>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>4</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="GeneralTab">
        <property name="enabled">
@@ -629,16 +629,7 @@
             <string>General track options</string>
            </attribute>
            <layout class="QHBoxLayout" name="horizontalLayout_13">
-            <property name="leftMargin">
-             <number>5</number>
-            </property>
-            <property name="topMargin">
-             <number>5</number>
-            </property>
-            <property name="rightMargin">
-             <number>5</number>
-            </property>
-            <property name="bottomMargin">
+            <property name="margin">
              <number>5</number>
             </property>
             <item>
@@ -776,16 +767,7 @@
             <string>Demux options</string>
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_5">
-            <property name="leftMargin">
-             <number>5</number>
-            </property>
-            <property name="topMargin">
-             <number>5</number>
-            </property>
-            <property name="rightMargin">
-             <number>5</number>
-            </property>
-            <property name="bottomMargin">
+            <property name="margin">
              <number>5</number>
             </property>
             <item>
@@ -845,16 +827,7 @@
              <string>Bitrate</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_17">
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
+             <property name="margin">
               <number>5</number>
              </property>
              <item>
@@ -1194,16 +1167,7 @@
            <string>Chapters</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_11">
-           <property name="leftMargin">
-            <number>5</number>
-           </property>
-           <property name="topMargin">
-            <number>5</number>
-           </property>
-           <property name="rightMargin">
-            <number>5</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>5</number>
            </property>
            <item>
@@ -1350,14 +1314,14 @@
             </layout>
            </item>
            <item>
-            <widget class="QCheckBox" name="checkBoxV3">
-             <property name="text">
-              <string>Force BD-ROM V3 format</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
+             <widget class="QCheckBox" name="checkBoxV3">
+               <property name="text">
+                 <string>Force BD-ROM V3 format</string>
+               </property>
+               <property name="checked">
+                 <bool>false</bool>
+               </property>
+             </widget>
            </item>
            <item>
             <layout class="QGridLayout" name="gridLayout_10">
@@ -1696,16 +1660,7 @@
         <string>Split &amp;&amp; cut</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_8">
-        <property name="leftMargin">
-         <number>5</number>
-        </property>
-        <property name="topMargin">
-         <number>5</number>
-        </property>
-        <property name="rightMargin">
-         <number>5</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>5</number>
         </property>
         <item>
@@ -1720,16 +1675,7 @@
            <string>Splitting</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_21">
-           <property name="leftMargin">
-            <number>5</number>
-           </property>
-           <property name="topMargin">
-            <number>5</number>
-           </property>
-           <property name="rightMargin">
-            <number>5</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>5</number>
            </property>
            <item>
@@ -1873,16 +1819,7 @@
            <string>Cutting</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_23">
-           <property name="leftMargin">
-            <number>5</number>
-           </property>
-           <property name="topMargin">
-            <number>5</number>
-           </property>
-           <property name="rightMargin">
-            <number>5</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>5</number>
            </property>
            <item>
@@ -1994,16 +1931,7 @@
         <string>Subtitles</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_9">
-        <property name="leftMargin">
-         <number>5</number>
-        </property>
-        <property name="topMargin">
-         <number>5</number>
-        </property>
-        <property name="rightMargin">
-         <number>5</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>5</number>
         </property>
         <item>
@@ -2018,20 +1946,36 @@
            <string> Default text based subtitles font: </string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_25">
-           <property name="leftMargin">
-            <number>5</number>
-           </property>
-           <property name="topMargin">
-            <number>5</number>
-           </property>
-           <property name="rightMargin">
-            <number>5</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>5</number>
            </property>
            <item>
             <layout class="QGridLayout" name="gridLayout_7">
+             <item row="1" column="0">
+              <widget class="QTableView" name="fontSettingsTableView">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>84</height>
+                </size>
+               </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="horizontalHeaderStretchLastSection">
+                <bool>true</bool>
+               </attribute>
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+              </widget>
+             </item>
              <item row="1" column="1">
               <layout class="QVBoxLayout" name="verticalLayout_16">
                <item>
@@ -2163,37 +2107,6 @@
                 </widget>
                </item>
               </layout>
-             </item>
-             <item row="1" column="0">
-              <widget class="QTableView" name="fontSettingsTableView">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>84</height>
-                </size>
-               </property>
-               <attribute name="horizontalHeaderVisible">
-                <bool>false</bool>
-               </attribute>
-               <attribute name="horizontalHeaderDefaultSectionSize">
-                <number>26</number>
-               </attribute>
-               <attribute name="verticalHeaderVisible">
-                <bool>false</bool>
-               </attribute>
-               <attribute name="verticalHeaderCascadingSectionResizes">
-                <bool>true</bool>
-               </attribute>
-               <attribute name="verticalHeaderDefaultSectionSize">
-                <number>19</number>
-               </attribute>
-              </widget>
              </item>
             </layout>
            </item>
@@ -2593,16 +2506,7 @@
         <string>About</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_12">
-        <property name="leftMargin">
-         <number>5</number>
-        </property>
-        <property name="topMargin">
-         <number>5</number>
-        </property>
-        <property name="rightMargin">
-         <number>5</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>5</number>
         </property>
         <item>
@@ -2639,16 +2543,7 @@ p, li { white-space: pre-wrap; }
        <property name="spacing">
         <number>4</number>
        </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item>

--- a/tsMuxerGUI/tsmuxerwindow.ui
+++ b/tsMuxerGUI/tsmuxerwindow.ui
@@ -31,7 +31,7 @@
      </property>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="GeneralTab">
        <property name="enabled">
@@ -629,7 +629,16 @@
             <string>General track options</string>
            </attribute>
            <layout class="QHBoxLayout" name="horizontalLayout_13">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>5</number>
+            </property>
+            <property name="topMargin">
+             <number>5</number>
+            </property>
+            <property name="rightMargin">
+             <number>5</number>
+            </property>
+            <property name="bottomMargin">
              <number>5</number>
             </property>
             <item>
@@ -767,7 +776,16 @@
             <string>Demux options</string>
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout_5">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>5</number>
+            </property>
+            <property name="topMargin">
+             <number>5</number>
+            </property>
+            <property name="rightMargin">
+             <number>5</number>
+            </property>
+            <property name="bottomMargin">
              <number>5</number>
             </property>
             <item>
@@ -827,7 +845,16 @@
              <string>Bitrate</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_17">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
               <number>5</number>
              </property>
              <item>
@@ -1167,7 +1194,16 @@
            <string>Chapters</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_11">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>5</number>
+           </property>
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <property name="rightMargin">
+            <number>5</number>
+           </property>
+           <property name="bottomMargin">
             <number>5</number>
            </property>
            <item>
@@ -1314,14 +1350,14 @@
             </layout>
            </item>
            <item>
-             <widget class="QCheckBox" name="checkBoxV3">
-               <property name="text">
-                 <string>Force BD-ROM V3 format</string>
-               </property>
-               <property name="checked">
-                 <bool>false</bool>
-               </property>
-             </widget>
+            <widget class="QCheckBox" name="checkBoxV3">
+             <property name="text">
+              <string>Force BD-ROM V3 format</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
            </item>
            <item>
             <layout class="QGridLayout" name="gridLayout_10">
@@ -1660,7 +1696,16 @@
         <string>Split &amp;&amp; cut</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_8">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>5</number>
+        </property>
+        <property name="bottomMargin">
          <number>5</number>
         </property>
         <item>
@@ -1675,7 +1720,16 @@
            <string>Splitting</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_21">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>5</number>
+           </property>
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <property name="rightMargin">
+            <number>5</number>
+           </property>
+           <property name="bottomMargin">
             <number>5</number>
            </property>
            <item>
@@ -1819,7 +1873,16 @@
            <string>Cutting</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_23">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>5</number>
+           </property>
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <property name="rightMargin">
+            <number>5</number>
+           </property>
+           <property name="bottomMargin">
             <number>5</number>
            </property>
            <item>
@@ -1931,7 +1994,16 @@
         <string>Subtitles</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_9">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>5</number>
+        </property>
+        <property name="bottomMargin">
          <number>5</number>
         </property>
         <item>
@@ -1946,106 +2018,20 @@
            <string> Default text based subtitles font: </string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_25">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>5</number>
+           </property>
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <property name="rightMargin">
+            <number>5</number>
+           </property>
+           <property name="bottomMargin">
             <number>5</number>
            </property>
            <item>
             <layout class="QGridLayout" name="gridLayout_7">
-             <item row="1" column="0">
-              <widget class="QTableWidget" name="listViewFont">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>84</height>
-                </size>
-               </property>
-               <attribute name="horizontalHeaderVisible">
-                <bool>false</bool>
-               </attribute>
-               <attribute name="horizontalHeaderStretchLastSection">
-                <bool>true</bool>
-               </attribute>
-               <attribute name="verticalHeaderVisible">
-                <bool>false</bool>
-               </attribute>
-               <row>
-                <property name="text">
-                 <string>New Row</string>
-                </property>
-               </row>
-               <row>
-                <property name="text">
-                 <string>New Row</string>
-                </property>
-               </row>
-               <row>
-                <property name="text">
-                 <string>New Row</string>
-                </property>
-               </row>
-               <row>
-                <property name="text">
-                 <string>New Row</string>
-                </property>
-               </row>
-               <column>
-                <property name="text">
-                 <string>New Column</string>
-                </property>
-               </column>
-               <column>
-                <property name="text">
-                 <string>New Column</string>
-                </property>
-               </column>
-               <item row="0" column="0">
-                <property name="text">
-                 <string>Name:</string>
-                </property>
-               </item>
-               <item row="0" column="1">
-                <property name="text">
-                 <string/>
-                </property>
-               </item>
-               <item row="1" column="0">
-                <property name="text">
-                 <string>Size:</string>
-                </property>
-               </item>
-               <item row="1" column="1">
-                <property name="text">
-                 <string/>
-                </property>
-               </item>
-               <item row="2" column="0">
-                <property name="text">
-                 <string>Color:</string>
-                </property>
-               </item>
-               <item row="2" column="1">
-                <property name="text">
-                 <string/>
-                </property>
-               </item>
-               <item row="3" column="0">
-                <property name="text">
-                 <string>Options:</string>
-                </property>
-               </item>
-               <item row="3" column="1">
-                <property name="text">
-                 <string/>
-                </property>
-               </item>
-              </widget>
-             </item>
              <item row="1" column="1">
               <layout class="QVBoxLayout" name="verticalLayout_16">
                <item>
@@ -2177,6 +2163,37 @@
                 </widget>
                </item>
               </layout>
+             </item>
+             <item row="1" column="0">
+              <widget class="QTableView" name="fontSettingsTableView">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>84</height>
+                </size>
+               </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="horizontalHeaderDefaultSectionSize">
+                <number>26</number>
+               </attribute>
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="verticalHeaderCascadingSectionResizes">
+                <bool>true</bool>
+               </attribute>
+               <attribute name="verticalHeaderDefaultSectionSize">
+                <number>19</number>
+               </attribute>
+              </widget>
              </item>
             </layout>
            </item>
@@ -2576,7 +2593,16 @@
         <string>About</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_12">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>5</number>
+        </property>
+        <property name="bottomMargin">
          <number>5</number>
         </property>
         <item>
@@ -2613,7 +2639,16 @@ p, li { white-space: pre-wrap; }
        <property name="spacing">
         <number>4</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -2978,7 +3013,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>editSplitSize</tabstop>
   <tabstop>comboBoxMeasure</tabstop>
   <tabstop>checkBoxCut</tabstop>
-  <tabstop>listViewFont</tabstop>
+  <tabstop>fontSettingsTableView</tabstop>
   <tabstop>fontButton</tabstop>
   <tabstop>colorButton</tabstop>
   <tabstop>spinEditBorder</tabstop>


### PR DESCRIPTION
This change moves all code related to handling font settings from TsMuxerWindow to its own model. The widget handling the data is now just an ordinary QTableView.

This does away with storing everything as strings inside a QTableWidget, which means that functions using font data to generate metafile or other kinds of output use QFont objects directly.