### PR TITLE
Create Joining Files But Finishing WithError Code 11

### DIFF
--- a/tsMuxerGUI/Joining Files But Finishing WithError Code 11
+++ b/tsMuxerGUI/Joining Files But Finishing WithError Code 11
@@ -1,0 +1,3 @@
+Joining .m2ts video files but finishing With Error Codes #11 and #245
+This is also due to old outdated versions
+Needs To Be Fixed on Next release


### PR DESCRIPTION
Not joining .m2ts files in h.264 Video Format it may cause some errors-to be fixed with an update.