### PR TITLE
Use .ec3 as the extension for Dolby Digital Plus (E-AC3) files

### DIFF
--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -39,36 +39,41 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
                                    const map<string, string>& params, AbstractStreamReader* codecReader)
 {
     codecReader->setDemuxMode(true);
-    uint8_t descrBuffer[188];
-    int descriptorLen = codecReader->getTSDescriptor(descrBuffer, true, true);
     string fileExt = "track";
-    if (codecName == "A_AC3")
-        fileExt = ".ac3";
-    else if (codecName == "A_AAC")
+
+    // this call seemingly does nothing, but it actually makes some
+    // StreamReaders refresh/set their private variables, enabling proper
+    // codec->extension mapping in here. don't remove it.
+    uint8_t descrBuffer[188];
+    codecReader->getTSDescriptor(descrBuffer, true, true);
+
+    if (codecName == "A_AAC")
+    {
         fileExt = ".aac";
+    }
     else if (codecName == "A_MP3")
     {
-        MpegAudioStreamReader* mp3Reader = (MpegAudioStreamReader*)codecReader;
+        const auto mp3Reader = static_cast<MpegAudioStreamReader*>(codecReader);
         if (mp3Reader->getLayer() == 3)
             fileExt = ".mp3";
         else
             fileExt = ".mpa";
     }
     else if (codecName == "A_DTS")
+    {
         fileExt = ".dts";
+    }
     else if (codecName == "A_LPCM")
     {
         fileExt = ".wav";
-        LPCMStreamReader* lpcmReader = (LPCMStreamReader*)codecReader;
-        // lpcmReader->setDemuxMode(true);
     }
     else if (codecName == "A_AC3")
     {
-        AC3StreamReader* ac3Reader = (AC3StreamReader*)codecReader;
+        const auto ac3Reader = static_cast<AC3StreamReader*>(codecReader);
         if (ac3Reader->isTrueHD() && !ac3Reader->getDownconvertToAC3())
             fileExt = ".trueHD";
         else if (ac3Reader->isEAC3())
-            fileExt = ".ddp";
+            fileExt = ".ec3";
         else
             fileExt = ".ac3";
     }
@@ -79,14 +84,10 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
     else if (codecName == "S_HDMV/PGS")
     {
         fileExt = ".sup";
-        PGSStreamReader* pgsReader = (PGSStreamReader*)codecReader;
-        // pgsReader->setDemuxMode(true);
     }
     else if (codecName == "S_TEXT/UTF8")
     {
         fileExt = ".sup";
-        SRTStreamReader* srtReader = (SRTStreamReader*)codecReader;
-        // srtReader->setDemuxMode(true);
     }
     else if (codecName[0] == 'V')
     {
@@ -115,13 +116,6 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
             fileExt = ".mpv";
         }
     }
-
-    /*
-    if (codecName[0] == 'A') {
-            // Used for "more correct" switching between the boundaries of Blu-Ray disc files
-            ((SimplePacketizerReader*) codecReader)->setMPLSInfo(m_mplsParser.m_playItems);
-    }
-    */
 
     vector<string> fileList = extractFileList(streamName);
     string fileName;

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -4,22 +4,22 @@
 <context>
     <name>FontSettingsTableModel</name>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <location filename="../fontsettingstablemodel.cpp" line="135"/>
         <source>Options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -129,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <location filename="../tsmuxerwindow.cpp" line="93"/>
         <source>General track options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -195,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1010"/>
+        <location filename="../tsmuxerwindow.cpp" line="1055"/>
         <source>Downconvert HD audio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -221,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="55"/>
+        <location filename="../tsmuxerwindow.cpp" line="95"/>
         <source>Demux options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2628"/>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Demux</source>
         <translation type="unfinished"></translation>
     </message>
@@ -745,7 +745,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2662"/>
-        <location filename="../tsmuxerwindow.cpp" line="2282"/>
+        <location filename="../tsmuxerwindow.cpp" line="2327"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -761,7 +761,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2781"/>
-        <location filename="../tsmuxerwindow.cpp" line="2266"/>
+        <location filename="../tsmuxerwindow.cpp" line="2311"/>
         <source>Sta&amp;rt muxing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -771,196 +771,288 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="29"/>
