### PR TITLE
Simplify AC3 Classes

### DIFF
--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -118,7 +118,7 @@ AC3Codec::AC3ParseError AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
             int m_fscod2 = gbc.getBits(2);
             if (m_fscod2 == 3)
                 return AC3ParseError::AC3_PARSE_ERROR_SYNC;
-            
+
             numblkscod = 3;
             m_sample_rate = ff_ac3_freqs[m_fscod2] / 2;
         }
@@ -277,9 +277,9 @@ AC3Codec::AC3ParseError AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
         m_bsmod = gbc.getBits(3);
         m_acmod = gbc.getBits(3);
         if ((m_acmod & 1) && m_acmod != AC3_ACMOD_MONO)
-           gbc.skipBits(2);  // m_cmixlev
+            gbc.skipBits(2);  // m_cmixlev
         if (m_acmod & 4)
-           gbc.skipBits(2);  // m_surmixlev
+            gbc.skipBits(2);  // m_surmixlev
         if (m_acmod == AC3_ACMOD_STEREO)
             m_dsurmod = gbc.getBits(2);
         m_lfeon = gbc.getBit();
@@ -539,7 +539,7 @@ uint64_t AC3Codec::getFrameDurationNano()
         return m_bsid > 10 ? m_frameDurationNano : 0;  // E-AC3. finish frame after AC3 frame
     if (m_waitMoreData)
         return 0;  // AC3 HD
-    
+
     return m_frameDurationNano;
 }
 

--- a/tsMuxer/ac3Codec.h
+++ b/tsMuxer/ac3Codec.h
@@ -7,35 +7,22 @@ struct CodecInfo;
 
 typedef struct MLPHeaderInfo
 {
-    MLPHeaderInfo() : subType(MlpSubType::stUnknown), channels(0) {}
+    MLPHeaderInfo()
+        : subType(MlpSubType::stUnknown), access_unit_size(0), channels(0), group1_samplerate(0), peak_bitrate(0)
+    {
+    }
+
     enum class MlpSubType
     {
         stUnknown,
         stTRUEHD,
         stMLP
     };
-    int stream_type;  ///< 0xBB for MLP, 0xBA for TrueHD
-
-    int group1_bits;  ///< The bit depth of the first substream
-    int group2_bits;  ///< Bit depth of the second substream (MLP only)
 
     int group1_samplerate;  ///< Sample rate of first substream
-    int group2_samplerate;  ///< Sample rate of second substream (MLP only)
-
-    int channels_mlp;          ///< Channel arrangement for MLP streams
-    int channels_thd_stream1;  ///< Channel arrangement for substream 1 of TrueHD streams (5.1)
-    int channels_thd_stream2;  ///< Channel arrangement for substream 2 of TrueHD streams (7.1)
-
-    int access_unit_size;       ///< Number of samples per coded frame
-    int access_unit_size_pow2;  ///< Next power of two above number of samples per frame
-
-    int is_vbr;        ///< Stream is VBR instead of CBR
-    int peak_bitrate;  ///< Peak bitrate for VBR, actual bitrate (==peak) for CBR
-
-    int num_substreams;  ///< Number of substreams within stream
-
+    int access_unit_size;   ///< Number of samples per coded frame
+    int peak_bitrate;       ///< Peak bitrate for VBR, actual bitrate (==peak) for CBR
     int channels;
-    uint64_t frame_duration_nano;
     MlpSubType subType;
 } MLPHeaderInfo;
 
@@ -51,13 +38,31 @@ class AC3Codec
         stateDecodeTrueHDFirst,
         stateDecodeTrueHD
     };
+
+    enum class AC3ParseError
+    {
+        AC3_PARSE_NO_ERROR = 0,
+        AC3_PARSE_ERROR_SYNC = -1,
+        AC3_PARSE_ERROR_BSID = -2,
+        AC3_PARSE_ERROR_SAMPLE_RATE = -3,
+        AC3_PARSE_ERROR_FRAME_SIZE = -4
+    };
+
     AC3Codec()
+        : m_fscod(0),
+          m_frmsizecod(0),
+          m_bsmod(0),
+          m_acmod(0),
+          m_halfratecod(0),
+          m_sample_rate(0),
+          m_frame_size(0),
+          m_samples(0)
     {
         m_downconvertToAC3 = m_true_hd_mode = false;
         m_state = AC3State::stateDecodeAC3;
         m_waitMoreData = false;
         setTestMode(false);
-        m_frameDuration = false;
+        m_frameDurationNano = 0;
         m_bit_rateExt = 0;
         m_bit_rate = 0;
         m_channels = 0;
@@ -79,7 +84,7 @@ class AC3Codec
    protected:
     int decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes);
     uint8_t* findFrame(uint8_t* buff, uint8_t* end);
