### PR TITLE
PAT PMT should better be placed in the beginning of the TS

### DIFF
--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -287,7 +287,7 @@ int AC3Codec::decodeFrame(uint8_t* buf, uint8_t* end, int& skipBytes)
             if (err != AC3ParseError::NO_ERROR)
                 return 0;  // parse error
 
-            m_frameDurationNano = (1000000000ull * m_samples) / m_sample_rate;
+            m_frameDurationNano = (INTERNAL_PTS_FREQ * m_samples) / m_sample_rate;
             rez = m_frame_size;
         }
 

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -190,7 +190,7 @@ int AC3StreamReader::readPacketTHD(AVPacket& avPacket)
                     LTRACE(LT_INFO, 2,
                            getCodecInfo().displayName
                                << " stream (track " << m_streamIndex << "): overlapped frame detected at position "
-                               << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / 1e9, ',') << ". Remove frame.");
+                               << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / INTERNAL_PTS_FREQ, ',') << ". Remove frame.");
                 }
 
                 m_delayedAc3Packet = avPacket;

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -145,7 +145,7 @@ int AC3StreamReader::flushPacket(AVPacket& avPacket)
     {
         if (!(avPacket.flags & AVPacket::PRIORITY_DATA))
             avPacket.pts = avPacket.dts =
-                m_totalTHDSamples * 1000000000ll / mlp.m_samplerate;  // replace time to a next HD packet
+                m_totalTHDSamples * INTERNAL_PTS_FREQ / mlp.m_samplerate;  // replace time to a next HD packet
     }
     return rez;
 }
