### PR TITLE
UDF2.50 Named Stream flags

### DIFF
--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -852,8 +852,8 @@ void IsoWriter::close()
     int64_t sz = m_file.size();
     m_metadataMirrorLBN = m_file.size() / SECTOR_SIZE + 1;
     m_tagLocationBaseAddr = m_partitionStartAddress;
-    writeExtentFileDescriptor(0, FileType_MetadataMirror, m_metadataFileLen, m_metadataMirrorLBN - m_partitionStartAddress,
-                              0);
+    writeExtentFileDescriptor(0, FileType_MetadataMirror, m_metadataFileLen,
+                              m_metadataMirrorLBN - m_partitionStartAddress, 0);
 
     // allocate space for metadata mirror file
     memset(m_buffer, 0, sizeof(m_buffer));

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -214,7 +214,7 @@ class IsoWriter
     void writeUnallocatedSpaceDescriptor();
     void writeTerminationDescriptor();
     void writeLogicalVolumeIntegrityDescriptor();
-    int writeExtentFileDescriptor(uint8_t fileType, uint64_t len, uint32_t pos, int linkCount, ExtentList* extents = 0);
+    int writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount, ExtentList* extents = 0);
     void writeFileSetDescriptor();
     void writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd);
     // void writeFileIdentifierDescriptor();
@@ -226,7 +226,7 @@ class IsoWriter
     void writeSector(uint8_t* sectorData);
     uint32_t absoluteSectorNum();
 
-    void writeIcbTag(uint8_t* buffer, uint8_t fileType);
+    void writeIcbTag(bool namedStream, uint8_t* buffer, uint8_t fileType);
     void writeDescriptors();
     void allocateMetadata();
     void writeMetadata(int lbn);

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -214,7 +214,8 @@ class IsoWriter
     void writeUnallocatedSpaceDescriptor();
     void writeTerminationDescriptor();
     void writeLogicalVolumeIntegrityDescriptor();
-    int writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount, ExtentList* extents = 0);
+    int writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
+                                  ExtentList* extents = 0);
     void writeFileSetDescriptor();
     void writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd);
     // void writeFileIdentifierDescriptor();


### PR DESCRIPTION
For Named Stream "*UDF Unique ID Mapping Data", icbtag stream flag shall be set to 1.

Fixes the following error in udf_tester:
```
	EFE  file type FILE  UniqueID: #0000000000000000   name: <SysStreamDir>//"*UDF Unique ID Mapping Data"
	EFE  34  icbtag error: Flags Stream bit: 0, expected: 1, see DCN-5152.
```