### PR TITLE
 Fix muxing of HDR DV MKV to BD 

### DIFF
--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -395,7 +395,8 @@ unsigned HEVCStreamReader::getStreamHeight() const { return m_sps ? m_sps->pic_h
 
 int HEVCStreamReader::getStreamHDR() const
 {
-    return (m_hdr->isDVRPU || m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
+//    return (m_hdr->isDVRPU || m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
+    return (m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
 }
 
 double HEVCStreamReader::getStreamFPS(void* curNalUnit)

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -395,7 +395,6 @@ unsigned HEVCStreamReader::getStreamHeight() const { return m_sps ? m_sps->pic_h
 
 int HEVCStreamReader::getStreamHDR() const
 {
-//    return (m_hdr->isDVRPU || m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
     return (m_hdr->isDVEL) ? 4 : (m_hdr->isHDR10plus ? 16 : (m_hdr->isHDR10 ? 2 : 1));
 }
 


### PR DESCRIPTION
Fixes #781
DV EL will still be muxed correctly but the Double Layer Single Tracks will be muxed as HDR10 video streams. They won't work as DV streams anyways so this is the only thing that makes sense. 

If someone has a use case to mux those streams as DV EL, I suggest a muxing option per video track to force muxing as DV EL. 