@@ -202,7 +202,7 @@ int AC3StreamReader::readPacketTHD(AVPacket& avPacket)
         else
         {
             // thg packet
-            avPacket.dts = avPacket.pts = m_totalTHDSamples * 1000000000ll / mlp.m_samplerate;
+            avPacket.dts = avPacket.pts = m_totalTHDSamples * INTERNAL_PTS_FREQ / mlp.m_samplerate;
 
             m_totalTHDSamples += mlp.m_samples;
             m_demuxedTHDSamples += mlp.m_samples;

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -400,7 +400,7 @@ int DTSStreamReader::decodeHdInfo(uint8_t* buff, uint8_t* end)
                 hd_bitDepth = nuBitResolution;
 
                 if (!m_isCoreExists)
-                    m_frameDuration = pi_frame_length * 1e9 / hd_pi_sample_rate;
+                    m_frameDuration = pi_frame_length * INTERNAL_PTS_FREQ / hd_pi_sample_rate;
 
                 if (m_hdType != DTSHD_SUBTYPE::DTS_SUBTYPE_MASTER_AUDIO)
                     m_hdBitrate = (unsigned)(hd_pi_sample_rate / (double)pi_frame_length * hdFrameSize * 8);
@@ -577,7 +577,7 @@ int DTSStreamReader::decodeFrame(uint8_t* buff, uint8_t* end, int& skipBytes, in
             return 0;
 
         pi_frame_length = (nblks + 1) * 32;
-        m_frameDuration = pi_frame_length * 1e9 / pi_sample_rate;
+        m_frameDuration = pi_frame_length * INTERNAL_PTS_FREQ / pi_sample_rate;
 
         afterFrameData = buff + i_frame_size;
         if (afterFrameData > end - 4)

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -464,7 +464,7 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hd
         if (nalType == NALUnit::NALType::nuSPS || nalType == NALUnit::NALType::nuSubSPS)
         {
             processSPS(nal);
-            *dstBuff = (uint8_t)TSDescriptorTag::AVC;                  // descriptor tag
+            *dstBuff++ = (uint8_t)TSDescriptorTag::AVC;                  // descriptor tag
             *dstBuff++ = 4;                                            // descriptor length
             *dstBuff++ = nal[1];                                       // profile_idc
             *dstBuff++ = nal[2];                                       // constraint flags

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -397,7 +397,7 @@ int H264StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVP
                 if (!m_bdRomMetaDataMsg.empty())
                 {
                     // we got slice. fill previous metadata SEI message
-                    auto pts90k = (int64_t)(m_curDts / INT_FREQ_TO_TS_FREQ + 0.5 + m_startPts);
+                    auto pts90k = m_curDts / INT_FREQ_TO_TS_FREQ + m_startPts;
                     uint8_t* srcData = &m_bdRomMetaDataMsg[0];
                     SEIUnit::updateMetadataPts(srcData + m_bdRomMetaDataMsgPtsPos, pts90k);
 
@@ -1197,7 +1197,7 @@ int H264StreamReader::processSliceNal(uint8_t* buff)
 
     if (m_OffsetMetadataPtsAddr)
     {
-        auto pts90k = (int64_t)(m_curDts / INT_FREQ_TO_TS_FREQ + 0.5 + m_startPts);
+        auto pts90k = m_curDts / INT_FREQ_TO_TS_FREQ + m_startPts;
         SEIUnit::updateMetadataPts(m_OffsetMetadataPtsAddr, pts90k);
         m_OffsetMetadataPtsAddr = 0;
     }

--- a/tsMuxer/matroskaDemuxer.cpp
+++ b/tsMuxer/matroskaDemuxer.cpp
@@ -652,9 +652,9 @@ int MatroskaDemuxer::matroska_parse_block(uint8_t *data, int size, int64_t pos, 
                 pkt = new AVPacket();
                 pkt->data = 0;
                 pkt->size = 0;
-                pkt->pts = timecode * 1000000ll;  // our AvPacket in nanoseconds
+                pkt->pts = timecode * INTERNAL_PTS_FREQ / 1000;  // our AvPacket in INTERNAL_PTS_FREQ
                 pkt->pos = pos;
-                pkt->duration = duration * 1000000ll;
+                pkt->duration = duration * INTERNAL_PTS_FREQ / 1000;
 
                 pkt->stream_index = track + 1;  // tracks[track]->stream_index;
 

--- a/tsMuxer/matroskaParser.cpp
+++ b/tsMuxer/matroskaParser.cpp
@@ -373,9 +373,9 @@ void ParsedSRTTrackData::extractData(AVPacket* pkt, uint8_t* buff, int size)
         prefix = "\xEF\xBB\xBF";  // UTF-8 header
     prefix += int32ToStr(++m_packetCnt);
     prefix += "\n";
-    prefix += floatToTime(pkt->pts / 1e9, ',');
+    prefix += floatToTime(pkt->pts / INTERNAL_PTS_FREQ, ',');
     prefix += " --> ";
-    prefix += floatToTime((pkt->pts + pkt->duration) / 1e9, ',');
+    prefix += floatToTime((pkt->pts + pkt->duration) / INTERNAL_PTS_FREQ, ',');
     prefix += '\n';
     std::string postfix = "\n\n";
     pkt->size = (int)(size + prefix.length() + postfix.length());
@@ -420,7 +420,7 @@ void ParsedPGTrackData::extractData(AVPacket* pkt, uint8_t* buff, int size)
         dst[0] = 'P';
         dst[1] = 'G';
         auto ptsDts = (uint32_t*)(dst + 2);
-        ptsDts[0] = my_htonl((uint32_t)((pkt->pts * 90000) / 1000000000));
+        ptsDts[0] = my_htonl((uint32_t)(pkt->pts / (196 * 300)));
         ptsDts[1] = 0;
         dst += PG_HEADER_SIZE;
         memcpy(dst, curPtr, blockSize);

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -841,18 +841,6 @@ VideoAspectRatio arNameToCode(const string& arName)
         return VideoAspectRatio::AR_KEEP_DEFAULT;
 }
 
-double correctFps(double fps)
-{
-    if (fabs(fps - 23.976) < 1e-4)
-        return 23.97602397602397;
-    else if (fabs(fps - 29.97) < 1e-4)
-        return 29.97002997002997;
-    else if (fabs(fps - 59.94) < 1e-4)
-        return 59.94005994005994;
-    else
-        return fps;
-}
-
 PIPParams::PipCorner pipCornerFromStr(const std::string& value)
 {
     std::string v = trimStr(strToLowerCase(value));

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -544,9 +544,10 @@ int METADemuxer::addStream(const string codec, const string& codecStreamName, co
             coeff = 1000000ull;
             value = strToInt32(timeShift.c_str());
         }
-        streamInfo.m_timeShift = value * coeff;
-        if (value * coeff > 0)
-            streamInfo.m_lastDTS = value * coeff;
+        value = value * (int64_t)coeff / 1000ll * (int64_t)INTERNAL_PTS_FREQ / 1000000ll;
+        streamInfo.m_timeShift = value;
+        if (value > 0)
+            streamInfo.m_lastDTS = value;
     }
 
     itr = addParams.find("lang");

--- a/tsMuxer/mlpStreamReader.cpp
+++ b/tsMuxer/mlpStreamReader.cpp
@@ -61,7 +61,7 @@ int MLPStreamReader::readPacket(AVPacket& avPacket)
             return rez;
 
         // thg packet
-        avPacket.dts = avPacket.pts = m_totalTHDSamples * 1000000000ll / m_samplerate;
+        avPacket.dts = avPacket.pts = m_totalTHDSamples * INTERNAL_PTS_FREQ / m_samplerate;
 
         m_totalTHDSamples += m_samples;
         m_demuxedTHDSamples += m_samples;
@@ -80,7 +80,7 @@ int MLPStreamReader::flushPacket(AVPacket& avPacket)
     {
         if (!(avPacket.flags & AVPacket::PRIORITY_DATA))
             avPacket.pts = avPacket.dts =
-                m_totalTHDSamples * 1000000000ll / m_samplerate;  // replace time to a next HD packet
+                m_totalTHDSamples * INTERNAL_PTS_FREQ / m_samplerate;  // replace time to a next HD packet
     }
     return rez;
 }

--- a/tsMuxer/mpegStreamReader.cpp
+++ b/tsMuxer/mpegStreamReader.cpp
@@ -283,6 +283,7 @@ int MPEGStreamReader::decodeNal(uint8_t* buff)
 void MPEGStreamReader::updateFPS(void* curNALUnit, uint8_t* buff, uint8_t* nextNal, int oldSPSLen)
 {
     double spsFps = getStreamFPS(curNALUnit);
+	spsFps = correctFps(spsFps);
     if (spsFps == 0 && m_fps == 0)
     {
         setFPS(25.0);

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -322,7 +322,7 @@ void PGSStreamReader::renderTextShow(int64_t inTime)
         tmp[idx] <<= 1;
         tmp[idx]++;
     }
-    inTime = (int64_t)(inTime / INT_FREQ_TO_TS_FREQ);
+    inTime = inTime / INT_FREQ_TO_TS_FREQ;
 
     double decodedObjectSize = m_render->renderedHeight() * m_scaled_width;
     auto compositionDecodeTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_DECODING_RATE + 0.999);
@@ -374,7 +374,7 @@ void PGSStreamReader::renderTextHide(int64_t outTime)
     auto windowsTransferTime = (int64_t)(90000.0 * decodedObjectSize / PIXEL_COMPOSITION_RATE + 0.999);
 
     m_firstRenderedPacket = true;
-    outTime = (int64_t)(outTime / INT_FREQ_TO_TS_FREQ);
+    outTime = outTime / INT_FREQ_TO_TS_FREQ;
     m_renderedBlocks.clear();
     // hide text
     uint8_t* curPos = m_renderedData;
@@ -706,8 +706,8 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
     {
         if (m_renderedBlocks.size() > 0)
         {
-            avPacket.pts = (int64_t)(m_renderedBlocks.begin()->pts * INT_FREQ_TO_TS_FREQ);
-            avPacket.dts = (int64_t)(m_renderedBlocks.begin()->dts * INT_FREQ_TO_TS_FREQ);
+            avPacket.pts = m_renderedBlocks.begin()->pts * INT_FREQ_TO_TS_FREQ;
+            avPacket.dts = m_renderedBlocks.begin()->dts * INT_FREQ_TO_TS_FREQ;
         }
         else
         {

--- a/tsMuxer/psgStreamReader.cpp
+++ b/tsMuxer/psgStreamReader.cpp
@@ -535,7 +535,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         avPacket.pts = m_lastPTS;
         avPacket.dts = m_lastDTS;
         m_isNewFrame = true;
-        // LTRACE(LT_INFO, 2, "PGS PES#" << m_streamIndex << ". PTS=" << m_lastPTS/1e9 << " DTS=" << m_lastDTS/1e9);
+        // LTRACE(LT_INFO, 2, "PGS PES#" << m_streamIndex << ". PTS=" << m_lastPTS/INTERNAL_PTS_FREQ << " DTS=" << m_lastDTS/INTERNAL_PTS_FREQ);
         if (m_needRescale)
         {
             avPacket.dts = FFMAX(0, avPacket.dts);
@@ -573,7 +573,7 @@ int PGSStreamReader::readPacket(AVPacket& avPacket)
         m_curPos += pesHeaderLen;
         m_processedSize += pesHeaderLen;
         m_state = State::stParsePGS;
-        // LTRACE(LT_INFO, 2, "PGS PES#" << m_streamIndex << ". PTS=" << m_lastPTS/1e9 << " DTS=" << m_lastDTS/1e9);
+        // LTRACE(LT_INFO, 2, "PGS PES#" << m_streamIndex << ". PTS=" << m_lastPTS/INTERNAL_PTS_FREQ << " DTS=" << m_lastDTS/INTERNAL_PTS_FREQ);
         avPacket.pts = m_lastPTS;
         avPacket.dts = m_lastDTS;
         m_isNewFrame = true;

--- a/tsMuxer/simplePacketizerReader.cpp
+++ b/tsMuxer/simplePacketizerReader.cpp
@@ -25,7 +25,7 @@ SimplePacketizerReader::SimplePacketizerReader() : AbstractStreamReader()
     m_halfFrameLen = 0;
 }
 
-static const double mplsEps = 1e9 / 45000.0 / 2.0;
+static const double mplsEps = INTERNAL_PTS_FREQ / 45000.0 / 2.0;
 
 void SimplePacketizerReader::doMplsCorrection()
 {
@@ -171,7 +171,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
             LTRACE(LT_INFO, 2,
                    getCodecInfo().displayName
                        << " stream (track " << m_streamIndex << "): bad frame detected at position"
-                       << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / 1e9, ',') << ". Resync stream.");
+                       << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / INTERNAL_PTS_FREQ, ',') << ". Resync stream.");
             m_needSync = true;
             return 0;
         }
@@ -212,7 +212,7 @@ int SimplePacketizerReader::readPacket(AVPacket& avPacket)
                     LTRACE(LT_INFO, 2,
                            getCodecInfo().displayName
                                << " stream (track " << m_streamIndex << "): overlapped frame detected at position "
-                               << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / 1e9, ',') << ". Remove frame.");
+                               << floatToTime((avPacket.pts - PTS_CONST_OFFSET) / INTERNAL_PTS_FREQ, ',') << ". Remove frame.");
                 m_mplsOffset -= getFrameDurationNano();
                 m_curPts -= getFrameDurationNano();
                 return readPacket(avPacket);  // ignore overlapped packet, get next one

