### PR TITLE
Take sub fps from video even when video is not selected

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1747,19 +1747,16 @@ QString TsMuxerWindow::getSrtParams()
 
     for (int i = 0; i < ui->trackLV->rowCount(); ++i)
     {
-        if (ui->trackLV->item(i, 0)->checkState() == Qt::Checked)
-        {
-            auto codecInfo = getCodecInfo(i);
-            if (!codecInfo)
-                continue;
+        auto codecInfo = getCodecInfo(i);
+        if (!codecInfo)
+            continue;
 
-            if (isVideoCodec(codecInfo->displayName))
-            {
-                rez += QString(",video-width=") + QString::number(codecInfo->width);
-                rez += QString(",video-height=") + QString::number(codecInfo->height);
-                rez += QString(",fps=") + fpsTextToFpsStr(codecInfo->fpsText);
-                return rez;
-            }
+        if (isVideoCodec(codecInfo->displayName))
+        {
+            rez += QString(",video-width=") + QString::number(std::min(codecInfo->width, 1920));
+            rez += QString(",video-height=") + QString::number(std::min(codecInfo->height, 1080));
+            rez += QString(",fps=") + fpsTextToFpsStr(codecInfo->fpsText);
+            return rez;
         }
     }
     rez += ",video-width=1920,video-height=1080,fps=23.976";


### PR DESCRIPTION
Subtitle fps should be taken from the video stream even if this video stream is not checked.
Also, SUP subtitle image should be limited to 1920x1080.