### PR TITLE
Fix off-by-one error in GraphicsPath::AddString() call

### DIFF
--- a/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
+++ b/tsMuxer/osdep/textSubtitlesRenderWin32.cpp
@@ -112,8 +112,8 @@ void TextSubtitlesRenderWin32::drawText(const std::string& text, RECT* rect)
     Gdiplus::GraphicsPath path;
 
     auto text_wide = toWide(text);
-    path.AddString(text_wide.data(), (int)text_wide.size(), &fontFamily, m_font.m_opts & 0xf, (float)m_font.m_size,
-                   Gdiplus::Point(rect->left, rect->top), &strformat);
+    path.AddString(text_wide.data(), static_cast<int>(text_wide.size()) - 1, &fontFamily, m_font.m_opts & 0xf,
+                   (float)m_font.m_size, Gdiplus::Point(rect->left, rect->top), &strformat);
 
     uint8_t alpha = m_font.m_color >> 24;
     uint8_t outColor = (alpha * 48 + 128) / 255;


### PR DESCRIPTION
AddString's documentation clearly says that its second parameter is supposed to
be the number of characters to display. Since the vector returned by toWide() is
always null-terminated and the termination character is included in its size(),
this resulted in AddString() treating the termination character as something it
is supposed to actually draw.

Perhaps some versions of AddString() explicitly stop at the termination
character and don't process any further characters : this is probably why this
issue has gone unnoticed for so long.

Fixes #598