### PR TITLE
Added Spanish language to language selector

### DIFF
--- a/tsMuxerGUI/CMakeLists.txt
+++ b/tsMuxerGUI/CMakeLists.txt
@@ -30,6 +30,7 @@ set(tsmuxer_ts_files
   translations/tsmuxergui_zh.ts
   translations/tsmuxergui_de.ts
   translations/tsmuxergui_he.ts
+  translations/tsmuxergui_es.ts
 )
 
 set(lang_qrc "translations.qrc")

--- a/tsMuxerGUI/translations.qrc
+++ b/tsMuxerGUI/translations.qrc
@@ -6,6 +6,6 @@
 <file alias="tsmuxergui_zh.qm">tsmuxergui_zh.qm</file>
 <file alias="tsmuxergui_de.qm">tsmuxergui_de.qm</file>
 <file alias="tsmuxergui_he.qm">tsmuxergui_he.qm</file>
-<file alias="tsmuxergui_he.qm">tsmuxergui_es.qm</file>
+<file alias="tsmuxergui_es.qm">tsmuxergui_es.qm</file>
 </qresource>
 </RCC>

--- a/tsMuxerGUI/translations.qrc
+++ b/tsMuxerGUI/translations.qrc
@@ -6,5 +6,6 @@
 <file alias="tsmuxergui_zh.qm">tsmuxergui_zh.qm</file>
 <file alias="tsmuxergui_de.qm">tsmuxergui_de.qm</file>
 <file alias="tsmuxergui_he.qm">tsmuxergui_he.qm</file>
+<file alias="tsmuxergui_he.qm">tsmuxergui_es.qm</file>
 </qresource>
 </RCC>

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -289,6 +289,7 @@ void initLanguageComboBox(QComboBox *comboBox)
     comboBox->addItem(QString::fromUtf8("简体中文"), "zh");
     comboBox->addItem(QString::fromUtf8("Deutsch"), "de");
     comboBox->addItem(QString::fromUtf8("עִברִית"), "he");
+    comboBox->addItem(QString::fromUtf8("Español"), "es");
     comboBox->setCurrentIndex(-1);  // makes sure currentIndexChanged() is emitted when reading settings.
 }
 


### PR DESCRIPTION
Hi again,

Although the translation is done, it is not yet visible. I think it will not appear in the "language select combo box" if it is not indicated in this file. I'm not a programmer yet (I'm learning), but my logic tells me that this file will look for the compiled version of the translation. Such compiled version should be created automatically during build, right?

I don't know if the program code has any way to detect the default language of the user's system.

Regards.