### PR TITLE
initialize ctts_count to 0 and shrink ctts_data

### DIFF
--- a/tsMuxer/movDemuxer.cpp
+++ b/tsMuxer/movDemuxer.cpp
@@ -1189,6 +1189,8 @@ int MovDemuxer::mov_read_ctts(MOVAtom atom)
     get_be24();  // flags
     const unsigned entries = get_be32();
     st->ctts_data.resize(entries);
+    st->ctts_data.shrink_to_fit();
+    st->ctts_count = 0;
     for (unsigned i = 0; i < entries; i++)
     {
         st->ctts_data[i].count = get_be32();


### PR DESCRIPTION
fix #841 

Make sure that `ctts_data.capacity()` matches `ctts_data.size()` for `emplace_back()` in the following code.

https://github.com/justdan96/tsMuxer/blob/75c9cb3514815d07378007d36cc90c3f209e7b36/tsMuxer/movDemuxer.cpp#L1100-L1102
