### PR TITLE
Fix race condtion that cause corrupted tail of output TS

### DIFF
--- a/libmediation/containers/safequeue.h
+++ b/libmediation/containers/safequeue.h
@@ -50,6 +50,15 @@ class SafeQueue
         return val;
     }
 
+    T peek()
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+
+        T val = m_queue.front();
+
+        return val;
+    }
+
    private:
     mutable std::mutex m_mtx;
     std::queue<T> m_queue;
@@ -104,6 +113,21 @@ class WaitableSafeQueue : public SafeQueueWithNotification<T>
 
         return val;
     }
+
+    T peek()
+    {
+        std::unique_lock<std::mutex> lk(m_mtx);
+
+        while (SafeQueue<T>::empty())
+        {
+            m_cond.wait(lk);
+        }
+
+        T val = SafeQueue<T>::peek();
+
+        return val;
+    }
+
 
    private:
     std::mutex m_mtx;

--- a/tsMuxer/bufferedFileWriter.cpp
+++ b/tsMuxer/bufferedFileWriter.cpp
@@ -22,7 +22,6 @@ void WriterData::execute() const
 BufferedFileWriter::BufferedFileWriter() : m_terminated(false), m_writeQueue(WRITE_QUEUE_MAX_SIZE)
 {
     m_lastErrorCode = 0;
-    m_nothingToExecute = true;
     run(this);
 }
 
@@ -40,7 +39,7 @@ void BufferedFileWriter::thread_main()
 {
     while (!m_terminated)
     {
-        WriterData writerData = m_writeQueue.pop();
+        WriterData writerData = m_writeQueue.peek();
         try
         {
             writerData.execute();
@@ -63,7 +62,7 @@ void BufferedFileWriter::thread_main()
             m_lastErrorCode = -1;
             LTRACE(LT_ERROR, 0, "BufferedFileWriter::thread_main() throws unknown exception");
         }
-        m_nothingToExecute = m_writeQueue.empty();
+        m_writeQueue.pop();
     }
 }
 

--- a/tsMuxer/bufferedFileWriter.h
+++ b/tsMuxer/bufferedFileWriter.h
@@ -42,12 +42,11 @@ class BufferedFileWriter final : public TerminatableThread
     {
         if (m_lastErrorCode == 0)
         {
-            m_nothingToExecute = false;
             return m_writeQueue.push(data);
         }
         throw std::runtime_error(m_lastErrorStr);
     }
-    bool isQueueEmpty() const { return m_nothingToExecute; }
+    bool isQueueEmpty() const { return m_writeQueue.empty(); }
 
    protected:
     void thread_main() override;


### PR DESCRIPTION
We found that occasioinally the tail of the TS output is corrupted. After some debugging and guessing, the problem should be caused by this code
```
m_nothingToExecute = m_writeQueue.empty();
```
This code is not atomic. It is equivalent to this:
```
bool flag = m_writeQueue.empty();
m_nothingToExecute = flag;
```
Other threads could jump in after the first line and before the second line. 
This includes BufferedFileWriter::addWriterData(). When addWriteData() is indeed be called, 
the situation will be like this:
```
bool flag = m_writeQueue.empty(); // (true)

  m_nothingToExecute = false;
  m_writeQueue.push(data);

m_nothingToExecute = flag; // (true)
```
writeQueue is inserted a data and is NOT empty; however, m_nothingToExecute is set to true by the final line. 
That will cause waitForWriting() to return and then close() is called before the remaining byte is flushed to the output.