### PR TITLE
PGS demuxing: set DTS equal to PTS for packets with PTS_DTS_flags=0b10

### DIFF
--- a/tsMuxer/pgsStreamReader.cpp
+++ b/tsMuxer/pgsStreamReader.cpp
@@ -811,10 +811,7 @@ int PGSStreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
         *dstBuffer++ = 'G';
         auto data = reinterpret_cast<uint32_t*>(dstBuffer);
         *data++ = my_htonl(static_cast<uint32_t>(internalClockToPts(m_lastPTS)));
-        if (m_lastDTS != m_lastPTS)
-            *data = my_htonl(static_cast<uint32_t>(internalClockToPts(m_lastDTS)));
-        else
-            *data = 0;
+        *data = my_htonl(static_cast<uint32_t>(internalClockToPts(m_lastDTS)));
         return 10;
     }
     return 0;


### PR DESCRIPTION
This is a tiny change in demuxing. I think this is more logical than a sporadically null DTS in the output .SUP file.

- `PTS_DTS_flags=0b10` suggests PTS=DTS, rather than DTS=0.
- To mux back the stream, it is easier to check for PTS=DTS to find back `0b10 == PTS_DTS_flags` candidates rather than look at the segment type and do guess work, as DTS=0 can be a valid value, while PTS and DTS should never be equal in a TS packet.