### PR TITLE
UDF2.5 UniqueID

### DIFF
--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -978,8 +978,8 @@ void IsoWriter::writeAllocationExtentDescriptor(ExtentList* extents, size_t star
     m_file.write(m_buffer, SECTOR_SIZE);
 }
 
-int IsoWriter::writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
-                                         ExtentList* extents)
+int IsoWriter::writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len,
+                                         uint32_t pos, int linkCount, ExtentList* extents)
 {
     int sectorsWrited = 0;
 

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -396,8 +396,8 @@ void FileEntryInfo::serializeFile()
 
     memset(buffer, 0, sizeof(buffer));
 
-    int writed = m_owner->writeExtentFileDescriptor(m_name == "*UDF Unique ID Mapping Data", m_fileType, m_fileSize,
-                                                    m_sectorNum, 1, &m_extents);
+    int writed = m_owner->writeExtentFileDescriptor(m_name == "*UDF Unique ID Mapping Data", m_objectId, m_fileType,
+                                                    m_fileSize, m_sectorNum, 1, &m_extents);
     assert(writed == m_sectorsUsed);
 }
 
@@ -417,10 +417,11 @@ void FileEntryInfo::serializeDir()
     writer.writeLE8(0x0A);   // File Characteristics, parent flag (3-th bit) and  'directory' bit (1-th)
     writer.writeLE8(0x00);   // Length of File Identifier (=L_FI)
 
+    int parentId = m_parent ? m_parent->m_objectId : 0;
     writer.writeLongAD(0x800, m_parent ? m_parent->m_sectorNum : m_owner->absoluteSectorNum(), 0x01,
-                       0);  // parent entry ICB
-    writer.writeLE16(0);    // Length of Implementation Use
-    writer.writeLE16(0);    // zero d-string for parent FID
+                       parentId);  // parent entry ICB
+    writer.writeLE16(0);           // Length of Implementation Use
+    writer.writeLE16(0);           // zero d-string for parent FID
     writer.closeDescriptorTag();
 
     // ------------ 2 (entries) ---------------
@@ -428,7 +429,7 @@ void FileEntryInfo::serializeDir()
     for (auto& i : m_subDirs) writeEntity(writer, i);
     assert(writer.size() < SECTOR_SIZE);  // not supported
 
-    m_owner->writeExtentFileDescriptor(0, m_fileType, writer.size(), m_sectorNum + 1, m_subDirs.size() + 1);
+    m_owner->writeExtentFileDescriptor(0, m_objectId, m_fileType, writer.size(), m_sectorNum + 1, m_subDirs.size() + 1);
     m_owner->writeSector(buffer);
 }
 
@@ -852,7 +853,7 @@ void IsoWriter::close()
     int64_t sz = m_file.size();
     m_metadataMirrorLBN = m_file.size() / SECTOR_SIZE + 1;
     m_tagLocationBaseAddr = m_partitionStartAddress;
-    writeExtentFileDescriptor(0, FileType_MetadataMirror, m_metadataFileLen,
+    writeExtentFileDescriptor(0, 0, FileType_MetadataMirror, m_metadataFileLen,
                               m_metadataMirrorLBN - m_partitionStartAddress, 0);
 
     // allocate space for metadata mirror file
@@ -873,7 +874,7 @@ void IsoWriter::close()
     m_file.seek(1024 * 576);
     // metadata file location and length (located at 576K, point to 640K address)
     m_tagLocationBaseAddr = m_partitionStartAddress;  //(1024 * 576)/SECTOR_SIZE;
-    writeExtentFileDescriptor(0, FileType_Metadata, m_metadataFileLen, m_metadataLBN - m_partitionStartAddress, 0);
+    writeExtentFileDescriptor(0, 0, FileType_Metadata, m_metadataFileLen, m_metadataLBN - m_partitionStartAddress, 0);
     m_tagLocationBaseAddr = m_metadataLBN;  // I don't know why. I doing just as scenarist does
     writeMetadata(m_metadataLBN);
 
@@ -977,7 +978,7 @@ void IsoWriter::writeAllocationExtentDescriptor(ExtentList* extents, size_t star
     m_file.write(m_buffer, SECTOR_SIZE);
 }
 
-int IsoWriter::writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
+int IsoWriter::writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
                                          ExtentList* extents)
 {
     int sectorsWrited = 0;
@@ -1031,6 +1032,7 @@ int IsoWriter::writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uin
     // skip Stream Directory ICB
 
     strcpy((char*)m_buffer + 169, m_impId.c_str());  // Implementation Identifier
+    m_buffer[200] = objectId;                        // Unique ID
 
     // skip Length of Extended Attributes
     if (fileType != FileType_File && fileType != FileType_RealtimeFile)

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -214,8 +214,8 @@ class IsoWriter
     void writeUnallocatedSpaceDescriptor();
     void writeTerminationDescriptor();
     void writeLogicalVolumeIntegrityDescriptor();
-    int writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
-                                  ExtentList* extents = 0);
+    int writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len, uint32_t pos,
+                                  int linkCount, ExtentList* extents = 0);
     void writeFileSetDescriptor();
     void writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd);
     // void writeFileIdentifierDescriptor();

--- a/tsMuxer/iso_writer.h
+++ b/tsMuxer/iso_writer.h
@@ -214,7 +214,7 @@ class IsoWriter
     void writeUnallocatedSpaceDescriptor();
     void writeTerminationDescriptor();
     void writeLogicalVolumeIntegrityDescriptor();
-    int writeExtentFileDescriptor(bool namedStream, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
+    int writeExtentFileDescriptor(bool namedStream, uint32_t objectId, uint8_t fileType, uint64_t len, uint32_t pos, int linkCount,
                                   ExtentList* extents = 0);
     void writeFileSetDescriptor();
     void writeAllocationExtentDescriptor(ExtentList* extents, size_t start, size_t indexEnd);


### PR DESCRIPTION
Fixes files and directories UniqueID in Extended File Entry and in File Identifier Descriptor.

Fixes the following types of errors in UDF_Verifier:
```
	EFE  file type DIR   UniqueID: #0000000000000000   name: "BDMV"
	EFE  200 Error: UniqueID: #0000000000000000
```
```
	FID  UniqueID: #00000000  cid:       name: "META"/<parent FID>, refers to: "BDMV"
	FID  32  Error: UniqueID:         #00000000
-			Bits 0-31 have a value lower than 16,
-			UDF 2.3.4.3, 3.2.1.1, 3.3.3.4.
-		 No association with the Root Directory or
-		 the System Stream Directory, UDF 2.3.6.7.
```