### PR TITLE
Tidy-up textSubtitles classes

### DIFF
--- a/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
@@ -63,9 +63,9 @@ void TextSubtitlesRenderWin32::setRenderSize(int width, int height)
     m_pbmpInfo->bmiHeader.biCompression = BI_RGB;
     m_pbmpInfo->bmiHeader.biClrUsed = 256 * 256 * 256;
     m_hbmp = ::CreateDIBSection(m_dc, m_pbmpInfo, DIB_RGB_COLORS, (void**)&m_pData, 0, 0);
-    SelectObject(m_dc, m_hbmp);
     if (m_hbmp == 0)
         THROW(ERR_COMMON, "Can't initialize graphic subsystem for render text subtitles");
+    SelectObject(m_dc, m_hbmp);
     ::SetBkColor(m_dc, RGB(0, 0, 0));
     ::SetBkMode(m_dc, TRANSPARENT);
 }
@@ -103,25 +103,25 @@ void TextSubtitlesRenderWin32::drawText(const std::string& text, RECT* rect)
 #ifdef OLD_WIN32_RENDERER
     ::DrawText(m_dc, text.c_str(), text.length(), rect, DT_NOPREFIX);
 #else
-    Graphics graphics(m_dc);
+    Gdiplus::Graphics graphics(m_dc);
     graphics.SetSmoothingMode(SmoothingModeHighQuality);
     graphics.SetInterpolationMode(InterpolationModeHighQualityBicubic);
 
     FontFamily fontFamily(toWide(m_font.m_name).data());
     StringFormat strformat;
-    GraphicsPath path;
+    Gdiplus::GraphicsPath path;
 
     auto text_wide = toWide(text);
-    path.AddString(text_wide.data(), text_wide.size(), &fontFamily, m_font.m_opts & 0xf, m_font.m_size,
+    path.AddString(text_wide.data(), (int)text_wide.size(), &fontFamily, m_font.m_opts & 0xf, (float)m_font.m_size,
                    Gdiplus::Point(rect->left, rect->top), &strformat);
 
     uint8_t alpha = m_font.m_color >> 24;
-    uint8_t outColor = (float)alpha / 255.0 * 48.0 + 0.5;
-    Pen pen(Color(outColor, 0, 0, 0), m_font.m_borderWidth * 2);
+    uint8_t outColor = (alpha * 48 + 128) / 255;
+    Pen pen(Color(outColor, 0, 0, 0), m_font.m_borderWidth * 2.0f);
     pen.SetLineJoin(LineJoinRound);
     graphics.DrawPath(&pen, &path);
 
-    Pen penInner(Color(alpha, 0, 0, 0), m_font.m_borderWidth);
+    Pen penInner(Color(alpha, 0, 0, 0), (float)m_font.m_borderWidth);
     penInner.SetLineJoin(LineJoinRound);
     graphics.DrawPath(&penInner, &path);
 
@@ -137,21 +137,21 @@ void TextSubtitlesRenderWin32::getTextSize(const std::string& text, SIZE* mSize)
 #else
     int opts = m_font.m_opts & 0xf;
     FontFamily fontFamily(toWide(m_font.m_name).data());
-    ::Font font(&fontFamily, m_font.m_size, opts, UnitPoint);
+    ::Font font(&fontFamily, (float)m_font.m_size, opts, UnitPoint);
 
     int lineSpacing = fontFamily.GetLineSpacing(FontStyleRegular);
-    int lineSpacingPixel = font.GetSize() * lineSpacing / fontFamily.GetEmHeight(opts);
+    int lineSpacingPixel = (int)(font.GetSize() * lineSpacing / fontFamily.GetEmHeight(opts));
 
     StringFormat strformat;
-    GraphicsPath path;
+    Gdiplus::GraphicsPath path;
     auto text_wide = toWide(text);
-    path.AddString(text_wide.data(), text_wide.size(), &fontFamily, opts, m_font.m_size, Gdiplus::Point(0, 0),
+    path.AddString(text_wide.data(), (int)text_wide.size(), &fontFamily, opts, (float)m_font.m_size, Gdiplus::Point(0, 0),
                    &strformat);
-    RectF rect;
-    Pen pen(Color(0x30, 0, 0, 0), m_font.m_borderWidth * 2);
+    Gdiplus::RectF rect;
+    Pen pen(Color(0x30, 0, 0, 0), m_font.m_borderWidth * 2.0f);
     pen.SetLineJoin(LineJoinRound);
     path.GetBounds(&rect, 0, &pen);
-    mSize->cx = rect.Width;
+    mSize->cx = (int)rect.Width;
     mSize->cy = lineSpacingPixel;
 #endif
 }
@@ -164,16 +164,12 @@ int TextSubtitlesRenderWin32::getLineSpacing()
     return tm.tmAscent;
 #else
     int opts = m_font.m_opts & 0xf;
-    FontFamily fontFamily(toWide(m_font.m_name).data());
-    ::Font font(&fontFamily, m_font.m_size, opts, UnitPoint);
+    Gdiplus::FontFamily fontFamily(toWide(m_font.m_name).data());
+    ::Font font(&fontFamily, (float)m_font.m_size, opts, UnitPoint);
 
     int lineSpacing = fontFamily.GetLineSpacing(opts);
-    int lineSpacingPixel = font.GetSize() * lineSpacing / fontFamily.GetEmHeight(opts);
+    int lineSpacingPixel = (int)(font.GetSize() * lineSpacing / fontFamily.GetEmHeight(opts));
     return lineSpacingPixel;
-
-    // int ascent = fontFamily.GetCellAscent(opts);
-    // int ascentPixel = font.GetSize() * ascent / fontFamily.GetEmHeight(opts);
-    // return ascentPixel;
 #endif
 }
 
