### PR TITLE
Split directory.cpp into unix/win32 parts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ BreakBeforeBraces: Allman
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
 ColumnLimit: 120
+IncludeBlocks: Preserve

--- a/libmediation/CMakeLists.txt
+++ b/libmediation/CMakeLists.txt
@@ -2,17 +2,16 @@ cmake_minimum_required (VERSION 3.1)
 project(mediation)
 
 add_library(mediation STATIC
-  fs/directory.cpp
   types/types.cpp
   system/terminatablethread.cpp
 )
 
 IF(WIN32)
     target_compile_definitions(mediation PRIVATE "-DUNICODE")
-    target_sources(mediation PRIVATE fs/osdep/file_win32.cpp)
+    target_sources(mediation PRIVATE fs/osdep/file_win32.cpp fs/osdep/directory_win32.cpp)
 ELSE()
     target_compile_definitions(mediation PRIVATE "-D_FILE_OFFSET_BITS=64")
-    target_sources(mediation PRIVATE fs/osdep/file_unix.cpp)
+    target_sources(mediation PRIVATE fs/osdep/file_unix.cpp fs/osdep/directory_unix.cpp)
 ENDIF()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/libmediation/fs/directory_priv.h
+++ b/libmediation/fs/directory_priv.h
@@ -20,4 +20,36 @@ void recurseDirectorySearch(F&& findFilesFn, D&& findDirsFn, const std::string& 
     }
 }
 
