### PR TITLE
Fix incorrect stream type of EAC3 stream in TS

### DIFF
--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -337,10 +337,17 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
             streamType = StreamType::AUDIO_TRUE_HD;
         else if (ac3Reader->isEAC3() && !ac3Reader->getDownconvertToAC3())
         {
-            if (ac3Reader->isSecondary())
-                streamType = StreamType::AUDIO_EAC3_SECONDARY;
+            if (m_bluRayMode)
+            {
+                if (ac3Reader->isSecondary())
+                    streamType = StreamType::AUDIO_EAC3_SECONDARY;
+                else
+                    streamType = StreamType::AUDIO_EAC3;
+            }
             else
-                streamType = StreamType::AUDIO_EAC3;
+            {
+                streamType = StreamType::AUDIO_EAC3_ATSC;
+            }
         }
         else
             streamType = StreamType::AUDIO_AC3;

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -44,6 +44,7 @@ bool isAudioStreamType(StreamType stream_coding_type)
     case StreamType::AUDIO_DTS:
     case StreamType::AUDIO_TRUE_HD:
     case StreamType::AUDIO_EAC3:
+    case StreamType::AUDIO_EAC3_ATSC:
     case StreamType::AUDIO_DTS_HD:
     case StreamType::AUDIO_DTS_HD_MA:
     case StreamType::AUDIO_EAC3_SECONDARY:
@@ -319,6 +320,7 @@ bool TS_program_map_section::deserialize(uint8_t* buffer, int buf_size)
             case StreamType::AUDIO_AAC:
             case StreamType::AUDIO_AC3:
             case StreamType::AUDIO_EAC3:
+            case StreamType::AUDIO_EAC3_ATSC:
             case StreamType::AUDIO_DTS:
                 audio_pid = elementary_pid;
                 audio_type = (int)stream_type;


### PR DESCRIPTION
When doing the Dolby certification, the demuxer can't demux the eac3 stream due to stream type incorrect. TsMuxeR coded the stream type of EAC3 as 0x84 and the correct one should be 0x87.