@@ -185,16 +181,12 @@ int TextSubtitlesRenderWin32::getBaseline()
     return tm.tmAscent;
 #else
     int opts = m_font.m_opts & 0xf;
-    FontFamily fontFamily(toWide(m_font.m_name).data());
-    ::Font font(&fontFamily, m_font.m_size, opts, UnitPoint);
+    Gdiplus::FontFamily fontFamily(toWide(m_font.m_name).data());
+    ::Font font(&fontFamily, (float)m_font.m_size, opts, UnitPoint);
 
     int descentOffset = fontFamily.GetCellDescent(opts);
-    int descentPixel = font.GetSize() * descentOffset / fontFamily.GetEmHeight(opts);
+    int descentPixel = (int)(font.GetSize() * descentOffset / fontFamily.GetEmHeight(opts));
     return descentPixel;
-
-    // int ascent = fontFamily.GetCellAscent(opts);
-    // int ascentPixel = font.GetSize() * ascent / fontFamily.GetEmHeight(opts);
-    // return ascentPixel;
 #endif
 }
 

--- a/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
@@ -145,8 +145,8 @@ void TextSubtitlesRenderWin32::getTextSize(const std::string& text, SIZE* mSize)
     StringFormat strformat;
     Gdiplus::GraphicsPath path;
     auto text_wide = toWide(text);
-    path.AddString(text_wide.data(), (int)text_wide.size(), &fontFamily, opts, (float)m_font.m_size, Gdiplus::Point(0, 0),
-                   &strformat);
+    path.AddString(text_wide.data(), (int)text_wide.size(), &fontFamily, opts, (float)m_font.m_size,
+                   Gdiplus::Point(0, 0), &strformat);
     Gdiplus::RectF rect;
     Pen pen(Color(0x30, 0, 0, 0), m_font.m_borderWidth * 2.0f);
     pen.SetLineJoin(LineJoinRound);

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -100,7 +100,7 @@ void PGSStreamReader::composition_object(BitStreamReader& bitReader)
 
 void PGSStreamReader::pgs_window(BitStreamReader& bitReader)
 {
-    bitReader.skipBits(8);  // window_id
+    bitReader.skipBits(8);   // window_id
     bitReader.skipBits(32);  // window_horizontal_position, window_vertical_position
     bitReader.skipBits(32);  // window_width, window_height
 }

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -22,10 +22,20 @@ double pgs_frame_rates[16] = {
     0, 23.97602397602397, 24, 25, 29.97002997002997, 30, 50, 59.94005994005994, 60, 0, 0, 0, 0, 0, 0, 0};
 
 PGSStreamReader::PGSStreamReader()
