### PR TITLE
Remove #ifdef apple in order to use std::filesystem

### DIFF
--- a/tsMuxer/osdep/textSubtitlesRenderFT.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderFT.cpp
@@ -104,12 +104,9 @@ void TextSubtitlesRenderFT::loadFontMap()
             std::map<std::string, std::string>::iterator itr = m_fontNameToFile.find(fontFamily);
 
             if (itr == m_fontNameToFile.end() || fileList[i].length() < itr->second.length())
-#if defined(__APPLE__) && defined(__MACH__)
-                m_fontNameToFile[fontFamily] = std::__fs::filesystem::canonical(fileList[i]).string();
-#else
+            {
                 m_fontNameToFile[fontFamily] = std::filesystem::canonical(fileList[i]).string();
-#endif
-
+            }
             FT_Done_Face(font);
         }
         // LTRACE(LT_INFO, 2, "after loading font " << fileList[i].c_str());


### PR DESCRIPTION
It seems like `std::__fs` is a leftover from the days when support for `filesystem` was still experimental in AppleClang. `filesystem` was officially declared as supported in Xcode 11 when targeting macOS 10.15, which is our current `MACOSX_DEPLOYMENT_TARGET`, so there is no need to keep this `ifdef` around.