### PR TITLE
Typo in my Spanish translation

### DIFF
--- a/tsMuxerGUI/translations/about_es.html
+++ b/tsMuxerGUI/translations/about_es.html
@@ -55,7 +55,7 @@ p, li { white-space: pre-wrap; }
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para convertir flujos LPCM en WAVE y viceversa </li>
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para introducir información sobre el idioma de la pista en la estructura del Blu-ray y en la cabecera TS </li>
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para cortar archivos de origen </li>
-<li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para dividiar archivos de salida </li>
+<li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para dividir archivos de salida </li>
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para detectar retraso de audio en fuentes TS/M2TS/MPG/VOB/EVO </li>
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para eliminar información de 'pulldown' del flujo de datos </li>
 <li style=" font-size:9pt;" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Capacidad para abrir listas de reproducción Blu-ray (archivos .mpls) </li>


### PR DESCRIPTION
I'm sorry to open another "pull request". I have seen a typo in the HTML. There are always small invisible errors, no matter how much one checks them thoroughly.

Regards!