+    : m_avFragmentEnd(0),
+      m_firstRenderedPacket(true),
+      m_objectWindowHeight(0),
+      m_objectWindowTop(0),
+      m_paletteVersion(0),
+      m_palleteID(0),
+      m_ptsStart(0),
+      object_height(0),
+      object_width(0)
 {
     m_curPos = m_buffer = 0;
     m_tmpBufferLen = 0;
-    m_state = stParsePES;
+    m_state = State::stParsePES;
+    composition_state = CompositionState::csEpochStart;
     m_processedSize = 0;
     m_demuxMode = false;
     m_afterPesByte = 0;
@@ -38,19 +48,16 @@ PGSStreamReader::PGSStreamReader()
     m_scale = 1.0;
     m_isNewFrame = false;
     m_needRescale = false;
-    window_horizontal_position = 0;
-    window_vertical_position = 0;
     m_imgBuffer = 0;
     m_rgbBuffer = 0;
     m_scaledRgbBuffer = 0;
     m_scaled_width = 0;
     m_scaled_height = 0;
     m_render = new text_subtitles::TextToPGSConverter(false);
-    m_renderedLen = 0;
     m_renderedData = 0;
     m_fontBorder = 0;
     m_offsetId = 0xff;
-    m_forced_on_flag = 0;
+    m_forced_on_flag = false;
 
     // SS PG data
     isSSPG = false;
@@ -70,7 +77,7 @@ void PGSStreamReader::video_descriptor(BitStreamReader& bitReader)
 
 void PGSStreamReader::composition_descriptor(BitStreamReader& bitReader)
 {
-    composition_number = bitReader.getBits(16);
+    bitReader.skipBits(16);  // composition_number
     composition_state = (CompositionState)bitReader.getBits(2);
     bitReader.skipBits(6);
 }
@@ -78,29 +85,24 @@ void PGSStreamReader::composition_descriptor(BitStreamReader& bitReader)
 void PGSStreamReader::composition_object(BitStreamReader& bitReader)
 {
     int object_id_ref = bitReader.getBits(16);
-    int window_id_ref = bitReader.getBits(8);
-    int object_cropped_flag = bitReader.getBit();
+    bitReader.skipBits(8);  // window_id_ref
+    bool object_cropped_flag = bitReader.getBit();
     m_forced_on_flag = bitReader.getBit();
     bitReader.skipBits(6);
     composition_object_horizontal_position[object_id_ref] = bitReader.getBits(16);
     composition_object_vertical_position[object_id_ref] = bitReader.getBits(16);
     if (object_cropped_flag)
     {
-        int object_cropping_horizontal_position = bitReader.getBits(16);
-        int object_cropping_vertical_position = bitReader.getBits(16);
-        int object_cropping_width = bitReader.getBits(16);
-        int object_cropping_height = bitReader.getBits(16);
+        bitReader.skipBits(32);  // object_cropping_horizontal_position, object_cropping_vertical_position
+        bitReader.skipBits(32);  // object_cropping_width, object_cropping_height
     }
 }
 
 void PGSStreamReader::pgs_window(BitStreamReader& bitReader)
 {
-    int window_id = bitReader.getBits(8);
-    window_horizontal_position = bitReader.getBits(16);
-    window_vertical_position = bitReader.getBits(16);
-    int window_width = bitReader.getBits(16);
-    int window_heigh = bitReader.getBits(16);
-    window_heigh = window_heigh;
+    bitReader.skipBits(8);  // window_id
+    bitReader.skipBits(32);  // window_horizontal_position, window_vertical_position
+    bitReader.skipBits(32);  // window_width, window_height
 }
 
 int PGSStreamReader::calcFpsIndex(double fps)
@@ -136,7 +138,7 @@ void PGSStreamReader::yuvToRgb(int minY)
     // uint8_t* dst = m_rgbBuffer;
     RGBQUAD* dst = (RGBQUAD*)m_rgbBuffer;
 
-    RGBQUAD rgbPal[256];
+    RGBQUAD rgbPal[256]{};
     text_subtitles::YUVQuad yuvPal[256];
     memset(&rgbPal[0], 0, sizeof(rgbPal));
     memset(&rgbPal[0], 0, sizeof(yuvPal));
@@ -163,10 +165,7 @@ void PGSStreamReader::decodeRleData(int xOffset, int yOffset)
         return;
     uint8_t* src = &m_dstRle[0];
     uint8_t* srcEnd = src + m_dstRle.size();
-    // object_width
-    // object_height
-    // window_horizontal_position
-    // window_vertical_position
+
     uint8_t* dst = m_imgBuffer + (yOffset * m_video_width + xOffset);
     int dstLineStep = m_video_width - object_width;
     uint8_t color;
@@ -240,7 +239,7 @@ int PGSStreamReader::readObjectDef(uint8_t* pos, uint8_t* end)
             pos += 3;  // skip object ID and version number
             seq = *pos++;
         }
-        int oldSize = m_dstRle.size();
+        size_t oldSize = m_dstRle.size();
         m_dstRle.resize(oldSize + end - pos);
         memcpy(&m_dstRle[oldSize], pos, end - pos);
         pos += end - pos;
@@ -250,8 +249,8 @@ int PGSStreamReader::readObjectDef(uint8_t* pos, uint8_t* end)
         decodeRleData(composition_object_horizontal_position[object_id],
                       composition_object_vertical_position[object_id]);
         yuvToRgb(m_fontBorder ? Y_THRESHOLD : 0);