-    double getFrameDurationNano();
+    uint64_t getFrameDurationNano();
     const CodecInfo& getCodecInfo();
     const std::string getStreamInfo();
 
@@ -88,19 +93,12 @@ class AC3Codec
     bool m_waitMoreData;
     bool m_downconvertToAC3;
     bool m_true_hd_mode;
-    bool m_useNewStyleAudioPES;
-    const static CodecInfo m_codecInfo;
-    const static unsigned DTS_HEADER_SIZE = 14;
-    uint16_t m_sync_word;
-    uint16_t m_crc1;
     uint8_t m_fscod;
     int m_frmsizecod;
     uint8_t m_bsid;
     uint8_t m_bsidBase;
     uint8_t m_bsmod;
     uint8_t m_acmod;
-    uint8_t m_cmixlev;
-    uint8_t m_surmixlev;
     uint8_t m_dsurmod;
     uint8_t m_lfeon;
     uint8_t m_halfratecod;
@@ -112,24 +110,20 @@ class AC3Codec
 
     MLPHeaderInfo mh;
 
-    int m_fscod2;
     int m_samples;
 
     uint32_t m_bit_rateExt;
     bool m_extChannelsExists;
 
-    int parseHeader(uint8_t* buf, uint8_t* end);
-    int writeAC3Descriptor(uint8_t* dstBuff);
-    int writeEAC3Descriptor(uint8_t* dstBuff);
+    AC3ParseError parseHeader(uint8_t* buf, uint8_t* end);
 
-    int testParseHeader(uint8_t* buf, uint8_t* end);
+    AC3ParseError testParseHeader(uint8_t* buf, uint8_t* end);
     bool testDecodeTestFrame(uint8_t* buf, uint8_t* end);
-    bool findMajorSync(uint8_t* buffer, uint8_t* end);
     bool decodeDtsHdFrame(uint8_t* buffer, uint8_t* end);
 
    protected:
     bool m_testMode;
-    double m_frameDuration;
+    uint64_t m_frameDurationNano;
 };
 
 #endif

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -12,7 +12,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
 {
    public:
     AC3StreamReader()
-        : SimplePacketizerReader(), m_useNewStyleAudioPES(false), m_hdFrameOffset(0), m_thdTsLen(0), m_ac3TsLen(0)
+        : SimplePacketizerReader(), m_useNewStyleAudioPES(false)
     {
         m_downconvertToAC3 = m_true_hd_mode = false;
         m_state = AC3State::stateDecodeAC3;
@@ -22,7 +22,6 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
         m_demuxedTHDSamples = 0;
         m_totalTHDSamples = 0;
         m_nextAc3Time = 0;
-        m_thdFrameOffset = 0;
     };
     int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
@@ -60,20 +59,14 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
 
    private:
     bool m_useNewStyleAudioPES;
-    int m_hdFrameOffset;
-    uint64_t m_thdTsLen;
-    uint64_t m_ac3TsLen;
 
     bool m_thdDemuxWaitAc3;
 
-    // std::deque<AVPacket> m_delayedAc3Packet;
     MemoryBlock m_delayedAc3Buffer;
     AVPacket m_delayedAc3Packet;
-    // std::deque<AVPacket> m_delayedTHDPacket;
     int m_demuxedTHDSamples;
-    int64_t m_totalTHDSamples;
-    int64_t m_nextAc3Time;
-    int64_t m_thdFrameOffset;
+    uint64_t m_totalTHDSamples;
+    uint64_t m_nextAc3Time;
 };
 
 #endif

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -11,8 +11,7 @@
 class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
 {
    public:
-    AC3StreamReader()
-        : SimplePacketizerReader(), m_useNewStyleAudioPES(false)
+    AC3StreamReader() : SimplePacketizerReader(), m_useNewStyleAudioPES(false)
     {
         m_downconvertToAC3 = m_true_hd_mode = false;
         m_state = AC3State::stateDecodeAC3;


### PR DESCRIPTION
Remove unused members.
Initialize all members.
Change frameDuration (in nanoseconds) from double to uint64.
Change enum type to enum class type.