### PR TITLE
Tidy-up metaDemuxer class

### DIFF
--- a/libmediation/types/types.cpp
+++ b/libmediation/types/types.cpp
@@ -96,6 +96,8 @@ uint8_t strToInt8u(const char* const str) { return (uint8_t)strtol(str, 0, 10); 
 
 double strToDouble(const char* const str) { return strtod(str, 0); }
 
+float strToFloat(const char* const str) { return strtof(str, 0); }
+
 bool strToBool(const char* const str)
 {
     if (!strcmp(str, "true"))
@@ -302,7 +304,7 @@ void splitStr(vector<string>& rez, const char* str, char splitter)
 
 string extractFileExt(const string& src)
 {
-    for (int i = src.size() - 1; i >= 0; i--)
+    for (size_t i = src.size() - 1; i > 0; i--)
         if (src[i] == '.')
         {
             string rez = src.substr(i + 1);
@@ -317,7 +319,7 @@ string extractFileExt(const string& src)
 string extractFileName(const string& src)
 {
     int endPos = src.size();
-    for (int i = src.size() - 1; i >= 0; i--)
+    for (size_t i = src.size() - 1; i > 0; i--)
         if (src[i] == '.')
         {
             if (endPos == src.size())

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -29,7 +29,7 @@ uint16_t strToInt16u(const char* const);
 int8_t strToInt8(const char* const);
 uint8_t strToInt8u(const char* const);
 double strToDouble(const char* const);  // The length of the string should not exceed 15 characters
-float strToFloat(const char* const);  // The length of the string should not exceed 15 characters
+float strToFloat(const char* const);    // The length of the string should not exceed 15 characters
 bool strToBool(const char* const);
 bool strEndWith(const std::string& str, const std::string& substr);
 bool strStartWith(const std::string& str, const std::string& substr);

--- a/libmediation/types/types.h
+++ b/libmediation/types/types.h
@@ -29,6 +29,7 @@ uint16_t strToInt16u(const char* const);
 int8_t strToInt8(const char* const);
 uint8_t strToInt8u(const char* const);
 double strToDouble(const char* const);  // The length of the string should not exceed 15 characters
+float strToFloat(const char* const);  // The length of the string should not exceed 15 characters
 bool strToBool(const char* const);
 bool strEndWith(const std::string& str, const std::string& substr);
 bool strStartWith(const std::string& str, const std::string& substr);

--- a/tsMuxer/abstractDemuxer.h
+++ b/tsMuxer/abstractDemuxer.h
@@ -52,7 +52,7 @@ class MemoryBlock
         }
     }
 
-    int size() const { return m_size; }
+    size_t size() const { return m_size; }
 
     uint8_t* data() { return m_data.empty() ? 0 : &m_data[0]; }
 
@@ -62,7 +62,7 @@ class MemoryBlock
 
    private:
     std::vector<uint8_t> m_data;
-    int m_size;
+    size_t m_size;
 };
 
 typedef MemoryBlock StreamData;

--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -73,8 +73,6 @@ struct StreamInfo
     bool m_isSubStream;
 };
 
-// drpReadSequence - the stream is not fragmented
-// drpFragmented   - the stream is fragmented according to the resulting container
 enum class DemuxerReadPolicy
 {
     drpReadSequence,
@@ -138,13 +136,12 @@ class ContainerToReaderWrapper : public AbstractReader
 
     bool gotoByte(uint32_t readerID, uint64_t seekDist) override { return false; }
     void terminate();
-    void openAllStream();
     std::map<std::string, DemuxerData> m_demuxers;
 
    private:
     int64_t m_discardedSize;
     int m_readerCnt;
-    int m_readBuffOffset;
+    size_t m_readBuffOffset;
     const BufferedReaderManager& m_readManager;
     std::map<uint32_t, ReaderInfo> m_readerInfo;
     const METADemuxer& m_owner;
@@ -165,7 +162,6 @@ struct DetectStreamRez
 class METADemuxer : public AbstractDemuxer
 {
    public:
-    // METADemuxer(const BufferedReaderManager& readManager, const char* streamName);
     METADemuxer(const BufferedReaderManager& readManager);
     ~METADemuxer() override;
     // virtual void initStream();


### PR DESCRIPTION
Reduce memory footprint of detectTrackReader
Correct types, make casting explicit
Add "srtToFloat" method