-        BitmapInfo bmpDest;
-        BitmapInfo bmpRef;
+        BitmapInfo bmpDest{};
+        BitmapInfo bmpRef{};
 
         bmpRef.buffer = (RGBQUAD*)m_rgbBuffer;
         bmpRef.Width = m_video_width;
@@ -279,8 +278,8 @@ void PGSStreamReader::rescaleRGB(BitmapInfo* bmpDest, BitmapInfo* bmpRef)
     {
         for (int xDest = 0; xDest < bmpDest->Width; xDest++)
         {
-            int floor_x = floor(xDest * xFactor);
-            int floor_y = floor(yDest * yFactor);
+            int floor_x = (int)floor(xDest * xFactor);
+            int floor_y = (int)floor(yDest * yFactor);
             int ceil_x = FFMIN(bmpRef->Width - 1, floor_x + 1);
             int ceil_y = FFMIN(bmpRef->Height - 1, floor_y + 1);
             double fraction_x = xDest * xFactor - floor_x;
@@ -295,16 +294,16 @@ void PGSStreamReader::rescaleRGB(BitmapInfo* bmpDest, BitmapInfo* bmpRef)
             c4 += ceil_x;
             double b1 = one_minus_x * c1->rgbRed + fraction_x * c2->rgbRed;
             double b2 = one_minus_x * c3->rgbRed + fraction_x * c4->rgbRed;
-            ImagePixels->rgbRed = one_minus_y * b1 + fraction_y * b2;
+            ImagePixels->rgbRed = (uint8_t)(one_minus_y * b1 + fraction_y * b2);
             b1 = one_minus_x * c1->rgbGreen + fraction_x * c2->rgbGreen;
             b2 = one_minus_x * c3->rgbGreen + fraction_x * c4->rgbGreen;
-            ImagePixels->rgbGreen = one_minus_y * b1 + fraction_y * b2;
+            ImagePixels->rgbGreen = (uint8_t)(one_minus_y * b1 + fraction_y * b2);
             b1 = one_minus_x * c1->rgbBlue + fraction_x * c2->rgbBlue;
             b2 = one_minus_x * c3->rgbBlue + fraction_x * c4->rgbBlue;
-            ImagePixels->rgbBlue = one_minus_y * b1 + fraction_y * b2;
+            ImagePixels->rgbBlue = (uint8_t)(one_minus_y * b1 + fraction_y * b2);
             b1 = one_minus_x * c1->rgbReserved + fraction_x * c2->rgbReserved;
             b2 = one_minus_x * c3->rgbReserved + fraction_x * c4->rgbReserved;
-            ImagePixels->rgbReserved = one_minus_y * b1 + fraction_y * b2;
+            ImagePixels->rgbReserved = (uint8_t)(one_minus_y * b1 + fraction_y * b2);
             ImagePixels++;
         }
     }
@@ -325,25 +324,25 @@ void PGSStreamReader::renderTextShow(int64_t inTime)
         tmp[idx] <<= 1;
         tmp[idx]++;
     }
-    inTime /= INT_FREQ_TO_TS_FREQ;
+    inTime = (int64_t)(inTime / INT_FREQ_TO_TS_FREQ);
 
     double decodedObjectSize = m_render->renderedHeight() * m_scaled_width;
-    int64_t compositionDecodeTime = 90000.0 * decodedObjectSize / PIXEL_DECODING_RATE + 0.999;
-    int64_t windowsTransferTime = 90000.0 * decodedObjectSize / PIXEL_COMPOSITION_RATE + 0.999;
+    int64_t compositionDecodeTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_DECODING_RATE + 0.999);
+    int64_t windowsTransferTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_COMPOSITION_RATE + 0.999);
     const int64_t PLANEINITIALIZATIONTIME =
-        90000.0 * (m_scaled_width * m_scaled_height) / PIXEL_COMPOSITION_RATE + 0.999;
+        (int64_t)(90000.0 * (m_scaled_width * m_scaled_height) / PIXEL_COMPOSITION_RATE + 0.999);
     const int64_t PRESENTATION_DTS_DELTA = PLANEINITIALIZATIONTIME + windowsTransferTime;
 
     m_objectWindowHeight = FFMAX(0, m_render->renderedHeight());
-    // m_objectWindowTop = FFMAX(0, m_render->m_videoHeight - m_objectWindowHeight - m_render->m_bottomOffset);
     m_objectWindowTop = m_render->maxLine();
 
     // show text
     uint8_t* curPos = m_renderedData;
     // composition segment. pts=x,  dts = x-0.0648 (pts alignment to video grid) (I get constant value from real PGS
     // track as example)
