### PR TITLE
[Bug] Fix delay rounding

### DIFF
--- a/tsMuxer/tsDemuxer.h
+++ b/tsMuxer/tsDemuxer.h
@@ -27,8 +27,11 @@ class TSDemuxer : public AbstractDemuxer
     int64_t getTrackDelay(uint32_t pid) override
     {
         if (m_firstPtsTime.find(pid) != m_firstPtsTime.end())
-            return (int64_t)((m_firstPtsTime[pid] - (m_firstVideoPTS != -1 ? m_firstVideoPTS : m_firstPTS)) / 90.0 +
-                             0.5);  // convert to ms
+        {
+            int64_t clockTicks = m_firstPtsTime[pid] - (m_firstVideoPTS != -1 ? m_firstVideoPTS : m_firstPTS);
+            return clockTicks / 90.0 + (clockTicks >= 0 ? 0.5 : -0.5);  // convert to ms
+        }
+
         else
             return 0;
     }

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -1003,7 +1003,7 @@ bool TSMuxer::muxPacket(AVPacket& avPacket)
         if (m_firstPts[m_firstPts.size() - 1] == -1)
         {
             m_curFileStartPts = avPacket.pts;
-            uint64_t firstPtsShift = nanoClockToPts(avPacket.pts);
+            int64_t firstPtsShift = nanoClockToPts(avPacket.pts);
             m_fixed_pcr_offset = m_timeOffset - m_vbvLen + firstPtsShift;
             if (m_fixed_pcr_offset < 0)
                 m_fixed_pcr_offset = 0;

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -199,7 +199,7 @@ class TSMuxer : public AbstractMuxer
     bool m_pesSpsPps;
     bool m_computeMuxStats;
     int m_pmtFrames;
-    uint64_t m_curFileStartPts;
+    int64_t m_curFileStartPts;
     int64_t m_vbvLen;
     int m_mainStreamIndex;
 


### PR DESCRIPTION
When delay is negative, the integer truncating needs to be done after adding -0.5, not +0.5.