--- a/tsMuxer/simplePacketizerReader.cpp
+++ b/tsMuxer/simplePacketizerReader.cpp
@@ -40,7 +40,7 @@ void SimplePacketizerReader::doMplsCorrection()
             // m_curPts = m_lastMplsTime; // fix PTS up
         }
         m_lastMplsTime += (int64_t)((m_mplsInfo[m_curMplsIndex].OUT_time - m_mplsInfo[m_curMplsIndex].IN_time) *
-                                    (1000000000 / 45000.0));
+                                    (INTERNAL_PTS_FREQ / 45000.0));
     }
 }
 

--- a/tsMuxer/simplePacketizerReader.h
+++ b/tsMuxer/simplePacketizerReader.h
@@ -31,7 +31,7 @@ class SimplePacketizerReader : public AbstractStreamReader
         if (m_mplsInfo.size() > 0)
         {
             m_curMplsIndex = 0;
-            m_lastMplsTime = (m_mplsInfo[0].OUT_time - m_mplsInfo[0].IN_time) * (1000000000.0 / 45000.0);
+            m_lastMplsTime = (m_mplsInfo[0].OUT_time - m_mplsInfo[0].IN_time) * (INTERNAL_PTS_FREQ / 45000.0);
         }
         else
             m_curMplsIndex = -1;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -932,7 +932,7 @@ bool TSMuxer::muxPacket(AVPacket& avPacket)
     }
 
     // if (m_lastProcessedDts != avPacket.dts || m_lastStreamIndex != avPacket.stream_index)