-        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="57"/>
-        <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tsmuxerwindow.cpp" line="59"/>
-        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
+        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <source>AC3/E-AC3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="61"/>
-        <source>Disk image (*.iso);;all files (*.*)</source>
+        <source>AAC (advanced audio coding)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="551"/>
+        <location filename="../tsmuxerwindow.cpp" line="62"/>
+        <source>AVC/MVC/H.264 elementary stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="63"/>
+        <source>HEVC (High Efficiency Video Codec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="64"/>
+        <source>Digital Theater System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="65"/>
+        <source>DTS-HD Master Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="66"/>
+        <source>Mpeg video elementary stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="67"/>
+        <source>Mpeg audio elementary stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="68"/>
+        <location filename="../tsmuxerwindow.cpp" line="97"/>
+        <source>Transport Stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="69"/>
+        <location filename="../tsmuxerwindow.cpp" line="101"/>
+        <source>BDAV Transport Stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="70"/>
+        <source>Program Stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="71"/>
+        <source>Matroska audio/video files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="72"/>
+        <source>MP4 audio/video files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="73"/>
+        <source>Quick time audio/video files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="74"/>
+        <source>Blu-ray play list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="75"/>
+        <source>Blu-ray PGS subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="76"/>
+        <source>Text subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="77"/>
+        <source>WAVE - Uncompressed PCM audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="78"/>
+        <source>RAW LPCM Stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="89"/>
+        <source>All supported media files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="104"/>
+        <source>Disk image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="596"/>
         <source>Not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="662"/>
+        <location filename="../tsmuxerwindow.cpp" line="1180"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="618"/>
+        <location filename="../tsmuxerwindow.cpp" line="663"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="911"/>
+        <location filename="../tsmuxerwindow.cpp" line="956"/>
         <source>Add media files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="926"/>
+        <location filename="../tsmuxerwindow.cpp" line="971"/>
         <source>File already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="927"/>
+        <location filename="../tsmuxerwindow.cpp" line="972"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1049"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1006"/>
+        <location filename="../tsmuxerwindow.cpp" line="1051"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1008"/>
+        <location filename="../tsmuxerwindow.cpp" line="1053"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1141"/>
+        <location filename="../tsmuxerwindow.cpp" line="1186"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1151"/>
+        <location filename="../tsmuxerwindow.cpp" line="1196"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Mux</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1412"/>
+        <location filename="../tsmuxerwindow.cpp" line="1459"/>
         <source>tsMuxeR error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1416"/>
+        <location filename="../tsmuxerwindow.cpp" line="1463"/>
         <source>tsMuxeR not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1434"/>
+        <location filename="../tsmuxerwindow.cpp" line="1481"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2142"/>
-        <location filename="../tsmuxerwindow.cpp" line="2143"/>
+        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2188"/>
         <source>No track selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2149"/>
+        <location filename="../tsmuxerwindow.cpp" line="2194"/>
         <source>Append media files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2165"/>
+        <location filename="../tsmuxerwindow.cpp" line="2210"/>
         <source>Invalid file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2166"/>
+        <location filename="../tsmuxerwindow.cpp" line="2211"/>
         <source>Appended file must have same file extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2264"/>
+        <location filename="../tsmuxerwindow.cpp" line="2309"/>
         <source>Sta&amp;rt demuxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2278"/>
+        <location filename="../tsmuxerwindow.cpp" line="2323"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.cpp" line="2409"/>
         <source>Select file for muxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2386"/>
-        <location filename="../tsmuxerwindow.cpp" line="2402"/>
+        <location filename="../tsmuxerwindow.cpp" line="2431"/>
+        <location filename="../tsmuxerwindow.cpp" line="2447"/>
         <source>Invalid file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2387"/>
+        <location filename="../tsmuxerwindow.cpp" line="2432"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2403"/>
+        <location filename="../tsmuxerwindow.cpp" line="2448"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2419"/>
+        <location filename="../tsmuxerwindow.cpp" line="2464"/>
         <source>Overwrite existing %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Muxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Demuxing in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2451"/>
+        <location filename="../tsmuxerwindow.cpp" line="2496"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2466"/>
+        <location filename="../tsmuxerwindow.cpp" line="2511"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2467"/>
+        <location filename="../tsmuxerwindow.cpp" line="2512"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_en.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_en.ts
@@ -844,7 +844,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="73"/>
-        <source>Quick time audio/video files</source>
+        <source>QuickTime audio/video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/tsMuxerGUI/translations/tsmuxergui_fr.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_fr.ts
@@ -844,7 +844,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="73"/>
-        <source>Quick time audio/video files</source>
+        <source>QuickTime audio/video files</source>
         <translation>Fichiers audio/vidéo QuickTime</translation>
     </message>
     <message>

--- a/tsMuxerGUI/translations/tsmuxergui_fr.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_fr.ts
@@ -4,22 +4,22 @@
 <context>
     <name>FontSettingsTableModel</name>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Size:</source>
         <translation>Taille :</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <location filename="../fontsettingstablemodel.cpp" line="135"/>
         <source>Options:</source>
         <translation>Options :</translation>
     </message>
@@ -129,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <location filename="../tsmuxerwindow.cpp" line="93"/>
         <source>General track options</source>
         <translation>Options générales de la piste</translation>
     </message>
@@ -195,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1010"/>
+        <location filename="../tsmuxerwindow.cpp" line="1055"/>
         <source>Downconvert HD audio</source>
         <translation>Supprimer les données HD de l&apos;audio</translation>
     </message>
@@ -221,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="55"/>
+        <location filename="../tsmuxerwindow.cpp" line="95"/>
         <source>Demux options</source>
         <translation>Options de démuxage</translation>
     </message>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2628"/>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Demux</source>
         <translation>Démuxer</translation>
     </message>
@@ -745,7 +745,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2662"/>
-        <location filename="../tsmuxerwindow.cpp" line="2282"/>
+        <location filename="../tsmuxerwindow.cpp" line="2327"/>
         <source>File name</source>
         <translation>Nom du fichier</translation>
     </message>
@@ -761,7 +761,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2781"/>
-        <location filename="../tsmuxerwindow.cpp" line="2266"/>
+        <location filename="../tsmuxerwindow.cpp" line="2311"/>
         <source>Sta&amp;rt muxing</source>
         <translation>&amp;Démarrer le muxage</translation>
     </message>
@@ -771,196 +771,304 @@
         <translation>Sauvegarder le fichier Meta</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation>Tous les fichiers média pris en charge (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 flux élémentaire (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Flux vidéo élémentaire Mpeg (*.mpv *.m1v *.m2v);;Flux audio élémentaire Mpeg (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Fichiers audio/vidéo Matroska (*.mkv *.mka *.mks);;Fichiers audio/vidéo MP4 (*.mp4 *.m4a *.m4v);;Fichiers audio/vidéo QuickTime (*.mov);;Liste de lecture Blu-Ray (*.mpls *.mpl);;Sous-titres PGS de Blu-ray (*.sup);;Sous-titres à base de texte (*.srt);;WAVE - Audio PCM non compressé (*.wav *.w64);;Flux LPCM RAW (*.pcm);;Tous les fichiers (*.*)</translation>
+        <translation type="vanished">Tous les fichiers média pris en charge (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 flux élémentaire (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Flux vidéo élémentaire Mpeg (*.mpv *.m1v *.m2v);;Flux audio élémentaire Mpeg (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Fichiers audio/vidéo Matroska (*.mkv *.mka *.mks);;Fichiers audio/vidéo MP4 (*.mp4 *.m4a *.m4v);;Fichiers audio/vidéo QuickTime (*.mov);;Liste de lecture Blu-Ray (*.mpls *.mpl);;Sous-titres PGS de Blu-ray (*.sup);;Sous-titres à base de texte (*.srt);;WAVE - Audio PCM non compressé (*.wav *.w64);;Flux LPCM RAW (*.pcm);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation>Transport stream (*.ts);;Tous les fichiers (*.*)</translation>
+        <translation type="vanished">Transport stream (*.ts);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation>BDAV Transport Stream (*.m2ts);;Tous les fichiers (*.*)</translation>
+        <translation type="vanished">BDAV Transport Stream (*.m2ts);;Tous les fichiers (*.*)</translation>
+    </message>
+    <message>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="vanished">Image disque (*.iso);; Tous les fichiers (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <source>All files</source>
+        <translation>Tous les fichiers</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <source>AC3/E-AC3</source>
+        <translation>AC3/E-AC3</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="61"/>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation>Image disque (*.iso);; Tous les fichiers (*.*)</translation>
+        <source>AAC (advanced audio coding)</source>
+        <translation>AAC (advanced audio coding)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="551"/>
+        <location filename="../tsmuxerwindow.cpp" line="62"/>
+        <source>AVC/MVC/H.264 elementary stream</source>
+        <translation>AVC/MVC/H.264 flux élémentaire</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="63"/>
+        <source>HEVC (High Efficiency Video Codec)</source>
+        <translation>HEVC (High Efficiency Video Codec)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="64"/>
+        <source>Digital Theater System</source>
+        <translation>Digital Theater System</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="65"/>
+        <source>DTS-HD Master Audio</source>
+        <translation>DTS-HD Master Audio</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="66"/>
+        <source>Mpeg video elementary stream</source>
+        <translation>Flux vidéo élémentaire Mpeg</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="67"/>
+        <source>Mpeg audio elementary stream</source>
+        <translation>Flux audio élémentaire Mpeg</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="68"/>
+        <location filename="../tsmuxerwindow.cpp" line="97"/>
+        <source>Transport Stream</source>
+        <translation>Transport Stream</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="69"/>
+        <location filename="../tsmuxerwindow.cpp" line="101"/>
+        <source>BDAV Transport Stream</source>
+        <translation>BDAV Transport Stream</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="70"/>
+        <source>Program Stream</source>
+        <translation>Program Stream</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="71"/>
+        <source>Matroska audio/video files</source>
+        <translation>Fichiers audio/vidéo Matroska</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="72"/>
+        <source>MP4 audio/video files</source>
+        <translation>Fichiers audio/vidéo MP4</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="73"/>
+        <source>Quick time audio/video files</source>
+        <translation>Fichiers audio/vidéo QuickTime</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="74"/>
+        <source>Blu-ray play list</source>
+        <translation>Liste de lecture Blu-Ray</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="75"/>
+        <source>Blu-ray PGS subtitles</source>
+        <translation>Sous-titres PGS de Blu-ray</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="76"/>
+        <source>Text subtitles</source>
+        <translation>Sous-titres à base de texte</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="77"/>
+        <source>WAVE - Uncompressed PCM audio</source>
+        <translation>WAVE - Audio PCM non compressé</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="78"/>
+        <source>RAW LPCM Stream</source>
+        <translation>Flux LPCM RAW</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="89"/>
+        <source>All supported media files</source>
+        <translation>Tous les fichiers média pris en charge</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="104"/>
+        <source>Disk image</source>
+        <translation>Image disque</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="596"/>
         <source>Not supported</source>
         <translation>Non pris en charge</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="662"/>
+        <location filename="../tsmuxerwindow.cpp" line="1180"/>
         <source>Unsupported format</source>
         <translation>Format non pris en charge</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="618"/>
+        <location filename="../tsmuxerwindow.cpp" line="663"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Impossible de déterminer le type de flux pour le fichier : &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="911"/>
+        <location filename="../tsmuxerwindow.cpp" line="956"/>
         <source>Add media files</source>
         <translation>Ajouter un fichiers médias</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="926"/>
+        <location filename="../tsmuxerwindow.cpp" line="971"/>
         <source>File already exists</source>
         <translation>Le fichier existe déjà</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="927"/>
+        <location filename="../tsmuxerwindow.cpp" line="972"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Le fichier &quot;%1&quot; existe déjà</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1049"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>Réduire le DTS-HD en DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1006"/>
+        <location filename="../tsmuxerwindow.cpp" line="1051"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>Réduire le TRUE-HD en AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1008"/>
+        <location filename="../tsmuxerwindow.cpp" line="1053"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>Réduire le E-AC3 en AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1141"/>
+        <location filename="../tsmuxerwindow.cpp" line="1186"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Format non pris en charge ou aucune piste n&apos;a été reconnue pour le fichier &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1151"/>
+        <location filename="../tsmuxerwindow.cpp" line="1196"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>La piste %1 n&apos;a pas été reconnue et a été ignorée pour le fichier &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Mux</source>
         <translation>Muxer</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1412"/>
+        <location filename="../tsmuxerwindow.cpp" line="1459"/>
         <source>tsMuxeR error</source>
         <translation>Erreur de tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1416"/>
+        <location filename="../tsmuxerwindow.cpp" line="1463"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxer introuvable !</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1434"/>
+        <location filename="../tsmuxerwindow.cpp" line="1481"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Impossible d&apos;exécuter tsMuxer !</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2142"/>
-        <location filename="../tsmuxerwindow.cpp" line="2143"/>
+        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2188"/>
         <source>No track selected</source>
         <translation>Aucune piste sélectionnée</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2149"/>
+        <location filename="../tsmuxerwindow.cpp" line="2194"/>
         <source>Append media files</source>
         <translation>Concaténer un fichiers médias</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2165"/>
+        <location filename="../tsmuxerwindow.cpp" line="2210"/>
         <source>Invalid file extension</source>
         <translation>Extension de fichier non valide</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2166"/>
+        <location filename="../tsmuxerwindow.cpp" line="2211"/>
         <source>Appended file must have same file extension.</source>
         <translation>Le fichier concaténé doit avoir la même extension de fichier.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2264"/>
+        <location filename="../tsmuxerwindow.cpp" line="2309"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Déma&amp;rrer le démuxage</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2278"/>
+        <location filename="../tsmuxerwindow.cpp" line="2323"/>
         <source>Folder</source>
         <translation>Dossier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.cpp" line="2409"/>
         <source>Select file for muxing</source>
         <translation>Sélectionner un fichier pour le muxage</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2386"/>
-        <location filename="../tsmuxerwindow.cpp" line="2402"/>
+        <location filename="../tsmuxerwindow.cpp" line="2431"/>
+        <location filename="../tsmuxerwindow.cpp" line="2447"/>
         <source>Invalid file name</source>
         <translation>Nom de fichier non valide</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2387"/>
+        <location filename="../tsmuxerwindow.cpp" line="2432"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Le fichier de sortie &quot;%1&quot;&apos; n&apos;a pas une extension valide. Veuillez changer l&apos;extension du fichier en &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2403"/>
+        <location filename="../tsmuxerwindow.cpp" line="2448"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Le fichier de sortie &quot;%1&quot;&apos; n&apos;a pas une extension valide. Veuillez changer l&apos;extension du fichier en &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation>fichier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>directory</source>
         <translation>dossier</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2419"/>
+        <location filename="../tsmuxerwindow.cpp" line="2464"/>
         <source>Overwrite existing %1?</source>
         <translation>Écraser %1 qui existe déjà ?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>La sortie %1 &quot;%2&quot; existe déjà. Souhaitez-vous l&apos;écraser ?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Muxing in progress</source>
         <translation>Muxage en cours</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Demuxing in progress</source>
         <translation>Démuxage en cours</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2451"/>
+        <location filename="../tsmuxerwindow.cpp" line="2496"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>Fichier de projet tsMuxeR (*.meta);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2466"/>
+        <location filename="../tsmuxerwindow.cpp" line="2511"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Impossible de créer le fichier Meta temporaire</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2467"/>
+        <location filename="../tsmuxerwindow.cpp" line="2512"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Impossible de créer le fichier Meta temporaire &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_fr.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_fr.ts
@@ -771,22 +771,6 @@
         <translation>Sauvegarder le fichier Meta</translation>
     </message>
     <message>
-        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation type="vanished">Tous les fichiers média pris en charge (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 flux élémentaire (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Flux vidéo élémentaire Mpeg (*.mpv *.m1v *.m2v);;Flux audio élémentaire Mpeg (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Fichiers audio/vidéo Matroska (*.mkv *.mka *.mks);;Fichiers audio/vidéo MP4 (*.mp4 *.m4a *.m4v);;Fichiers audio/vidéo QuickTime (*.mov);;Liste de lecture Blu-Ray (*.mpls *.mpl);;Sous-titres PGS de Blu-ray (*.sup);;Sous-titres à base de texte (*.srt);;WAVE - Audio PCM non compressé (*.wav *.w64);;Flux LPCM RAW (*.pcm);;Tous les fichiers (*.*)</translation>
-    </message>
-    <message>
-        <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation type="vanished">Transport stream (*.ts);;Tous les fichiers (*.*)</translation>
-    </message>
-    <message>
-        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation type="vanished">BDAV Transport Stream (*.m2ts);;Tous les fichiers (*.*)</translation>
-    </message>
-    <message>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation type="vanished">Image disque (*.iso);; Tous les fichiers (*.*)</translation>
-    </message>
-    <message>
         <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -844,8 +844,8 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="73"/>
-        <source>Quick time audio/video files</source>
-        <translation>Аудио/видео файлы Quick time</translation>
+        <source>QuickTime audio/video files</source>
+        <translation>Аудио/видео файлы QuickTime</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="74"/>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -771,22 +771,6 @@
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation type="vanished">Все поддерживаемые медиафайлы (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;Элементарный поток AVC/MVC/H.264 (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Элеменарный поток MPEG видео (*.mpv *.m1v *.m2v);;Элеменарный поток MPEG аудио (*.mpa);;Транспортный поток (*.ts);;Транспортный поток BDAV (*.m2ts *.mts *.ssif);;Программный поток (*.mpg *.mpeg *.vob *.evo);;Аудио/видео файлы матрёшки (*.mkv *.mka *.mks);;Аудио/видео файлы MP4 (*.mp4 *.m4a *.m4v);;Аудио/видео файлы Quick time (*.mov);;Плейлист блюрея (*.mpls *.mpl);;PGS субтитры блюрея (*.sup);;Текстовые субтитры (*.srt);;WAVE - Несжатый звук PCM (*.wav *.w64);;RAW LPCM поток (*.pcm);;Все файлы (*.*)</translation>
-    </message>
-    <message>
-        <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation type="vanished">Транспортный поток (*.ts);;все файлы (*.*)</translation>
-    </message>
-    <message>
-        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation type="vanished">Транспортный поток BDAV (*.m2ts);;все файлы (*.*)</translation>
-    </message>
-    <message>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation type="vanished">Образ диска (*.iso);;все файлы (*.*)</translation>
-    </message>
-    <message>
         <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>All files</source>
         <translation>Все файлы</translation>

--- a/tsMuxerGUI/translations/tsmuxergui_ru.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_ru.ts
@@ -4,22 +4,22 @@
 <context>
     <name>FontSettingsTableModel</name>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <location filename="../fontsettingstablemodel.cpp" line="135"/>
         <source>Options:</source>
         <translation>Параметры:</translation>
     </message>
@@ -129,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <location filename="../tsmuxerwindow.cpp" line="93"/>
         <source>General track options</source>
         <translation>Общие параметры дорожки</translation>
     </message>
@@ -195,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1010"/>
+        <location filename="../tsmuxerwindow.cpp" line="1055"/>
         <source>Downconvert HD audio</source>
         <translation>Упростить HD звук</translation>
     </message>
@@ -221,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="55"/>
+        <location filename="../tsmuxerwindow.cpp" line="95"/>
         <source>Demux options</source>
         <translation>Параметры записи дорожек</translation>
     </message>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2628"/>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Demux</source>
         <translation>Демукс</translation>
     </message>
@@ -745,7 +745,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2662"/>
-        <location filename="../tsmuxerwindow.cpp" line="2282"/>
+        <location filename="../tsmuxerwindow.cpp" line="2327"/>
         <source>File name</source>
         <translation>Имя Файла</translation>
     </message>
@@ -761,7 +761,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2781"/>
-        <location filename="../tsmuxerwindow.cpp" line="2266"/>
+        <location filename="../tsmuxerwindow.cpp" line="2311"/>
         <source>Sta&amp;rt muxing</source>
         <translation>Ста&amp;рт муксинга</translation>
     </message>
@@ -771,197 +771,305 @@
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation>Все поддерживаемые медиафайлы (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;Элементарный поток AVC/MVC/H.264 (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Элеменарный поток MPEG видео (*.mpv *.m1v *.m2v);;Элеменарный поток MPEG аудио (*.mpa);;Транспортный поток (*.ts);;Транспортный поток BDAV (*.m2ts *.mts *.ssif);;Программный поток (*.mpg *.mpeg *.vob *.evo);;Аудио/видео файлы матрёшки (*.mkv *.mka *.mks);;Аудио/видео файлы MP4 (*.mp4 *.m4a *.m4v);;Аудио/видео файлы Quick time (*.mov);;Плейлист блюрея (*.mpls *.mpl);;PGS субтитры блюрея (*.sup);;Текстовые субтитры (*.srt);;WAVE - Несжатый звук PCM (*.wav *.w64);;RAW LPCM поток (*.pcm);;Все файлы (*.*)</translation>
+        <translation type="vanished">Все поддерживаемые медиафайлы (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;Элементарный поток AVC/MVC/H.264 (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Элеменарный поток MPEG видео (*.mpv *.m1v *.m2v);;Элеменарный поток MPEG аудио (*.mpa);;Транспортный поток (*.ts);;Транспортный поток BDAV (*.m2ts *.mts *.ssif);;Программный поток (*.mpg *.mpeg *.vob *.evo);;Аудио/видео файлы матрёшки (*.mkv *.mka *.mks);;Аудио/видео файлы MP4 (*.mp4 *.m4a *.m4v);;Аудио/видео файлы Quick time (*.mov);;Плейлист блюрея (*.mpls *.mpl);;PGS субтитры блюрея (*.sup);;Текстовые субтитры (*.srt);;WAVE - Несжатый звук PCM (*.wav *.w64);;RAW LPCM поток (*.pcm);;Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation>Транспортный поток (*.ts);;все файлы (*.*)</translation>
+        <translation type="vanished">Транспортный поток (*.ts);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation>Транспортный поток BDAV (*.m2ts);;все файлы (*.*)</translation>
+        <translation type="vanished">Транспортный поток BDAV (*.m2ts);;все файлы (*.*)</translation>
+    </message>
+    <message>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="vanished">Образ диска (*.iso);;все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <source>All files</source>
+        <translation>Все файлы</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <source>AC3/E-AC3</source>
+        <translation>AC3/E-AC3</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="61"/>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation>Образ диска (*.iso);;все файлы (*.*)</translation>
+        <source>AAC (advanced audio coding)</source>
+        <translation>AAC (advanced audio coding)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="551"/>
+        <location filename="../tsmuxerwindow.cpp" line="62"/>
+        <source>AVC/MVC/H.264 elementary stream</source>
+        <translation>Элементарный поток AVC/MVC/H.264</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="63"/>
+        <source>HEVC (High Efficiency Video Codec)</source>
+        <translation>HEVC (High Efficiency Video Codec)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="64"/>
+        <source>Digital Theater System</source>
+        <translation>Digital Theater System</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="65"/>
+        <source>DTS-HD Master Audio</source>
+        <translation>DTS-HD Master Audio</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="66"/>
+        <source>Mpeg video elementary stream</source>
+        <translation>Элеменарный поток MPEG видео</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="67"/>
+        <source>Mpeg audio elementary stream</source>
+        <translation>Элеменарный поток MPEG аудио</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="68"/>
+        <location filename="../tsmuxerwindow.cpp" line="97"/>
+        <source>Transport Stream</source>
+        <translation>Транспортный поток</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="69"/>
+        <location filename="../tsmuxerwindow.cpp" line="101"/>
+        <source>BDAV Transport Stream</source>
+        <translation>Транспортный поток BDAV</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="70"/>
+        <source>Program Stream</source>
+        <translation>Программный поток</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="71"/>
+        <source>Matroska audio/video files</source>
+        <translation>Аудио/видео файлы матрёшки</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="72"/>
+        <source>MP4 audio/video files</source>
+        <translation>Аудио/видео файлы MP4</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="73"/>
+        <source>Quick time audio/video files</source>
+        <translation>Аудио/видео файлы Quick time</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="74"/>
+        <source>Blu-ray play list</source>
+        <translation>Плейлист блюрея</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="75"/>
+        <source>Blu-ray PGS subtitles</source>
+        <translation>PGS субтитры блюрея</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="76"/>
+        <source>Text subtitles</source>
+        <translation>Текстовые субтитры</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="77"/>
+        <source>WAVE - Uncompressed PCM audio</source>
+        <translation>WAVE - Несжатый звук PCM</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="78"/>
+        <source>RAW LPCM Stream</source>
+        <translation>RAW LPCM поток</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="89"/>
+        <source>All supported media files</source>
+        <translation>Все поддерживаемые медиафайлы</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="104"/>
+        <source>Disk image</source>
+        <translation>Образ диска</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="596"/>
         <source>Not supported</source>
         <translation>Не поддерживается</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="662"/>
+        <location filename="../tsmuxerwindow.cpp" line="1180"/>
         <source>Unsupported format</source>
         <translation>Неподдерживаемый формат</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="618"/>
+        <location filename="../tsmuxerwindow.cpp" line="663"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>Не определён тип потока. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="911"/>
+        <location filename="../tsmuxerwindow.cpp" line="956"/>
         <source>Add media files</source>
         <translation>Добавить медиафайлы</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="926"/>
+        <location filename="../tsmuxerwindow.cpp" line="971"/>
         <source>File already exists</source>
         <translation>Файл уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="927"/>
+        <location filename="../tsmuxerwindow.cpp" line="972"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>Файл &quot;%1&quot; уже есть</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1049"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>Преобразовать из DTS-HD в DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1006"/>
+        <location filename="../tsmuxerwindow.cpp" line="1051"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>Преобразовать из TRUE-HD в AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1008"/>
+        <location filename="../tsmuxerwindow.cpp" line="1053"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>Преобразовать из E-AC3 в AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1141"/>
+        <location filename="../tsmuxerwindow.cpp" line="1186"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>Неподдерживаемый формат или все дорожки не распознаны. Имя файла: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1151"/>
+        <location filename="../tsmuxerwindow.cpp" line="1196"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>Дорожка %1 не распознана и проигнорирована. Имя файла: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Mux</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1412"/>
+        <location filename="../tsmuxerwindow.cpp" line="1459"/>
         <source>tsMuxeR error</source>
         <translation>Ошибка tsMuxeR</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1416"/>
+        <location filename="../tsmuxerwindow.cpp" line="1463"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR не найден!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1434"/>
+        <location filename="../tsmuxerwindow.cpp" line="1481"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>Не возможно запустить tsMuxeR!</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2142"/>
-        <location filename="../tsmuxerwindow.cpp" line="2143"/>
+        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2188"/>
         <source>No track selected</source>
         <translation>Не выбрана дорожка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2149"/>
+        <location filename="../tsmuxerwindow.cpp" line="2194"/>
         <source>Append media files</source>
         <translation>Присоединить медиафайлы</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2165"/>
+        <location filename="../tsmuxerwindow.cpp" line="2210"/>
         <source>Invalid file extension</source>
         <translation>Неверное расширение файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2166"/>
+        <location filename="../tsmuxerwindow.cpp" line="2211"/>
         <source>Appended file must have same file extension.</source>
         <translation>Присоединяемый файл должен иметь тоже самое расширение файла.</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2264"/>
+        <location filename="../tsmuxerwindow.cpp" line="2309"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>Ста&amp;rт демуксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2278"/>
+        <location filename="../tsmuxerwindow.cpp" line="2323"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.cpp" line="2409"/>
         <source>Select file for muxing</source>
         <translation>Выберите файл для муксинга</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2386"/>
-        <location filename="../tsmuxerwindow.cpp" line="2402"/>
+        <location filename="../tsmuxerwindow.cpp" line="2431"/>
+        <location filename="../tsmuxerwindow.cpp" line="2447"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2387"/>
+        <location filename="../tsmuxerwindow.cpp" line="2432"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2403"/>
+        <location filename="../tsmuxerwindow.cpp" line="2448"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>Выходной файл &quot;%1&quot; имеет недопустимое расширение. Пожалуйста, измените расширение файла на &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translatorcomment>Используется в фразах &quot;Переписать существующий %1&quot; и &quot;Файл %1 уже существует&quot;.</translatorcomment>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>directory</source>
         <translation>каталог</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2419"/>
+        <location filename="../tsmuxerwindow.cpp" line="2464"/>
         <source>Overwrite existing %1?</source>
         <translation>Переписать существующий %1?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>Результат %1 &quot;%2&quot; уже есть. Хотите его перезаписать?</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Muxing in progress</source>
         <translation>Выполняется муксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Demuxing in progress</source>
         <translation>Выполняется демуксинг</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2451"/>
+        <location filename="../tsmuxerwindow.cpp" line="2496"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>Файл проекта tsMuxeR (*.meta);;все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2466"/>
+        <location filename="../tsmuxerwindow.cpp" line="2511"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>Не возможно создать временный файл проекта</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2467"/>
+        <location filename="../tsmuxerwindow.cpp" line="2512"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>Не возможно создать временный файл проекта &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_zh.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_zh.ts
@@ -771,22 +771,6 @@
         <translation>保存项目文件</translation>
     </message>
     <message>
-        <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation type="vanished">所有支持的媒体文件 (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (高级音频编码)) (*.aac);;AVC/MVC/H.264 基本流 (*.avc *.mvc *.264 *.h264);;HEVC (高效视频编解码器) (*.hevc *.hvc *.265 *.h265);;数字影院系统 (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg视频基本流 (*.mpv *.m1v *.m2v);;MPEG 音频基本流 (*.mpa);;传输流 (*.ts);;BDAV 传输流 (*.m2ts *.mts *.ssif);;节目流 (*.mpg *.mpeg *.vob *.evo);;Matroska 音频/视频 文件 (*.mkv *.mka *.mks);;MP4 音频/视频 文件 (*.mp4 *.m4a *.m4v);;Quick 音频/视频 文件 (*.mov);;蓝光播放列表 (*.mpls *.mpl);;蓝光PGS字幕 (*.sup);;文本字幕 (*.srt);;WAVE-未压缩的PCM音频 (*.wav *.w64);;RAW LPCM流 (*.pcm);;所有文件 (*.*)</translation>
-    </message>
-    <message>
-        <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation type="vanished">传输流 (*.ts);;所有文件 (*.*)</translation>
-    </message>
-    <message>
-        <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation type="vanished">BDAV 传输流 (*.m2ts);;所有文件 (*.*)</translation>
-    </message>
-    <message>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation type="vanished">磁盘镜像 (*.iso);;所有文件 (*.*)</translation>
-    </message>
-    <message>
         <location filename="../tsmuxerwindow.cpp" line="53"/>
         <source>All files</source>
         <translation>所有文件</translation>

--- a/tsMuxerGUI/translations/tsmuxergui_zh.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_zh.ts
@@ -4,22 +4,22 @@
 <context>
     <name>FontSettingsTableModel</name>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Name:</source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Size:</source>
         <translation>尺寸：</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="132"/>
+        <location filename="../fontsettingstablemodel.cpp" line="134"/>
         <source>Color:</source>
         <translation>颜色：</translation>
     </message>
     <message>
-        <location filename="../fontsettingstablemodel.cpp" line="133"/>
+        <location filename="../fontsettingstablemodel.cpp" line="135"/>
         <source>Options:</source>
         <translation>选项：</translation>
     </message>
@@ -129,7 +129,7 @@
         <location filename="../tsmuxerwindow.ui" line="325"/>
         <location filename="../tsmuxerwindow.ui" line="629"/>
         <location filename="../tsmuxerwindow.ui" line="810"/>
-        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <location filename="../tsmuxerwindow.cpp" line="93"/>
         <source>General track options</source>
         <translation>常规轨道选项</translation>
     </message>
@@ -195,7 +195,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="693"/>
-        <location filename="../tsmuxerwindow.cpp" line="1010"/>
+        <location filename="../tsmuxerwindow.cpp" line="1055"/>
         <source>Downconvert HD audio</source>
         <translation>降频高清音频</translation>
     </message>
@@ -221,7 +221,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="767"/>
-        <location filename="../tsmuxerwindow.cpp" line="55"/>
+        <location filename="../tsmuxerwindow.cpp" line="95"/>
         <source>Demux options</source>
         <translation>Demux选项</translation>
     </message>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2628"/>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Demux</source>
         <translation></translation>
     </message>
@@ -745,7 +745,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2662"/>
-        <location filename="../tsmuxerwindow.cpp" line="2282"/>
+        <location filename="../tsmuxerwindow.cpp" line="2327"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
@@ -761,7 +761,7 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.ui" line="2781"/>
-        <location filename="../tsmuxerwindow.cpp" line="2266"/>
+        <location filename="../tsmuxerwindow.cpp" line="2311"/>
         <source>Sta&amp;rt muxing</source>
         <translation>开始muxing</translation>
     </message>
@@ -771,196 +771,304 @@
         <translation>保存项目文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="29"/>
         <source>All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (advanced audio coding) (*.aac);;AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;Digital Theater System (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg video elementary stream (*.mpv *.m1v *.m2v);;Mpeg audio elementary stream (*.mpa);;Transport Stream (*.ts);;BDAV Transport Stream (*.m2ts *.mts *.ssif);;Program Stream (*.mpg *.mpeg *.vob *.evo);;Matroska audio/video files (*.mkv *.mka *.mks);;MP4 audio/video files (*.mp4 *.m4a *.m4v);;Quick time audio/video files (*.mov);;Blu-ray play list (*.mpls *.mpl);;Blu-ray PGS subtitles (*.sup);;Text subtitles (*.srt);;WAVE - Uncompressed PCM audio (*.wav *.w64);;RAW LPCM Stream (*.pcm);;All files (*.*)</source>
-        <translation>所有支持的媒体文件 (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (高级音频编码)) (*.aac);;AVC/MVC/H.264 基本流 (*.avc *.mvc *.264 *.h264);;HEVC (高效视频编解码器) (*.hevc *.hvc *.265 *.h265);;数字影院系统 (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg视频基本流 (*.mpv *.m1v *.m2v);;MPEG 音频基本流 (*.mpa);;传输流 (*.ts);;BDAV 传输流 (*.m2ts *.mts *.ssif);;节目流 (*.mpg *.mpeg *.vob *.evo);;Matroska 音频/视频 文件 (*.mkv *.mka *.mks);;MP4 音频/视频 文件 (*.mp4 *.m4a *.m4v);;Quick 音频/视频 文件 (*.mov);;蓝光播放列表 (*.mpls *.mpl);;蓝光PGS字幕 (*.sup);;文本字幕 (*.srt);;WAVE-未压缩的PCM音频 (*.wav *.w64);;RAW LPCM流 (*.pcm);;所有文件 (*.*)</translation>
+        <translation type="vanished">所有支持的媒体文件 (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;AC3/E-AC3 (*.ac3 *.ddp);;AAC (高级音频编码)) (*.aac);;AVC/MVC/H.264 基本流 (*.avc *.mvc *.264 *.h264);;HEVC (高效视频编解码器) (*.hevc *.hvc *.265 *.h265);;数字影院系统 (*.dts);;DTS-HD Master Audio (*.dtshd);;Mpeg视频基本流 (*.mpv *.m1v *.m2v);;MPEG 音频基本流 (*.mpa);;传输流 (*.ts);;BDAV 传输流 (*.m2ts *.mts *.ssif);;节目流 (*.mpg *.mpeg *.vob *.evo);;Matroska 音频/视频 文件 (*.mkv *.mka *.mks);;MP4 音频/视频 文件 (*.mp4 *.m4a *.m4v);;Quick 音频/视频 文件 (*.mov);;蓝光播放列表 (*.mpls *.mpl);;蓝光PGS字幕 (*.sup);;文本字幕 (*.srt);;WAVE-未压缩的PCM音频 (*.wav *.w64);;RAW LPCM流 (*.pcm);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="57"/>
         <source>Transport stream (*.ts);;all files (*.*)</source>
-        <translation>传输流 (*.ts);;所有文件 (*.*)</translation>
+        <translation type="vanished">传输流 (*.ts);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="59"/>
         <source>BDAV Transport Stream (*.m2ts);;all files (*.*)</source>
-        <translation>BDAV 传输流 (*.m2ts);;所有文件 (*.*)</translation>
+        <translation type="vanished">BDAV 传输流 (*.m2ts);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <source>Disk image (*.iso);;all files (*.*)</source>
+        <translation type="vanished">磁盘镜像 (*.iso);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="53"/>
+        <source>All files</source>
+        <translation>所有文件</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="60"/>
+        <source>AC3/E-AC3</source>
+        <translation>AC3/E-AC3</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="61"/>
-        <source>Disk image (*.iso);;all files (*.*)</source>
-        <translation>磁盘镜像 (*.iso);;所有文件 (*.*)</translation>
+        <source>AAC (advanced audio coding)</source>
+        <translation>AAC (高级音频编码)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="551"/>
+        <location filename="../tsmuxerwindow.cpp" line="62"/>
+        <source>AVC/MVC/H.264 elementary stream</source>
+        <translation>AVC/MVC/H.264 基本流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="63"/>
+        <source>HEVC (High Efficiency Video Codec)</source>
+        <translation>HEVC (高效视频编解码器)</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="64"/>
+        <source>Digital Theater System</source>
+        <translation>数字影院系统</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="65"/>
+        <source>DTS-HD Master Audio</source>
+        <translation>DTS-HD Master Audio</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="66"/>
+        <source>Mpeg video elementary stream</source>
+        <translation>Mpeg视频基本流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="67"/>
+        <source>Mpeg audio elementary stream</source>
+        <translation>MPEG 音频基本流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="68"/>
+        <location filename="../tsmuxerwindow.cpp" line="97"/>
+        <source>Transport Stream</source>
+        <translation>传输流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="69"/>
+        <location filename="../tsmuxerwindow.cpp" line="101"/>
+        <source>BDAV Transport Stream</source>
+        <translation>BDAV 传输流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="70"/>
+        <source>Program Stream</source>
+        <translation>节目流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="71"/>
+        <source>Matroska audio/video files</source>
+        <translation>Matroska 音频/视频 文件</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="72"/>
+        <source>MP4 audio/video files</source>
+        <translation>MP4 音频/视频 文件</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="73"/>
+        <source>Quick time audio/video files</source>
+        <translation>Quick 音频/视频 文件</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="74"/>
+        <source>Blu-ray play list</source>
+        <translation>蓝光播放列表</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="75"/>
+        <source>Blu-ray PGS subtitles</source>
+        <translation>蓝光PGS字幕</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="76"/>
+        <source>Text subtitles</source>
+        <translation>文本字幕</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="77"/>
+        <source>WAVE - Uncompressed PCM audio</source>
+        <translation>WAVE-未压缩的PCM音频</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="78"/>
+        <source>RAW LPCM Stream</source>
+        <translation>RAW LPCM流</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="89"/>
+        <source>All supported media files</source>
+        <translation>所有支持的媒体文件</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="104"/>
+        <source>Disk image</source>
+        <translation>磁盘镜像</translation>
+    </message>
+    <message>
+        <location filename="../tsmuxerwindow.cpp" line="596"/>
         <source>Not supported</source>
         <translation>不支持</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="617"/>
-        <location filename="../tsmuxerwindow.cpp" line="1135"/>
+        <location filename="../tsmuxerwindow.cpp" line="662"/>
+        <location filename="../tsmuxerwindow.cpp" line="1180"/>
         <source>Unsupported format</source>
         <translation>不支持的格式</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="618"/>
+        <location filename="../tsmuxerwindow.cpp" line="663"/>
         <source>Can&apos;t detect stream type. File name: &quot;%1&quot;</source>
         <translation>无法检测流类型。 文件名： &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="911"/>
+        <location filename="../tsmuxerwindow.cpp" line="956"/>
         <source>Add media files</source>
         <translation>添加媒体文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="926"/>
+        <location filename="../tsmuxerwindow.cpp" line="971"/>
         <source>File already exists</source>
         <translation>文件已存在</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="927"/>
+        <location filename="../tsmuxerwindow.cpp" line="972"/>
         <source>File &quot;%1&quot; already exists</source>
         <translation>文件 &quot;%1&quot; 已存在</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1004"/>
+        <location filename="../tsmuxerwindow.cpp" line="1049"/>
         <source>Downconvert DTS-HD to DTS</source>
         <translation>降频转换DTS-HD为DTS</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1006"/>
+        <location filename="../tsmuxerwindow.cpp" line="1051"/>
         <source>Downconvert TRUE-HD to AC3</source>
         <translation>降频转换TRUE-HD为AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1008"/>
+        <location filename="../tsmuxerwindow.cpp" line="1053"/>
         <source>Downconvert E-AC3 to AC3</source>
         <translation>降频转换E-AC3为AC3</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1141"/>
+        <location filename="../tsmuxerwindow.cpp" line="1186"/>
         <source>Unsupported format or all tracks are not recognized. File name: &quot;%1&quot;</source>
         <translation>不支持的格式或无法识别所有轨道。文件名： &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1151"/>
+        <location filename="../tsmuxerwindow.cpp" line="1196"/>
         <source>Track %1 was not recognized and ignored. File name: &quot;%2&quot;</source>
         <translation>轨道 %1 无法识别和忽略。文件名： &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1393"/>
+        <location filename="../tsmuxerwindow.cpp" line="1440"/>
         <source>Mux</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1412"/>
+        <location filename="../tsmuxerwindow.cpp" line="1459"/>
         <source>tsMuxeR error</source>
         <translation>tsMuxeR 错误</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1416"/>
+        <location filename="../tsmuxerwindow.cpp" line="1463"/>
         <source>tsMuxeR not found!</source>
         <translation>tsMuxeR 未找到！</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="1434"/>
+        <location filename="../tsmuxerwindow.cpp" line="1481"/>
         <source>Can&apos;t execute tsMuxeR!</source>
         <translation>无法执行tsMuxeR！</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2142"/>
-        <location filename="../tsmuxerwindow.cpp" line="2143"/>
+        <location filename="../tsmuxerwindow.cpp" line="2187"/>
+        <location filename="../tsmuxerwindow.cpp" line="2188"/>
         <source>No track selected</source>
         <translation>未选定轨道</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2149"/>
+        <location filename="../tsmuxerwindow.cpp" line="2194"/>
         <source>Append media files</source>
         <translation>附加媒体文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2165"/>
+        <location filename="../tsmuxerwindow.cpp" line="2210"/>
         <source>Invalid file extension</source>
         <translation>无效的文件扩展名</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2166"/>
+        <location filename="../tsmuxerwindow.cpp" line="2211"/>
         <source>Appended file must have same file extension.</source>
         <translation>附加文件必须具有相同的文件扩展名。</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2264"/>
+        <location filename="../tsmuxerwindow.cpp" line="2309"/>
         <source>Sta&amp;rt demuxing</source>
         <translation>开始demuxing</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2278"/>
+        <location filename="../tsmuxerwindow.cpp" line="2323"/>
         <source>Folder</source>
         <translation>文件夹</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2364"/>
+        <location filename="../tsmuxerwindow.cpp" line="2409"/>
         <source>Select file for muxing</source>
         <translation>选择要muxing的文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2386"/>
-        <location filename="../tsmuxerwindow.cpp" line="2402"/>
+        <location filename="../tsmuxerwindow.cpp" line="2431"/>
+        <location filename="../tsmuxerwindow.cpp" line="2447"/>
         <source>Invalid file name</source>
         <translation>无效的文件名</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2387"/>
+        <location filename="../tsmuxerwindow.cpp" line="2432"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.m2ts&quot;</source>
         <translation>输出文件 &quot;%1&quot; 具有无效的扩展名。 请将文件扩展名更改为 &quot;.m2ts&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2403"/>
+        <location filename="../tsmuxerwindow.cpp" line="2448"/>
         <source>The output file &quot;%1&quot; has invalid extension. Please, change file extension to &quot;.iso&quot;</source>
         <translation>输出文件 &quot;%1&quot; 具有无效的扩展名。 请将文件扩展名更改为 &quot;.iso&quot;</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>file</source>
         <extracomment>Used in expressions &quot;Overwrite existing %1&quot; and &quot;The output %1 already exists&quot;.</extracomment>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2417"/>
+        <location filename="../tsmuxerwindow.cpp" line="2462"/>
         <source>directory</source>
         <translation>目录</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2419"/>
+        <location filename="../tsmuxerwindow.cpp" line="2464"/>
         <source>Overwrite existing %1?</source>
         <translation>覆盖现有的 %1？</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2420"/>
+        <location filename="../tsmuxerwindow.cpp" line="2465"/>
         <source>The output %1 &quot;%2&quot; already exists. Do you want to overwrite it?</source>
         <translation>输出 %1 &quot;%2&quot; 已存在。要覆盖它吗？</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Muxing in progress</source>
         <translation>Muxing正在进行中</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2437"/>
+        <location filename="../tsmuxerwindow.cpp" line="2482"/>
         <source>Demuxing in progress</source>
         <translation>Demuxing正在进行中</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2451"/>
+        <location filename="../tsmuxerwindow.cpp" line="2496"/>
         <source>tsMuxeR project file (*.meta);;All files (*.*)</source>
         <translation>tsMuxeR 项目文件 (*.meta);;所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2466"/>
+        <location filename="../tsmuxerwindow.cpp" line="2511"/>
         <source>Can&apos;t create temporary meta file</source>
         <translation>无法创建临时项目文件</translation>
     </message>
     <message>
-        <location filename="../tsmuxerwindow.cpp" line="2467"/>
+        <location filename="../tsmuxerwindow.cpp" line="2512"/>
         <source>Can&apos;t create temporary meta file &quot;%1&quot;</source>
         <translation>无法创建临时项目文件 &quot;%1&quot;</translation>
     </message>

--- a/tsMuxerGUI/translations/tsmuxergui_zh.ts
+++ b/tsMuxerGUI/translations/tsmuxergui_zh.ts
@@ -844,8 +844,8 @@
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="73"/>
-        <source>Quick time audio/video files</source>
-        <translation>Quick 音频/视频 文件</translation>
+        <source>QuickTime audio/video files</source>
+        <translation>QuickTime 音频/视频 文件</translation>
     </message>
     <message>
         <location filename="../tsmuxerwindow.cpp" line="74"/>

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -70,7 +70,7 @@ QString fileDialogFilter()
                              {TsMuxerWindow::tr("Program Stream"), {"mpg", "mpeg", "vob", "evo"}},
                              {TsMuxerWindow::tr("Matroska audio/video files"), {"mkv", "mka", "mks"}},
                              {TsMuxerWindow::tr("MP4 audio/video files"), {"mp4", "m4a", "m4v"}},
-                             {TsMuxerWindow::tr("Quick time audio/video files"), {"mov"}},
+                             {TsMuxerWindow::tr("QuickTime audio/video files"), {"mov"}},
                              {TsMuxerWindow::tr("Blu-ray play list"), {"mpls", "mpl"}},
                              {TsMuxerWindow::tr("Blu-ray PGS subtitles"), {"sup"}},
                              {TsMuxerWindow::tr("Text subtitles"), {"srt"}},

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -32,8 +32,8 @@ namespace
 QString fileDialogFilter()
 {
     return TsMuxerWindow::tr(
-        "All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;\
-AC3/E-AC3 (*.ac3 *.ddp);;\
+        "All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.ddp *.ec3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;\
+AC3/E-AC3 (*.ac3 *.ddp *.ec3);;\
 AAC (advanced audio coding) (*.aac);;\
 AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;\
 HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;\

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -51,7 +51,6 @@ QString makeFileFilter(const FileFilterVec &filters)
         s << ");;";
     }
     rv.append(QString("%1 (*.*)").arg(TsMuxerWindow::tr("All files")));
-    qDebug() << rv;
     return rv;
 }
 

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -15,6 +15,8 @@
 #include <QTemporaryFile>
 #include <QTime>
 
+#include <unordered_set>
+
 #include "checkboxedheaderview.h"
 #include "codecinfo.h"
 #include "fontsettingstablemodel.h"
@@ -29,41 +31,77 @@
 
 namespace
 {
+using FileFilterVec = std::vector<std::pair<QString, std::vector<const char *>>>;
+
+QString makeFileFilter(const FileFilterVec &filters)
+{
+    QString rv;
+    QTextStream s(&rv);
+    for (auto &f : filters)
+    {
+        s << f.first << " (";
+        for (auto &e : f.second)
+        {
+            s << "*." << e;
+            if (&e != &f.second.back())
+            {
+                s << ' ';
+            }
+        }
+        s << ");;";
+    }
+    rv.append(QString("%1 (*.*)").arg(TsMuxerWindow::tr("All files")));
+    qDebug() << rv;
+    return rv;
+}
+
 QString fileDialogFilter()
 {
-    return TsMuxerWindow::tr(
-        "All supported media files (*.aac *.mpv *.mpa *.avc *.mvc *.264 *.h264 *.ac3 *.ddp *.ec3 *.dts *.dtshd *.ts *.m2ts *.mts *.ssif *.mpg *.mpeg *.vob *.evo *.mkv *.mka *.mks *.mp4 *.m4a *.m4v *.mov *.sup *.wav *.w64 *.pcm *.m1v *.m2v *.vc1 *.hevc *.hvc *.265 *.h265 *.mpls *.mpl *.srt);;\
-AC3/E-AC3 (*.ac3 *.ddp *.ec3);;\
-AAC (advanced audio coding) (*.aac);;\
-AVC/MVC/H.264 elementary stream (*.avc *.mvc *.264 *.h264);;\
-HEVC (High Efficiency Video Codec) (*.hevc *.hvc *.265 *.h265);;\
-Digital Theater System (*.dts);;\
-DTS-HD Master Audio (*.dtshd);;\
-Mpeg video elementary stream (*.mpv *.m1v *.m2v);;\
-Mpeg audio elementary stream (*.mpa);;\
-Transport Stream (*.ts);;\
-BDAV Transport Stream (*.m2ts *.mts *.ssif);;\
-Program Stream (*.mpg *.mpeg *.vob *.evo);;\
-Matroska audio/video files (*.mkv *.mka *.mks);;\
-MP4 audio/video files (*.mp4 *.m4a *.m4v);;\
-Quick time audio/video files (*.mov);;\
-Blu-ray play list (*.mpls *.mpl);;\
-Blu-ray PGS subtitles (*.sup);;\
-Text subtitles (*.srt);;\
-WAVE - Uncompressed PCM audio (*.wav *.w64);;\
-RAW LPCM Stream (*.pcm);;\
-All files (*.*)");
+    FileFilterVec filters = {{TsMuxerWindow::tr("AC3/E-AC3"), {"ac3", "ddp", "ec3"}},
+                             {TsMuxerWindow::tr("AAC (advanced audio coding)"), {"aac"}},
+                             {TsMuxerWindow::tr("AVC/MVC/H.264 elementary stream"), {"avc", "mvc", "264", "h264"}},
+                             {TsMuxerWindow::tr("HEVC (High Efficiency Video Codec)"), {"hevc", "hvc", "265", "h265"}},
+                             {TsMuxerWindow::tr("Digital Theater System"), {"dts"}},
+                             {TsMuxerWindow::tr("DTS-HD Master Audio"), {"dtshd"}},
+                             {TsMuxerWindow::tr("Mpeg video elementary stream"), {"mpv", "m1v", "m2v"}},
+                             {TsMuxerWindow::tr("Mpeg audio elementary stream"), {"mpa"}},
+                             {TsMuxerWindow::tr("Transport Stream"), {"ts"}},
+                             {TsMuxerWindow::tr("BDAV Transport Stream"), {"m2ts", "mts", "ssif"}},
+                             {TsMuxerWindow::tr("Program Stream"), {"mpg", "mpeg", "vob", "evo"}},
+                             {TsMuxerWindow::tr("Matroska audio/video files"), {"mkv", "mka", "mks"}},
+                             {TsMuxerWindow::tr("MP4 audio/video files"), {"mp4", "m4a", "m4v"}},
+                             {TsMuxerWindow::tr("Quick time audio/video files"), {"mov"}},
+                             {TsMuxerWindow::tr("Blu-ray play list"), {"mpls", "mpl"}},
+                             {TsMuxerWindow::tr("Blu-ray PGS subtitles"), {"sup"}},
+                             {TsMuxerWindow::tr("Text subtitles"), {"srt"}},
+                             {TsMuxerWindow::tr("WAVE - Uncompressed PCM audio"), {"wav", "w64"}},
+                             {TsMuxerWindow::tr("RAW LPCM Stream"), {"pcm"}}};
+    std::unordered_set<std::string> uniqueExts;
+    for (auto &f : filters)
+    {
+        uniqueExts.insert(std::begin(f.second), std::end(f.second));
+    }
+    std::vector<const char *> allSupportedExts;
+    for (auto &s : uniqueExts)
+    {
+        allSupportedExts.push_back(s.c_str());
+    }
+    filters.insert(std::begin(filters), {TsMuxerWindow::tr("All supported media files"), allSupportedExts});
+    return makeFileFilter(filters);
 }
 
 QString TI_DEFAULT_TAB_NAME() { return TsMuxerWindow::tr("General track options"); }
 
 QString TI_DEMUX_TAB_NAME() { return TsMuxerWindow::tr("Demux options"); }
 
-QString TS_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("Transport stream (*.ts);;all files (*.*)"); }
+QString TS_SAVE_DIALOG_FILTER() { return makeFileFilter({{TsMuxerWindow::tr("Transport Stream"), {"ts"}}}); }
 
-QString M2TS_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("BDAV Transport Stream (*.m2ts);;all files (*.*)"); }
+QString M2TS_SAVE_DIALOG_FILTER()
+{
+    return makeFileFilter({{TsMuxerWindow::tr("BDAV Transport Stream"), {"m2ts", "mts", "ssif"}}});
+}
 
-QString ISO_SAVE_DIALOG_FILTER() { return TsMuxerWindow::tr("Disk image (*.iso);;all files (*.*)"); }
+QString ISO_SAVE_DIALOG_FILTER() { return makeFileFilter({{TsMuxerWindow::tr("Disk image"), {"iso"}}}); }
 
 QSettings *settings = nullptr;
 


### PR DESCRIPTION
Used this chance to finally rework file dialog filter string creation : the names of the extension groups are now clearly split so they appear separate in translation files.

Also fixed a bug in demux code - the AC3 would have an `.ac3` extension regardless of the actual format due to the `if` for `A_AC3` occurring twice.

Fixes #533 .

