### PR TITLE
PAT PMT should better be placed in the beginning of the TS

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -981,6 +981,13 @@ bool TSMuxer::muxPacket(AVPacket& avPacket)
     if (tsIndex == 0)
         THROW(ERR_TS_COMMON, "Unknown track number " << avPacket.stream_index);
 
+    auto newPCR = (int64_t)((avPacket.dts - m_minDts) / INT_FREQ_TO_TS_FREQ + 0.5 + m_fixed_pcr_offset);
+    if (m_lastPCR == -1)
+    {
+        writePATPMT(newPCR, true);
+        writePCR(newPCR);
+    }
+
     bool newPES = false;
     if (avPacket.dts != m_streamInfo[tsIndex].m_dts || avPacket.pts != m_streamInfo[tsIndex].m_pts ||
         tsIndex != m_lastTSIndex || avPacket.flags & AVPacket::FORCE_NEW_FRAME)
@@ -990,8 +997,6 @@ bool TSMuxer::muxPacket(AVPacket& avPacket)
     }
 
     m_lastTSIndex = tsIndex;
-
-    auto newPCR = (int64_t)((avPacket.dts - m_minDts) / INT_FREQ_TO_TS_FREQ + 0.5 + m_fixed_pcr_offset);
 
     if (m_cbrBitrate != -1 && m_lastPCR != -1)
     {


### PR DESCRIPTION
Player behaves better if PAT PMT are placed in the beginning of the TS. You can try playing the video here using VLC:
https://drive.google.com/drive/folders/1KWFEYB2pt7ON9xRVikciioYirlQldnqI?usp=sharing

before.ts: mux-ed output before this change
after.ts: mux-ed output after this change

This pull request included some changes from the another pull request... so let's consider this pull request later.