-    int rLen = m_render->composePresentationSegment(curPos, CM_Start, inTime, inTime - PRESENTATION_DTS_DELTA,
-                                                    m_objectWindowTop, m_demuxMode, m_forced_on_flag);
+    int rLen =
+        m_render->composePresentationSegment(curPos, CompositionMode::CM_Start, inTime, inTime - PRESENTATION_DTS_DELTA,
+                                             m_objectWindowTop, m_demuxMode, m_forced_on_flag);
     m_renderedBlocks.push_back(PGSRenderedBlock(inTime, inTime - PRESENTATION_DTS_DELTA, rLen, curPos));
     curPos += rLen;
     // window definition.   pts=x-0.001, dts = x-0.0648
@@ -369,27 +368,26 @@ void PGSStreamReader::renderTextShow(int64_t inTime)
     // end                  pts=x-0.0627, dts = x-0.0627
     rLen = m_render->composeEnd(curPos, odfPTS, odfPTS, m_demuxMode);
     m_renderedBlocks.push_back(PGSRenderedBlock(odfPTS, odfPTS, rLen, curPos));
-    curPos += rLen;
-    m_renderedLen = curPos - m_renderedData;
 }
 
 void PGSStreamReader::renderTextHide(int64_t outTime)
 {
     double decodedObjectSize = m_render->renderedHeight() * m_scaled_width;
-    int64_t compositionDecodeTime = 90000.0 * decodedObjectSize / PIXEL_DECODING_RATE + 0.999;
-    int64_t windowsTransferTime = 90000.0 * decodedObjectSize / PIXEL_COMPOSITION_RATE + 0.999;
+    int64_t compositionDecodeTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_DECODING_RATE + 0.999);
+    int64_t windowsTransferTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_COMPOSITION_RATE + 0.999);
     const int64_t PLANEINITIALIZATIONTIME =
-        90000.0 * (m_scaled_width * m_scaled_height) / PIXEL_COMPOSITION_RATE + 0.999;
+        (int64_t)(90000.0 * (m_scaled_width * m_scaled_height) / PIXEL_COMPOSITION_RATE + 0.999);
     const int64_t PRESENTATION_DTS_DELTA = PLANEINITIALIZATIONTIME + windowsTransferTime;
 
     m_firstRenderedPacket = true;
-    outTime /= INT_FREQ_TO_TS_FREQ;
+    outTime = (int64_t)(outTime / INT_FREQ_TO_TS_FREQ);
     m_renderedBlocks.clear();
     // hide text
     uint8_t* curPos = m_renderedData;
     // composition segment. pts=x,       dts = x-0.001 (pts alignment to video grid)
-    int rLen = m_render->composePresentationSegment(curPos, CM_Finish, outTime, outTime - windowsTransferTime - 90,
-                                                    m_objectWindowTop, m_demuxMode, false);
+    int rLen =
+        m_render->composePresentationSegment(curPos, CompositionMode::CM_Finish, outTime,
+                                             outTime - windowsTransferTime - 90, m_objectWindowTop, m_demuxMode, false);
     m_renderedBlocks.push_back(PGSRenderedBlock(outTime, outTime - windowsTransferTime - 90, rLen, curPos));
     curPos += rLen;
     // windows              pts=x-0.001, dts = x-0.001
@@ -401,23 +399,21 @@ void PGSStreamReader::renderTextHide(int64_t outTime)
     // end                  pts=x-0.001, dts = x-0.001
     rLen = m_render->composeEnd(curPos, outTime - 90, outTime - 90, m_demuxMode);
     m_renderedBlocks.push_back(PGSRenderedBlock(outTime - 90, outTime - 90, rLen, curPos));
-    curPos += rLen;
-    m_renderedLen = curPos - m_renderedData;
 }
 
 int64_t getTimeValueNano(uint8_t* pos)
 {
-    uint32_t pts = AV_RB32(pos);
+    int64_t pts = (int64_t)AV_RB32(pos);
     if (pts > 0xff000000u)
-        return ptsToNanoClock((int64_t)pts - 0x100000000ll);
+        return ptsToNanoClock(pts - 0x100000000ll);
     else
         return ptsToNanoClock(pts);
 }
 
-int64_t getTimeValueNano(uint64_t pts)
+int64_t getTimeValueNano(int64_t pts)
 {
     if (pts > 0x1ff000000ull)
-        return ptsToNanoClock(int64_t(pts) - 0x200000000ll);
+        return ptsToNanoClock(pts - 0x200000000ll);
     else
         return ptsToNanoClock(pts);
 }
