### PR TITLE
added size check before calling extractPMTDescriptors

### DIFF
--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -292,6 +292,11 @@ bool TS_program_map_section::deserialize(uint8_t* buffer, const int buf_size)
         bitReader.skipBits(4);  // reserved
         const auto program_info_len = bitReader.getBits<uint16_t>(12);
         uint8_t* curPos = bitReader.getBuffer() + bitReader.getBitsCount() / 8;
+        if (curPos + program_info_len + 4 > bufferEnd)
+        {
+            LTRACE(LT_WARN, 0, "Bad PMT table. skipped");
+            return false;
+        }
         extractPMTDescriptors(curPos, program_info_len);
         curPos += program_info_len;
         while (curPos < crcPos)


### PR DESCRIPTION
fix #859 
The reason for +4 is the possibility of accessing curPos[3] in extractPMTDescriptors when curPos < end.
https://github.com/justdan96/tsMuxer/blob/5f43ab2a45482ad448524dc61a1ab7204ca8849d/tsMuxer/tsPacket.cpp#L247-L248