### PR TITLE
heap buffer over-read is found in movDemuxer::simpleDemuxBlock

### DIFF
--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -724,7 +724,7 @@ int MovDemuxer::simpleDemuxBlock(DemuxedData& demuxedData, const PIDSet& accepte
         }
     }
     const int64_t startPos = m_processedBytes;
-    while (m_processedBytes - startPos < m_fileBlockSize && m_curChunk < chunks.size())
+    while (m_processedBytes - startPos < m_fileBlockSize && m_curChunk < chunks.size() && m_curChunk < m_mdat_data.size())
     {
         const int64_t offset = chunks[m_curChunk].first;
         int64_t next;


### PR DESCRIPTION
fix #839 