@@ -441,8 +437,8 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         PGSRenderedBlock& block = m_renderedBlocks[0];
         avPacket.data = block.data;
         avPacket.size = FFMIN(MAX_AV_PACKET_SIZE, block.len);
-        avPacket.pts = block.pts * INT_FREQ_TO_TS_FREQ;
-        avPacket.dts = block.dts * INT_FREQ_TO_TS_FREQ;
+        avPacket.pts = (int64_t)(block.pts * INT_FREQ_TO_TS_FREQ);
+        avPacket.dts = (int64_t)(block.dts * INT_FREQ_TO_TS_FREQ);
         block.data += avPacket.size;
         block.len -= avPacket.size;
         if (block.len == 0)
@@ -474,9 +470,9 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
             m_scaledRgbBuffer = new uint8_t[m_scaled_width * m_scaled_height * 4];
             m_renderedData = new uint8_t[(m_scaled_width + 16) * m_scaled_height + 16384];
 
-            memset(m_imgBuffer, 0xff, m_video_width * m_video_height);
-            memset(m_rgbBuffer, 0x00, m_video_width * m_video_height * 4);
-            memset(m_scaledRgbBuffer, 0x00, m_scaled_width * m_scaled_height * 4);
+            memset(m_imgBuffer, 0xff, (size_t)m_video_width * m_video_height);
+            memset(m_rgbBuffer, 0x00, (size_t)m_video_width * m_video_height * 4);
+            memset(m_scaledRgbBuffer, 0x00, (size_t)m_scaled_width * m_scaled_height * 4);
             m_render->setImageBuffer(m_scaledRgbBuffer);
         }
         LTRACE(LT_INFO, 2,
@@ -496,15 +492,15 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
                                                  << ". Scaling method: Bilinear interpolation");
     }
 
-    if (m_state == stAVPacketFragmented)
+    if (m_state == State::stAVPacketFragmented)
     {
-        int avLen = m_avFragmentEnd - m_curPos;
+        int avLen = (int)(m_avFragmentEnd - m_curPos);
         if (avLen > MAX_AV_PACKET_SIZE)
         {
             avLen = MAX_AV_PACKET_SIZE;
         }
         else
-            m_state = stParsePES;
+            m_state = State::stParsePES;
         avPacket.pts = m_lastPTS;
         avPacket.dts = m_lastDTS;
         avPacket.data = m_curPos;
@@ -534,14 +530,14 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
             memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
             return NEED_MORE_DATA;
         }
-        m_lastPTS = getTimeValueNano(m_curPos + 2) * m_scale;
+        m_lastPTS = (int64_t)(getTimeValueNano(m_curPos + 2) * m_scale);
         m_maxPTS = FFMAX(m_maxPTS, m_lastPTS);
-        m_lastDTS = getTimeValueNano(m_curPos + 6) * m_scale;
+        m_lastDTS = (int64_t)(getTimeValueNano(m_curPos + 6) * m_scale);
         if (m_lastDTS == 0)
             m_lastDTS = m_lastPTS;
         m_curPos += 10;
         m_processedSize += 10;
-        m_state = stParsePGS;
+        m_state = State::stParsePGS;
         avPacket.pts = m_lastPTS;
         avPacket.dts = m_lastDTS;
         m_isNewFrame = true;
@@ -555,7 +551,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     }
 
     bool pesStartCode = m_curPos[0] == 0 && m_curPos[1] == 0 && m_curPos[2] == 01;
-    // if (m_state == stParsePES)
+
     if (pesStartCode)
     {
         if (m_bufEnd - m_curPos < 8)
@@ -582,7 +578,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
             m_lastDTS = getTimeValueNano(pesPacket->getDts());
         m_curPos += pesHeaderLen;
         m_processedSize += pesHeaderLen;
-        m_state = stParsePGS;
+        m_state = State::stParsePGS;
         // LTRACE(LT_INFO, 2, "PGS PES#" << m_streamIndex << ". PTS=" << m_lastPTS/1e9 << " DTS=" << m_lastDTS/1e9);
         avPacket.pts = m_lastPTS;
         avPacket.dts = m_lastDTS;
@@ -605,14 +601,14 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     }
     uint8_t segment_type = *m_curPos;
     uint16_t segment_len = (uint16_t)AV_RB16(m_curPos + 1);
-    if (m_bufEnd - m_curPos < 3 + segment_len)
+    if (m_bufEnd - m_curPos < 3ll + segment_len)
     {
         m_tmpBufferLen = m_bufEnd - m_curPos;
         memmove(&m_tmpBuffer[0], m_curPos, m_tmpBufferLen);
         return NEED_MORE_DATA;
     }
     m_curPos += 3;