-    //    LTRACE(LT_INFO, 2, "dts=" << avPacket.dts/1000000000.0 << " index=" << avPacket.stream_index);
+    //    LTRACE(LT_INFO, 2, "dts=" << avPacket.dts/(196*27000000.0) << " index=" << avPacket.stream_index);
 #ifdef _DEBUG
     // assert (avPacket.dts >= m_lastProcessedDts);
     m_lastProcessedDts = avPacket.dts;

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -408,7 +408,7 @@ bool TSMuxer::doFlush()
     uint64_t newPCR = 0;
     if (m_m2tsMode)
     {
-        newPCR = (uint64_t)((m_endStreamDTS - m_minDts) / INT_FREQ_TO_TS_FREQ + 0.5 + m_fixed_pcr_offset);
+        newPCR = (m_endStreamDTS - m_minDts) / INT_FREQ_TO_TS_FREQ + m_fixed_pcr_offset;
         if (m_cbrBitrate != -1 && m_lastPCR != -1)
         {
             auto cbrPCR = (uint64_t)(m_lastPCR + m_pcrBits * 90000.0 / m_cbrBitrate + 0.5);
@@ -991,7 +991,7 @@ bool TSMuxer::muxPacket(AVPacket& avPacket)
 
     m_lastTSIndex = tsIndex;
 
-    auto newPCR = (int64_t)((avPacket.dts - m_minDts) / INT_FREQ_TO_TS_FREQ + 0.5 + m_fixed_pcr_offset);
+    auto newPCR = (avPacket.dts - m_minDts) / INT_FREQ_TO_TS_FREQ + m_fixed_pcr_offset;
 
     if (m_cbrBitrate != -1 && m_lastPCR != -1)
     {

--- a/tsMuxer/vod_common.cpp
+++ b/tsMuxer/vod_common.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include "math.h"
 
 using namespace std;
 
@@ -123,3 +124,30 @@ double timeToFloat(const std::string& chapterStr)
         hour = strToInt32(timeParts[timeParts.size() - 3].c_str());
     return hour * 3600 + min * 60 + sec;
 }
+
+double correctFps(double fps)
+{
+	struct FPSCorrect {
+	    double from;
+	    double to;
+	};
+
+	FPSCorrect fpsCorrectList[] = {
+		{  5.994,  5.99400599400599},
+		{ 11.988, 11.98801198801198},
+		{ 23.976, 23.97602397602397},
+		{ 47.952, 47.95204795204795},
+		{ 7.4925,  7.49250749250749},
+		{ 14.985, 14.98501498501498},
+		{ 29.97,  29.97002997002997},
+		{ 59.94,  59.94005994005994},
+	};
+
+    for (int i = 0; i < sizeof(fpsCorrectList)/sizeof(FPSCorrect); i++) {
+        if (fabs(fps - fpsCorrectList[i].from) < 1e-4) {
+            return fpsCorrectList[i].to;
+        }
+    }
+    return fps;
+}
+

--- a/tsMuxer/vod_common.h
+++ b/tsMuxer/vod_common.h
@@ -118,6 +118,7 @@ void AV_WB32(uint8_t* buffer, uint32_t value);
 std::string floatToTime(double time, char msSeparator = '.');
 double timeToFloat(const std::string& chapterStr);
 std::string toNativeSeparators(const std::string& dirName);
+double correctFps(double fps);
 
 static inline int64_t nanoClockToPts(int64_t value)
 {

--- a/tsMuxer/vod_common.h
+++ b/tsMuxer/vod_common.h
@@ -62,8 +62,8 @@ const unsigned DEFAULT_FRAME_FREQ = (uint32_t)(PCR_HALF_FREQUENCY / (4.8 * 1024.
 
 // const static int64_t FIXED_PTS_OFFSET = 378000000ll; //377910000ll;
 
-const static int64_t INTERNAL_PTS_FREQ = 1000000000;
-const static double INT_FREQ_TO_TS_FREQ = INTERNAL_PTS_FREQ / (double)PCR_FREQUENCY;
+const static int64_t INTERNAL_PTS_FREQ = 196 * 27000000ll;
+const static int64_t INT_FREQ_TO_TS_FREQ = INTERNAL_PTS_FREQ / PCR_FREQUENCY;
 
 const static uint32_t GOP_BUFFER_SIZE = 2 * 1024 * 1024;  // 512*1024;
 
@@ -121,11 +121,11 @@ std::string toNativeSeparators(const std::string& dirName);
 
 static inline int64_t nanoClockToPts(int64_t value)
 {
-    return int64_t(value / INT_FREQ_TO_TS_FREQ + (value >= 0 ? 0.5 : -0.5));
+    return value / INT_FREQ_TO_TS_FREQ;
 }
 static inline int64_t ptsToNanoClock(int64_t value)
 {
-    return int64_t(value * INT_FREQ_TO_TS_FREQ + (value >= 0 ? 0.5 : -0.5));
+    return value * INT_FREQ_TO_TS_FREQ;
 }
 
 struct PIPParams


### PR DESCRIPTION
Player behaves better if PAT PMT are placed in the beginning of the TS. You can try playing the video here using VLC:
https://drive.google.com/drive/folders/1KWFEYB2pt7ON9xRVikciioYirlQldnqI?usp=sharing

before.ts: mux-ed output before this change
after.ts: mux-ed output after this change

This pull request included some changes from the another pull request... so let's consider this pull request later.