### PR TITLE
Check for std::filesystem and Correct Linker Flags

### DIFF
--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -141,6 +141,11 @@ string(CONFIGURE [[
   }
 ]] GHC_FS_CODE @ONLY)
 
+# required for MacOS, osxcross and LLVM Clang
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "-std=c++17")
+endif()
+
 # check that we have the standard filesystem installed
 check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NO_LIB_NEEDED)
 set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")

--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -116,6 +116,33 @@ if(TSMUXER_STATIC_BUILD)
   endif()
 endif()
 
+# we can try compiling this small C++ program to test std::filesystem is working
+string(CONFIGURE [[
+  #include <filesystem>
+  int main( int argc, char ** argv ) {
+    std::filesystem::path p( argv[ 0 ] );
+    return p.string().length();
+  }
+]] STD_FS_CODE @ONLY)
+
+# check that we have the standard filesystem installed
+check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NO_LIB_NEEDED)
+set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")
+check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NEEDS_STDCXXFS)
+set(CMAKE_REQUIRED_LIBRARIES "c++fs")
+check_cxx_source_compiles("${STD_FS_CODE}"  STD_FS_NEEDS_CXXFS)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+if( ${STD_FS_NO_LIB_NEEDED} )
+  set( FS_LIBRARIES "" )
+elseif( ${STD_FS_NEEDS_STDCXXFS} )
+  set( FS_LIBRARIES stdc++fs )
+elseif( ${STD_FS_NEEDS_CXXFS} )
+  set( FS_LIBRARIES c++fs )
+else()
+  message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
+endif()
+
 if (WIN32)
   target_sources(tsmuxer PRIVATE osdep/textSubtitlesRenderWin32.cpp)
   target_link_libraries(tsmuxer gdiplus)
@@ -125,7 +152,7 @@ else()
   if(DEFINED OSXCROSS_SDK)
     list(TRANSFORM FREETYPE_LDFLAGS REPLACE "(-lfreetype)" "-lfreetype-static")
   endif()
-  target_link_libraries(tsmuxer ${FREETYPE_LIBRARIES} ${FREETYPE_LDFLAGS})
+  target_link_libraries(tsmuxer ${FS_LIBRARIES} ${FREETYPE_LIBRARIES} ${FREETYPE_LDFLAGS})
   target_include_directories(tsmuxer PRIVATE ${FREETYPE_INCLUDE_DIRS})
 endif()
 

--- a/tsMuxer/CMakeLists.txt
+++ b/tsMuxer/CMakeLists.txt
@@ -125,20 +125,58 @@ string(CONFIGURE [[
   }
 ]] STD_FS_CODE @ONLY)
 
+string(CONFIGURE [[
+  #include <experimental/filesystem>
+  int main( int argc, char ** argv ) {
+    std::experimental::filesystem::path p( argv[ 0 ] );
+    return p.string().length();
+  }
+]] EXP_FS_CODE @ONLY)
+
+string(CONFIGURE [[
+  #include <ghc/filesystem.hpp>
+  int main( int argc, char ** argv ) {
+    ghc::filesystem::path p( argv[ 0 ] );
+    return p.string().length();
+  }
+]] GHC_FS_CODE @ONLY)
+
 # check that we have the standard filesystem installed
 check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NO_LIB_NEEDED)
 set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")
 check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NEEDS_STDCXXFS)
 set(CMAKE_REQUIRED_LIBRARIES "c++fs")
-check_cxx_source_compiles("${STD_FS_CODE}"  STD_FS_NEEDS_CXXFS)
+check_cxx_source_compiles("${STD_FS_CODE}" STD_FS_NEEDS_CXXFS)
 unset(CMAKE_REQUIRED_LIBRARIES)
+# check that we have the experimental filesystem installed
+check_cxx_source_compiles("${EXP_FS_CODE}" EXP_FS_NO_LIB_NEEDED)
+set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")
+check_cxx_source_compiles("${EXP_FS_CODE}" EXP_FS_NEEDS_STDCXXFS)
+set(CMAKE_REQUIRED_LIBRARIES "c++fs")
+check_cxx_source_compiles("${EXP_FS_CODE}" EXP_FS_NEEDS_CXXFS)
+# check that we have GHC filesystem installed
+unset(CMAKE_REQUIRED_LIBRARIES)
+check_cxx_source_compiles("${GHC_FS_CODE}" GHC_FS_NO_LIB_NEEDED)
 
+# make sure to use the correct link libraries and filesystem code
 if( ${STD_FS_NO_LIB_NEEDED} )
   set( FS_LIBRARIES "" )
 elseif( ${STD_FS_NEEDS_STDCXXFS} )
   set( FS_LIBRARIES stdc++fs )
 elseif( ${STD_FS_NEEDS_CXXFS} )
   set( FS_LIBRARIES c++fs )
+elseif( ${EXP_FS_NO_LIB_NEEDED} )
+  set( FS_LIBRARIES "" )
+  add_compile_definitions( FS_EXP )
+elseif( ${EXP_FS_NEEDS_STDCXXFS} )
+  set( FS_LIBRARIES stdc++fs )
+  add_compile_definitions( FS_EXP )
+elseif( ${EXP_FS_NEEDS_CXXFS} )
+  set( FS_LIBRARIES c++fs )
+  add_compile_definitions( FS_EXP )
+elseif( ${GHC_FS_NO_LIB_NEEDED} )
+  set( FS_LIBRARIES "" )
+  add_compile_definitions( FS_GHC )
 else()
   message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
 endif()

--- a/tsMuxer/osdep/textSubtitlesRenderFT.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderFT.cpp
@@ -27,7 +27,20 @@ const static char FONT_ROOT[] = "/System/Library/Fonts/";
 #include <freetype/ftstroke.h>
 #include <fs/systemlog.h>
 
+#if !defined(FS_EXP) && !defined(FS_GHC)
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+#ifdef FS_EXP
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#ifdef FS_GHC
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#endif
 
 using namespace std;
 
@@ -105,7 +118,7 @@ void TextSubtitlesRenderFT::loadFontMap()
 
             if (itr == m_fontNameToFile.end() || fontFile.length() < itr->second.length())
             {
-                m_fontNameToFile[fontFamily] = std::filesystem::canonical(fontFile).string();
+                m_fontNameToFile[fontFamily] = fs::canonical(fontFile).string();
             }
             FT_Done_Face(font);
         }


### PR DESCRIPTION
This is a first step to supporting std::filesystem, std::experimental::filesystem, ghc::filesystem and boost::filesystem. For now we just check that we can correctly use std::filesystem and we try to figure out the correct linker flags.