### PR TITLE
HEVC: implement skipNal() for HEVC to skip EndOfSeq NAL

### DIFF
--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -406,6 +406,24 @@ double HEVCStreamReader::getStreamFPS(void* curNalUnit)
     return fps;
 }
 
+bool HEVCStreamReader::skipNal(uint8_t* nal)
+{
+    auto nalType = (HevcUnit::NalType)((*nal >> 1) & 0x3f);
+
+    if (nalType == HevcUnit::NalType::FD)
+        return true;
+
+    if ((nalType == HevcUnit::NalType::EOS || nalType == HevcUnit::NalType::EOB))
+    {
+        if (!m_eof || m_bufEnd - nal > 4)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool HEVCStreamReader::isSlice(HevcUnit::NalType nalType) const
 {
     if (!m_sps || !m_vps || !m_pps)

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -33,6 +33,7 @@ class HEVCStreamReader : public MPEGStreamReader
     virtual int writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPacket& avPacket,
                                   PriorityDataInfo* priorityData) override;
     void onSplitEvent() override { m_firstFileFrame = true; }
+    bool skipNal(uint8_t* nal) override;
 
    private:
     bool isSlice(HevcUnit::NalType nalType) const;


### PR DESCRIPTION
This is to avoid EndOfSeq NAL appear at the beginning of AU when multiple video ES files join together.
The implementation is similar to https://github.com/justdan96/tsMuxer/blob/master/tsMuxer/h264StreamReader.cpp#L884 