+template <typename SkipParentDirFn, typename CreateParentDirFn>
+bool preCreateDir(SkipParentDirFn&& skipParentFn, CreateParentDirFn&& createParentFn, char dirSeparator,
+                  const std::string& dirName, bool createParentDirs)
+{
+    if (dirName.empty())
+        return false;
+
+    if (createParentDirs)
+    {
+        for (auto separatorPos = dirName.find_first_not_of(dirSeparator), dirEnd = std::string::npos;
+             separatorPos != std::string::npos;
+             dirEnd = separatorPos, separatorPos = dirName.find_first_not_of(dirSeparator, separatorPos))
+        {
+            separatorPos = dirName.find(dirSeparator, separatorPos);
+            if (dirEnd != std::string::npos)
+            {
+                auto parentDir = dirName.substr(0, dirEnd);
+                if (skipParentFn(parentDir))
+                {
+                    continue;
+                }
+                if (!createParentFn(parentDir))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 #endif

--- a/libmediation/fs/directory_priv.h
+++ b/libmediation/fs/directory_priv.h
@@ -1,0 +1,23 @@
+#ifndef libmediation_directory_priv_h
+#define libmediation_directory_priv_h
+
+#include <string>
+#include <vector>
+
+template <typename F, typename D>
+void recurseDirectorySearch(F&& findFilesFn, D&& findDirsFn, const std::string& path, const std::string& mask,
+                            std::vector<std::string>* const fileList)
+{
+    // finding files
+    findFilesFn(path, mask, fileList, true);
+
+    std::vector<std::string> dirList;
+    findDirsFn(path, &dirList);
+
+    for (auto&& dir : dirList)
+    {
+        recurseDirectorySearch(findFilesFn, findDirsFn, dir, mask, fileList);
+    }
+}
+
+#endif

--- a/libmediation/fs/osdep/directory_unix.cpp
+++ b/libmediation/fs/osdep/directory_unix.cpp
@@ -1,0 +1,143 @@
+
+#include "../directory.h"
+#include "../directory_priv.h"
+
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <sstream>
+
+#include <dirent.h>
+#include <memory.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+using namespace std;
+
+char getDirSeparator()
+{
+    return '/';
+}
+
+string extractFileDir(const string& fileName)
+{
+    size_t index = fileName.find_last_of('/');
+    if (index != string::npos)
+        return fileName.substr(0, index + 1);
+    return "";
+}
+
+bool fileExists(const string& fileName)
+{
+    struct stat buf;
+    return stat(fileName.c_str(), &buf) == 0;
+}
+
+uint64_t getFileSize(const std::string& fileName)
+{
+    struct stat fileStat;
+    auto res = stat(fileName.c_str(), &fileStat) == 0;
+    return res ? static_cast<uint64_t>(fileStat.st_size) : 0;
+}
+
+bool createDir(const std::string& dirName, bool createParentDirs)
+{
+    if (dirName.empty())
+        return false;
+
+    if (createParentDirs)
+    {
+        for (string::size_type separatorPos = dirName.find_first_not_of(getDirSeparator()), dirEnd = string::npos;
+             separatorPos != string::npos;
+             dirEnd = separatorPos, separatorPos = dirName.find_first_not_of(getDirSeparator(), separatorPos))
+        {
+            separatorPos = dirName.find(getDirSeparator(), separatorPos);
+            if (dirEnd != string::npos)
+            {
+                string parentDir = dirName.substr(0, dirEnd);
+                if (mkdir(parentDir.c_str(), S_IREAD | S_IWRITE | S_IEXEC) == -1)
+                {
+                    if (errno != EEXIST)
+                        return false;
+                }
+            }
+        }
+    }
+
+    return mkdir(dirName.c_str(), S_IREAD | S_IWRITE | S_IEXEC) == 0;
+}
+
+bool deleteFile(const string& fileName)
+{
+    return unlink(fileName.c_str()) == 0;
+}
+
+#include <fnmatch.h>
+
+bool findFiles(const string& path, const string& fileMask, vector<string>* fileList, bool savePaths)
+{
+    dirent** namelist;
+
+    int n = scandir(path.c_str(), &namelist, 0, 0);  // alphasort);
+
+    if (n < 0)
+    {
+        return false;
+    }
+    else
+    {
+        while (n--)
+        {
+            if (namelist[n]->d_type == DT_REG)
+            {
+                string fileName(namelist[n]->d_name);
+
+                if (0 == fnmatch(fileMask.c_str(), fileName.c_str(), 0))
+                    fileList->push_back(savePaths ? path + fileName : fileName);
+            }
+            free(namelist[n]);
+        }
+        free(namelist);
+    }
+
+    return true;
+}
+
+bool findDirs(const string& path, vector<string>* dirsList)
+{
+    dirent** namelist;
+
+    int n = scandir(path.c_str(), &namelist, 0, 0);  // alphasort);
+
+    if (n < 0)
+    {
+        return false;
+    }
+    else
+    {
+        while (n--)
+        {
+            if (namelist[n]->d_type == DT_DIR)
+            {
+                string dirName(namelist[n]->d_name);
+
+                // we save only normal ones
+                if ("." != dirName && ".." != dirName)
+                    dirsList->push_back(path + dirName + "/");
+            }
+            free(namelist[n]);
+        }
+        free(namelist);
+    }
+
+    return true;
+}
+
+bool findFilesRecursive(const string& path, const string& mask, vector<string>* const fileList)
+{
+    recurseDirectorySearch(findFiles, findDirs, path, mask, fileList);
+    return true;
+}

--- a/libmediation/fs/osdep/directory_unix.cpp
+++ b/libmediation/fs/osdep/directory_unix.cpp
@@ -1,11 +1,10 @@
-#define _POSIX_C_SOURCE 200809L
-
 #include "../directory.h"
 #include "../directory_priv.h"
 
 #include <dirent.h>
 #include <fnmatch.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 using namespace std;

--- a/libmediation/fs/osdep/directory_unix.cpp
+++ b/libmediation/fs/osdep/directory_unix.cpp
@@ -36,8 +36,7 @@ uint64_t getFileSize(const std::string& fileName)
 bool createDir(const std::string& dirName, bool createParentDirs)
 {
     auto ok = preCreateDir([](auto) { return false; },
-                           [](auto&& parentDir)
-                           {
+                           [](auto&& parentDir) {
                                if (mkdir(parentDir.c_str(), S_IREAD | S_IWRITE | S_IEXEC) == -1)
                                {
                                    if (errno != EEXIST)

--- a/libmediation/fs/osdep/directory_unix.cpp
+++ b/libmediation/fs/osdep/directory_unix.cpp
@@ -1,26 +1,16 @@
+#define _POSIX_C_SOURCE 200809L
 
 #include "../directory.h"
 #include "../directory_priv.h"
 
-#include <errno.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#include <sstream>
-
 #include <dirent.h>
-#include <memory.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <fnmatch.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 using namespace std;
 
-char getDirSeparator()
-{
-    return '/';
-}
+char getDirSeparator() { return '/'; }
 
 string extractFileDir(const string& fileName)
 {
@@ -60,12 +50,7 @@ bool createDir(const std::string& dirName, bool createParentDirs)
     return ok ? mkdir(dirName.c_str(), S_IREAD | S_IWRITE | S_IEXEC) == 0 : false;
 }
 
-bool deleteFile(const string& fileName)
-{
-    return unlink(fileName.c_str()) == 0;
-}
-
-#include <fnmatch.h>
+bool deleteFile(const string& fileName) { return unlink(fileName.c_str()) == 0; }
 
 bool findFiles(const string& path, const string& fileMask, vector<string>* fileList, bool savePaths)
 {

--- a/libmediation/fs/osdep/directory_win32.cpp
+++ b/libmediation/fs/osdep/directory_win32.cpp
@@ -7,10 +7,7 @@
 
 using namespace std;
 
-char getDirSeparator()
-{
-    return '\\';
-}
+char getDirSeparator() { return '\\'; }
 
 string extractFileDir(const string& fileName)
 {

--- a/libmediation/fs/osdep/directory_win32.cpp
+++ b/libmediation/fs/osdep/directory_win32.cpp
@@ -41,14 +41,12 @@ uint64_t getFileSize(const std::string& fileName)
 bool createDir(const std::string& dirName, bool createParentDirs)
 {
     bool ok = preCreateDir(
-        [](auto&& parentDir)
-        {
+        [](auto&& parentDir) {
             return parentDir.empty() || parentDir[parentDir.size() - 1] == ':' || parentDir == "\\\\." ||
                    parentDir == "\\\\.\\" ||                                                        // UNC patch prefix
                    (strStartWith(parentDir, "\\\\.\\") && parentDir[parentDir.size() - 1] == '}');  // UNC patch prefix
         },
-        [](auto&& parentDir)
-        {
+        [](auto&& parentDir) {
             if (CreateDirectory(toWide(parentDir).data(), 0) == 0)
             {
                 if (GetLastError() != ERROR_ALREADY_EXISTS)


### PR DESCRIPTION
`directory.cpp` was essentially two implementations in one, separated with `ifdef`s. It's cleaner to just have two separate files, seeing how `CMakeLists.txt` for `libmediation` needs to check the platform it's running on and add the appropriate `file` implementation anyway.

This commit splits this file into two and extracts common code parts to `directory_priv.h`.