### PR TITLE
Avoid shifting by 32 bits in BitStreamWriter

### DIFF
--- a/tsMuxer/bitStream.cpp
+++ b/tsMuxer/bitStream.cpp
@@ -2,9 +2,6 @@
 
 #include <cstdint>
 
-int BitStream::m_maskInitialized = 0;
-unsigned BitStream::m_masks[INT_BIT + 1];
-
 void updateBits(const BitStreamReader& bitReader, int bitOffset, int bitLen, int value)
 {
     updateBits(bitReader.getBuffer(), bitOffset, bitLen, value);

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -98,13 +98,13 @@ void writeTimestamp(uint8_t* buffer, time_t time)
     time_t gt = mktime(gmtime(&time));
     int16_t timeZone = -1;
 
-    buff16[0] = ((1 << 12) | (timeZone & 0x0fff));
-    buff16[1] = parts->tm_year + 1900;
-    buffer[4] = parts->tm_mon + 1;
-    buffer[5] = parts->tm_mday;
-    buffer[6] = parts->tm_hour;
-    buffer[7] = parts->tm_min;
-    buffer[8] = parts->tm_sec;
+    buff16[0] = 0;
+    buff16[1] = 0;
+    buffer[4] = 0;
+    buffer[5] = 0;
+    buffer[6] = 0;
+    buffer[7] = 0;
+    buffer[8] = 0;
     buffer[9] = 0;  // ms parts
     buffer[10] = 0;
     buffer[11] = 0;

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -96,15 +96,15 @@ void writeTimestamp(uint8_t* buffer, time_t time)
 
     time_t lt = mktime(localtime(&time));
     time_t gt = mktime(gmtime(&time));
-    int16_t timeZone = -1;
+    int16_t timeZone = (lt - gt) / 60;
 
-    buff16[0] = 0;
-    buff16[1] = 0;
-    buffer[4] = 0;
-    buffer[5] = 0;
-    buffer[6] = 0;
-    buffer[7] = 0;
-    buffer[8] = 0;
+    buff16[0] = (1 << 12) + (timeZone & 0x0fff);
+    buff16[1] = parts->tm_year + 1900;
+    buffer[4] = parts->tm_mon + 1;
+    buffer[5] = parts->tm_mday;
+    buffer[6] = parts->tm_hour;
+    buffer[7] = parts->tm_min;
+    buffer[8] = parts->tm_sec;
     buffer[9] = 0;  // ms parts
     buffer[10] = 0;
     buffer[11] = 0;

--- a/tsMuxer/iso_writer.cpp
+++ b/tsMuxer/iso_writer.cpp
@@ -96,9 +96,9 @@ void writeTimestamp(uint8_t* buffer, time_t time)
 
     time_t lt = mktime(localtime(&time));
     time_t gt = mktime(gmtime(&time));
-    int16_t timeZone = (lt - gt) / 60;
+    int16_t timeZone = -1;
 
-    buff16[0] = (1 << 12) + (timeZone & 0x0fff);
+    buff16[0] = ((1 << 12) | (timeZone & 0x0fff));
     buff16[1] = parts->tm_year + 1900;
     buffer[4] = parts->tm_mon + 1;
     buffer[5] = parts->tm_mday;


### PR DESCRIPTION
Left-shifting by an amount which is more or equal to the type's width is undefined in both C and C++. This could happen in BitStreamWriter when `m_bitWrited` was zero, and resulted in inconsistent results between Intel and ARM targets.

On Intel, the amount of bits to shift is explicitly masked to its lower 5 (for 32-bit values) or 6 (for 64-bit values) bits. This is documented in the instruction set reference. Effectively, the amount of bits to be shifted is the actual amount modulo 32 or 64. In this particular case, asking the CPU to shift by 32 bits left the value unchanged.

ARM does not place any requirements on the behaviour of the CPU when the amount to shift is larger than 32/64 - the instruction set reference just says that the register is supposed to be "holding a shift amount from 0 to 31 in its bottom 5 bits. ". However, [MSVC documentation](https://docs.microsoft.com/en-us/cpp/build/common-visual-cpp-arm-migration-issues?view=msvc-170#shift-operator---behavior) suggests that values in registers might appear to "wrap around" when shifting by more than 32 or 64 bits, which is indeed what was observed here.

The fix essentially amounts to emulating Intel behaviour (as it was the original development platform and presumably most assumptions were made with it in mind, even if unknowingly) by not touching the value if the amount of bits to shift is 32.