### PR TITLE
if buff + frameSize is bigger than  srcEnd, break  before memcpy (movDemuxer.cpp::extractData)

### DIFF
--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -184,6 +184,7 @@ class MovParsedAudioTrackData final : public ParsedTrackPrivData
             unsigned frameSize = m_sc->sample_size;
             if (frameSize == 0)
                 frameSize = m_sc->m_index[m_sc->m_indexCur++];
+	    if (buff + frameSize > srcEnd) break;
             if (isAAC)
             {
                 m_aacRaw.m_channels = static_cast<uint8_t>(m_sc->channels);


### PR DESCRIPTION
fix #837

Since frameSize is initialized in the while statement, we added this check immediately after that initialization, not in the conditional expression of the while statement.