-    BitStreamReader bitReader;
+    BitStreamReader bitReader{};
     try
     {
         int number_of_composition_objects, palette_update_flag, palette_id_ref, number_of_windows;
@@ -632,9 +628,9 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
             //	  << " objectID=" << (int)m_curPos[0] << " version=" << (int) m_curPos[2]);
             if (m_needRescale)
             {
-                memset(m_imgBuffer, 0xff, m_video_width * m_video_height);
-                memset(m_rgbBuffer, 0x00, m_video_width * m_video_height * 4);
-                memset(m_scaledRgbBuffer, 0x00, m_scaled_width * m_scaled_height * 4);
+                memset(m_imgBuffer, 0xff, (size_t)m_video_width * m_video_height);
+                memset(m_rgbBuffer, 0x00, (size_t)m_video_width * m_video_height * 4);
+                memset(m_scaledRgbBuffer, 0x00, (size_t)m_scaled_width * m_scaled_height * 4);
                 if (readObjectDef(m_curPos, m_curPos + segment_len) == NEED_MORE_DATA)
                 {
                     m_tmpBufferLen = m_bufEnd - m_curPos;
@@ -660,9 +656,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
             {
                 composition_object(bitReader);
             }
-            // LTRACE(LT_INFO, 2, "PGS #" << m_streamIndex << " Presentation Composition Segment. State = "
-            //	<< composition_state << " number=" << composition_number);
-            if (composition_state != EPOTH_START && m_needRescale)
+            if (composition_state != CompositionState::csEpochStart && m_needRescale)
                 renderTextHide(m_maxPTS);
             break;
         case WINDOWS_DEF_SEGMENT:
@@ -694,6 +688,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     }
     catch (BitStreamException& e)
     {
+        (void)e;
         return NEED_MORE_DATA;
     }
     avPacket.pts = m_lastPTS;
@@ -709,18 +704,18 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     if (avLen > MAX_AV_PACKET_SIZE - 3)
     {
         avLen = MAX_AV_PACKET_SIZE - 3;
-        m_state = stAVPacketFragmented;
+        m_state = State::stAVPacketFragmented;
         m_avFragmentEnd = m_curPos + segment_len;
     }
     m_curPos += avLen;
-    m_processedSize += avLen + 3;
-    avPacket.size = avLen + 3;
+    m_processedSize += 3ll + avLen;
+    avPacket.size = 3ll + avLen;
     if (m_needRescale)
     {
         if (m_renderedBlocks.size() > 0)
         {
-            avPacket.pts = m_renderedBlocks.begin()->pts * INT_FREQ_TO_TS_FREQ;
-            avPacket.dts = m_renderedBlocks.begin()->dts * INT_FREQ_TO_TS_FREQ;
+            avPacket.pts = (int64_t)(m_renderedBlocks.begin()->pts * INT_FREQ_TO_TS_FREQ);
+            avPacket.dts = (int64_t)(m_renderedBlocks.begin()->dts * INT_FREQ_TO_TS_FREQ);
         }
         else
         {
@@ -787,7 +782,7 @@ CheckStreamRez PGSStreamReader::checkStream(uint8_t* buffer, int len, ContainerT
     return rez;
 }
 
-void PGSStreamReader::intDecodeStream(uint8_t* buffer, int len)
+void PGSStreamReader::intDecodeStream(uint8_t* buffer, size_t len)
 {
     uint8_t* bufEnd = buffer + len;
     uint8_t* curPos = buffer;
@@ -807,13 +802,13 @@ void PGSStreamReader::intDecodeStream(uint8_t* buffer, int len)
 
         uint8_t segment_type = *curPos;
         uint16_t segment_len = (uint16_t)AV_RB16(curPos + 1);
-        if (bufEnd - curPos < 3 + segment_len)
+        if (bufEnd - curPos < 3ll + segment_len)
             return;
 
         curPos += 3;
         if (segment_type == 0x16)
         {
-            BitStreamReader bitReader;
+            BitStreamReader bitReader{};
             bitReader.setBuffer(curPos, bufEnd);
             video_descriptor(bitReader);
             return;
@@ -834,9 +829,9 @@ int PGSStreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
         *dstBuffer++ = 'P';
         *dstBuffer++ = 'G';
         uint32_t* data = (uint32_t*)dstBuffer;
-        *data++ = my_htonl(nanoClockToPts(m_lastPTS));
+        *data++ = my_htonl((uint32_t)nanoClockToPts(m_lastPTS));
         if (m_lastDTS != m_lastPTS)
-            *data = my_htonl(nanoClockToPts(m_lastDTS));
+            *data = my_htonl((uint32_t)nanoClockToPts(m_lastDTS));
         else
             *data = 0;
         return 10;

--- a/tsMuxer/psgStreamReader.h
+++ b/tsMuxer/psgStreamReader.h
@@ -75,13 +75,13 @@ class PGSStreamReader : public AbstractStreamReader
         uint8_t* data;
     };
 
-    enum State
+    enum class State
     {
         stParsePES,
         stParsePGS,
         stAVPacketFragmented
     };
-    enum CompositionState
+    enum class CompositionState
     {
         csNormalCase,
         csAcquisitionPoint,
@@ -91,7 +91,7 @@ class PGSStreamReader : public AbstractStreamReader
     State m_state;
     uint8_t* m_curPos;
     uint8_t* m_buffer;
-    int m_tmpBufferLen;
+    size_t m_tmpBufferLen;
     std::vector<uint8_t> m_tmpBuffer;
     int64_t m_lastPTS;
     int64_t m_maxPTS;
@@ -114,8 +114,6 @@ class PGSStreamReader : public AbstractStreamReader
     uint8_t* m_imgBuffer;
     uint8_t* m_rgbBuffer;
     uint8_t* m_scaledRgbBuffer;
-    uint16_t window_horizontal_position;
-    uint16_t window_vertical_position;
     std::map<uint8_t, text_subtitles::YUVQuad> m_palette;
     int m_scaled_width;
     int m_scaled_height;
@@ -123,7 +121,6 @@ class PGSStreamReader : public AbstractStreamReader
     bool m_firstRenderedPacket;
 
     text_subtitles::TextToPGSConverter* m_render;
-    uint32_t m_renderedLen;
     uint8_t* m_renderedData;
     std::vector<PGSRenderedBlock> m_renderedBlocks;
 
@@ -141,7 +138,7 @@ class PGSStreamReader : public AbstractStreamReader
     void decodeRleData(int xOffset, int yOffset);
     void yuvToRgb(int minY);
     void rescaleRGB(BitmapInfo* bmpDest, BitmapInfo* bmpRef);
-    void intDecodeStream(uint8_t* buffer, int len);
+    void intDecodeStream(uint8_t* buffer, size_t len);
 
     int m_palleteID;
     int m_paletteVersion;
@@ -149,10 +146,9 @@ class PGSStreamReader : public AbstractStreamReader
     int m_objectWindowHeight;
     int m_objectWindowTop;
     uint8_t m_offsetId;
-    int m_forced_on_flag;
+    bool m_forced_on_flag;
 
     CompositionState composition_state;
-    int composition_number;
 };
 
 #endif

--- a/tsMuxer/srtStreamReader.h
+++ b/tsMuxer/srtStreamReader.h
@@ -57,7 +57,7 @@ class SRTStreamReader : public AbstractStreamReader
     double m_inTime;
     double m_outTime;
     int m_processedSize;
-    long m_charSize;
+    int32_t m_charSize;
     AbstractStreamReader* m_dstSubCodec;
     text_subtitles::TextToPGSConverter* m_srtRender;
     bool m_lastBlock;
@@ -73,12 +73,13 @@ class SRTStreamReader : public AbstractStreamReader
     uint32_t m_long_N;
     text_subtitles::TextAnimation m_animation;
 
-    enum
+    enum class ParseState
     {
         PARSE_FIRST_LINE,
         PARSE_TIME,
         PARSE_TEXT
-    } m_state;
+    };
+    ParseState m_state;
     uint8_t* renderNextMessage(uint32_t& renderedLen);
     bool parseTime(const std::string& text);
     std::string detectUTF8Lang(uint8_t* buffer, int len);

--- a/tsMuxer/textSubtitles.h
+++ b/tsMuxer/textSubtitles.h
@@ -15,7 +15,7 @@
 
 namespace text_subtitles
 {
-enum CompositionMode
+enum class CompositionMode
 {
     CM_Start,
     CM_Update,

--- a/tsMuxer/textSubtitlesRender.h
+++ b/tsMuxer/textSubtitlesRender.h
@@ -116,9 +116,7 @@ class TextSubtitlesRender
     Font m_font;
 
    protected:
-    YUVQuad RGBAToYUVA(RGBQUAD* rgba);
     int m_borderWidth;
-    int getRepeatCnt(uint32_t* pos, uint32_t* end);
     std::vector<std::pair<Font, std::string>> processTxtLine(const std::string& line, std::vector<Font>& fontStack);
     int browserSizeToRealSize(int bSize, double rSize);
 


### PR DESCRIPTION
Remove unused members.
Initialize all class members.
Make casts explicit.
Change enum type to enum class type.
More precise calculations of RGB<->YCbCr.